### PR TITLE
ci(check_format): Auto create PR to fix format

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -16,3 +16,13 @@ jobs:
       run: clang-format-9 -i src/*.cpp src/*/*.cpp src/*.hpp src/*/*.hpp
     - name: Check diff
       run: git diff --exit-code HEAD
+    - name: Create Pull Request
+      if: failure()
+      uses: peter-evans/create-pull-request@v2
+      with:
+        commit-message: "style: Format codes"
+        title: "Format codes for ${{ github.ref }}"
+        labels: "style"
+        assignees: "${{ github.actor }}"
+        reviewers: "${{ github.actor }}"
+        branch: 'auto-pr/clang-format/${{ github.ref }}'


### PR DESCRIPTION
##  Description

Auto create PR for Clang Format check.

## Motivation and Context

In this way, we can fix wrong format more easily.

This is better than commit directly, because:

1. It works on protected branches.
2. We can choose to merge it or change it manually.
3. After the merge, CI will run on it. Though it won't before the merge, we can still revert/fix it easily after the merge.

## Type of changes

- [x] CI (changes to CI configuration files and scripts)