### PR TITLE
fix(StringListsItem): Remove Unicode characters in the buttons

### DIFF
--- a/src/Settings/StringListsItem.cpp
+++ b/src/Settings/StringListsItem.cpp
@@ -42,15 +42,11 @@ StringListsItem::StringListsItem(const QList<QVariant> &cols, QWidget *parent) :
 
     buttonLayout = new QVBoxLayout();
 
-    int buttonWidth = qMax(qMax(fontMetrics().boundingRect("+").width(), fontMetrics().boundingRect("-").width()),
-                           qMax(fontMetrics().boundingRect("∧").width(), fontMetrics().boundingRect("∨").width()));
-
-    add = new QToolButton(this);
-    add->setMinimumWidth(buttonWidth);
-    add->setText("＋");
+    add = new QPushButton(this);
+    add->setText("Add");
     add->setShortcut({"Ctrl+N"});
     add->setToolTip("Insert a row (Ctrl+N)");
-    connect(add, &QToolButton::clicked, [&]() {
+    connect(add, &QPushButton::clicked, [&]() {
         int cols = table->columnCount();
         int rows = table->rowCount();
         auto items = table->selectedItems();
@@ -63,12 +59,11 @@ StringListsItem::StringListsItem(const QList<QVariant> &cols, QWidget *parent) :
     });
     buttonLayout->addWidget(add);
 
-    del = new QToolButton(this);
-    del->setMinimumWidth(buttonWidth);
-    del->setText("－");
+    del = new QPushButton(this);
+    del->setText("Remove");
     del->setShortcut({"Ctrl+W"});
     del->setToolTip("Delete the current row (Ctrl+W)");
-    connect(del, &QToolButton::clicked, [&]() {
+    connect(del, &QPushButton::clicked, [&]() {
         auto items = table->selectedItems();
         if (items.size())
         {
@@ -82,12 +77,11 @@ StringListsItem::StringListsItem(const QList<QVariant> &cols, QWidget *parent) :
     });
     buttonLayout->addWidget(del);
 
-    moveUp = new QToolButton(this);
-    moveUp->setMinimumWidth(buttonWidth);
-    moveUp->setText("∧");
+    moveUp = new QPushButton(this);
+    moveUp->setText("Move Up");
     moveUp->setShortcut({"Ctrl+Shift+Up"});
     moveUp->setToolTip("Move the current row up (Ctrl+Shift+Up)");
-    connect(moveUp, &QToolButton::clicked, [&]() {
+    connect(moveUp, &QPushButton::clicked, [&]() {
         int cols = table->columnCount();
         auto items = table->selectedItems();
         if (items.size())
@@ -106,12 +100,11 @@ StringListsItem::StringListsItem(const QList<QVariant> &cols, QWidget *parent) :
     });
     buttonLayout->addWidget(moveUp);
 
-    moveDown = new QToolButton(this);
-    moveDown->setMinimumWidth(buttonWidth);
-    moveDown->setText("∨");
+    moveDown = new QPushButton(this);
+    moveDown->setText("Move Down");
     moveDown->setShortcut({"Ctrl+Shift+Down"});
     moveDown->setToolTip("Move the current row down (Ctrl+Shift+Down)");
-    connect(moveDown, &QToolButton::clicked, [&]() {
+    connect(moveDown, &QPushButton::clicked, [&]() {
         int cols = table->columnCount();
         int rows = table->rowCount();
         auto items = table->selectedItems();

--- a/src/Settings/StringListsItem.hpp
+++ b/src/Settings/StringListsItem.hpp
@@ -19,8 +19,8 @@
 #define STRINGLISTSITEM_HPP
 
 #include <QHBoxLayout>
+#include <QPushButton>
 #include <QTableWidget>
-#include <QToolButton>
 #include <QVBoxLayout>
 
 class StringListsItem : public QWidget
@@ -40,10 +40,10 @@ class StringListsItem : public QWidget
     QHBoxLayout *layout = nullptr;
     QVBoxLayout *buttonLayout = nullptr;
     QTableWidget *table = nullptr;
-    QToolButton *add = nullptr;
-    QToolButton *del = nullptr;
-    QToolButton *moveUp = nullptr;
-    QToolButton *moveDown = nullptr;
+    QPushButton *add = nullptr;
+    QPushButton *del = nullptr;
+    QPushButton *moveUp = nullptr;
+    QPushButton *moveDown = nullptr;
 };
 
 #endif // STRINGLISTSITEM_HPP


### PR DESCRIPTION
## Description

The Unicode characters in the buttons are replaced by ASCII text.

## Motivation and Context

I got compilation error on my Windows. Though perhaps this can be fixed by configuring the compiler, it shows that it's better not to use Unicode characters in the code.

## How Has This Been Tested?

On my WIndows 10.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/80227475-3ddc3900-8680-11ea-8251-bd7da18d0c7b.png)

## Type of changes

- [x] Bug fix (changes which fix an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
