### PR TITLE
feat: Add choose where to save the test case files

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add Ctrl+Shift+D for duplicating the current line or the selection. (#237)
 - Add tooltips for many widgets. (#211)
 - Now you can add pairs of test cases from files. (#204 and #246)
+- Now you can choose where to save the test case files in Preferences->File Path->Testcases. (#176)
+- Now when saving the source file, if the parent directory of the file does not exist, it will be automatically created.
 
 ### Changed
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -121,7 +121,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     addPage("Extensions/CF Tool", {"CF/Path"});
 
-    addPage("File Path/Testcases", {"Testcases Matching Rules"});
+    addPage("File Path/Testcases", {"Input File Save Path", "Answer File Save Path", "Testcases Matching Rules"});
 
     addPage("Key Bindings", {"Hotkey/Compile", "Hotkey/Run", "Hotkey/Compile Run", "Hotkey/Format", "Hotkey/Kill",
                              "Hotkey/Change View Mode", "Hotkey/Snippets"});

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -471,5 +471,17 @@
         "default": "QList<QVariant> { QStringList {\"(.*)\\\\.in\", \"\\\\1.ans\"}, QStringList {\"(.*)\\\\.in\", \"\\\\1.out\"}}",
         "param": "QList<QVariant> { QStringList {\"Input Regex\", \"The regular expression for the input file name\"}, QStringList {\"Answer Replace\", \"The replace expression for the answer file name. You can use \\\"\\\\1\\\" for the first captured group.\"}}",
         "tip": "Pairs of regular expressions used when adding pairs of test cases from files. Each pair of regular expressions represents a test case."
+    },
+    {
+        "name": "Input File Save Path",
+        "type": "QString",
+        "default": "./${basename}_${1-index}.in",
+        "tip": "The path where the input files are saved.\nThis setting is a relative path to the source file.\nYou can use \"${filename}\" for the complete file name,\n\"${basename}\" for the base file name without the suffix,\n\"${0-index}\" for the index of the test case started from 0,\n\"${1-index}\" for the index of the test case started from 1."
+    },
+    {
+        "name": "Answer File Save Path",
+        "type": "QString",
+        "default": "./${basename}_${1-index}.ans",
+        "tip": "The path where the answer files are saved.\nThis setting is a relative path to the source file.\nYou can use \"${filename}\" for the complete file name,\n\"${basename}\" for the base file name without the suffix,\n\"${0-index}\" for the index of the test case started from 0,\n\"${1-index}\" for the index of the test case started from 1."
     }
 ]

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -19,7 +19,9 @@
 #include "Core/EventLogger.hpp"
 #include "Extensions/EditorTheme.hpp"
 #include <QCXXHighlighter>
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QJavaHighlighter>
 #include <QPythonHighlighter>
 #include <QSaveFile>
@@ -42,8 +44,14 @@ QString fileNameFilter(bool cpp, bool java, bool python)
     return "Source Files (" + filter.trimmed() + ")";
 }
 
-bool saveFile(const QString &path, const QString &content, const QString &head, bool safe, MessageLogger *log)
+bool saveFile(const QString &path, const QString &content, const QString &head, bool safe, MessageLogger *log,
+              bool createDirectory)
 {
+    if (createDirectory)
+    {
+        auto dirPath = QFileInfo(path).absolutePath();
+        LOG_ERR_IF(!QDir().mkpath(dirPath), QString("Failed to create the directory [%1]").arg(dirPath));
+    }
     if (safe && !SettingsHelper::isSaveFaster())
     {
         QSaveFile file(path);

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -36,7 +36,7 @@ const QStringList pythonSuffix = {"py", "py3"};
 QString fileNameFilter(bool cpp, bool java, bool python);
 
 bool saveFile(const QString &path, const QString &content, const QString &head = "Save File", bool safe = true,
-              MessageLogger *log = nullptr);
+              MessageLogger *log = nullptr, bool createDirectory = false);
 
 /**
  * @brief get the content of a file

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -141,57 +141,6 @@ QString TestCase::expected() const
     return expectedEdit->toPlainText();
 }
 
-void TestCase::loadFromFile(const QString &pathPrefix)
-{
-    LOG_INFO("Loading from file path " << pathPrefix);
-    auto content = Util::readFile(pathPrefix + ".in", "Read Input #" + QString::number(id + 1), log);
-    if (!content.isNull())
-    {
-        if (content.length() > SettingsHelper::getLoadTestCaseFileLengthLimit())
-        {
-            log->error(
-                "Testcases",
-                QString("The testcase file [%1] contains more than %2 characters, so it's not loaded. You can change "
-                        "the length limit in Preferences->Advanced->Limits->Load Test Case File Length Limit")
-                    .arg(pathPrefix + ".in")
-                    .arg(SettingsHelper::getLoadTestCaseFileLengthLimit()));
-        }
-        else
-            setInput(content);
-    }
-    content = Util::readFile(pathPrefix + ".ans", "Read Expected #" + QString::number(id + 1), log);
-    if (!content.isNull())
-    {
-        if (content.length() > SettingsHelper::getLoadTestCaseFileLengthLimit())
-        {
-            log->error(
-                "Testcases",
-                QString("The testcase file [%1] contains more than %2 characters, so it's not loaded. You can change "
-                        "the length limit in Preferences->Advanced->Limits->Load Test Case File Length Limit")
-                    .arg(pathPrefix + ".ans")
-                    .arg(SettingsHelper::getLoadTestCaseFileLengthLimit()));
-        }
-        else
-            setExpected(content);
-    }
-}
-
-void TestCase::save(const QString &pathPrefix, bool safe)
-{
-    LOG_INFO("Saving to pathPrefix" << pathPrefix << "In " << BOOL_INFO_OF(safe));
-
-    if (!input().isEmpty() || QFile::exists(pathPrefix + ".in"))
-    {
-        LOG_INFO("Input file exists and should be saved");
-        Util::saveFile(pathPrefix + ".in", input(), "Testcase Input #" + QString::number(id + 1), safe, log);
-    }
-    if (!expected().isEmpty() || QFile::exists(pathPrefix + ".ans"))
-    {
-        LOG_INFO("Expected file exists and should be saved");
-        Util::saveFile(pathPrefix + ".ans", expected(), "Testcase Expected #" + QString::number(id + 1), safe, log);
-    }
-}
-
 void TestCase::setID(int index)
 {
     LOG_INFO("Changed testcase ID to " << index);

--- a/src/Widgets/TestCase.hpp
+++ b/src/Widgets/TestCase.hpp
@@ -45,8 +45,6 @@ class TestCase : public QWidget
     QString input() const;
     QString output() const;
     QString expected() const;
-    void loadFromFile(const QString &pathPrefix);
-    void save(const QString &pathPrefix, bool safe);
     void setID(int index);
     void setVerdict(Core::Checker::Verdict verdict);
     Core::Checker::Verdict verdict() const;

--- a/src/Widgets/TestCases.hpp
+++ b/src/Widgets/TestCases.hpp
@@ -38,30 +38,42 @@ class TestCases : public QWidget
 
   public:
     explicit TestCases(MessageLogger *logger, QWidget *parent = nullptr);
-    void setInput(int index, const QString &input);
-    void setOutput(int index, const QString &output);
-    void setExpected(int index, const QString &expected);
-    void addTestCase(const QString &input = QString(), const QString &expected = QString());
-    void clearOutput();
-    void clear();
+
     QString input(int index) const;
     QString output(int index) const;
     QString expected(int index) const;
+
+    void setInput(int index, const QString &input);
+    void setOutput(int index, const QString &output);
+    void setExpected(int index, const QString &expected);
+
     void loadStatus(const QStringList &inputList, const QStringList &expectedList);
+
     QStringList inputs() const;
     QStringList expecteds() const;
-    void loadFromFile(const QString &filePath);
-    void save(const QString &filePath, bool safe);
+
+    void addTestCase(const QString &input = QString(), const QString &expected = QString());
+
+    void clearOutput();
+    void clear();
+
     int id(TestCase *testcase) const;
     int count() const;
+
     void setCheckerIndex(int index);
     int checkerIndex() const;
     void addCustomCheckers(const QStringList &list);
     QStringList customCheckers() const;
     QString checkerText() const;
     Core::Checker::CheckerType checkerType() const;
+
     void setShow(int index, bool show);
     bool isShow(int index) const;
+
+    void loadFromSavedFiles(const QString &filePath);
+    void saveToFiles(const QString &filePath, bool safe);
+
+    QString loadTestCaseFromFile(const QString &path, const QString &head);
 
   public slots:
     void setVerdict(int index, Core::Checker::Verdict verdict);
@@ -90,8 +102,9 @@ class TestCases : public QWidget
     bool choosingChecker = false;
 
     void updateVerdicts();
-    QString testFilePathPrefix(const QFileInfo &fileInfo, int index);
-    int numberOfTestFile(const QString &sourceName, const QFileInfo &fileName);
+    QString inputFilePath(const QString &filePath, int index);
+    QString answerFilePath(const QString &filePath, int index);
+    QString testCaseFilePath(QString rule, const QString &filePath, int index);
 };
 } // namespace Widgets
 #endif // TESTCASES_HPP

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -196,13 +196,13 @@ void MainWindow::runTestCase(int index)
 void MainWindow::loadTests()
 {
     if (!isUntitled() && SettingsHelper::isSaveTests())
-        testcases->loadFromFile(filePath);
+        testcases->loadFromSavedFiles(filePath);
 }
 
 void MainWindow::saveTests(bool safe)
 {
     if (!isUntitled() && SettingsHelper::isSaveTests())
-        testcases->save(filePath, safe);
+        testcases->saveToFiles(filePath, safe);
 }
 
 void MainWindow::setCFToolUI()
@@ -762,7 +762,7 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
         if (newFilePath.isEmpty())
             return false;
 
-        if (!Util::saveFile(newFilePath, editor->toPlainText(), head, safe, &log))
+        if (!Util::saveFile(newFilePath, editor->toPlainText(), head, safe, &log, true))
             return false;
 
         filePath = newFilePath;
@@ -779,7 +779,7 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
     }
     else if (!isUntitled())
     {
-        if (!Util::saveFile(filePath, editor->toPlainText(), head, safe, &log))
+        if (!Util::saveFile(filePath, editor->toPlainText(), head, safe, &log, true))
             return false;
         updateWatcher();
     }


### PR DESCRIPTION
## Description

- Now you can choose where to save the test case files in Preferences->File Path->Testcases.

- Now when saving the source file, if the parent directory of the file does not exist, it will be automatically created.

## Related Issue

This resolves #176.

## Motivation and Context

The files are in a mess if the test cases are saved in the same directory as the source file. With this feature, the user can save the test cases in a separate directory.

## How Has This Been Tested?

Tested on Manjaro KDE.

## Screenshots (if appropriate)

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [ ] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
