### PR TITLE
feat: Set different default file paths for different problem URLs

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,7 @@ Now error linting is available with Language Server. Linting can be helpful when
 - Now you can add pairs of test cases from files. (#204 and #246)
 - Now you can choose where to save the test case files in Preferences->File Path->Testcases. (#176)
 - Now when saving the source file, if the parent directory of the file does not exist, it will be automatically created.
+- Now you can set different default file paths for different problem URLs. (#200)
 
 ### Changed
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -130,6 +130,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     addPage("File Path/Testcases", {"Input File Save Path", "Answer File Save Path", "Testcases Matching Rules"});
 
+    addPage("File Path/Problem URL", {"Default File Paths For Problem URLs"});
+
     addPage("Key Bindings", {"Hotkey/Compile", "Hotkey/Run", "Hotkey/Compile Run", "Hotkey/Format", "Hotkey/Kill",
                              "Hotkey/Change View Mode", "Hotkey/Snippets"});
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -574,7 +574,7 @@
         "name": "Testcases Matching Rules",
         "type": "QList<QVariant>",
         "default": "QList<QVariant> { QStringList {\"(.*)\\\\.in\", \"\\\\1.ans\"}, QStringList {\"(.*)\\\\.in\", \"\\\\1.out\"}}",
-        "param": "QList<QVariant> { QStringList {\"Input Regex\", \"The regular expression for the input file name\"}, QStringList {\"Answer Replace\", \"The replace expression for the answer file name. You can use \\\"\\\\1\\\" for the first captured group.\"}}",
+        "param": "QList<QVariant> { QStringList {\"Input Regex\", \"The regular expression for the input file name\"}, QStringList {\"Answer Replace\", \"The replace expression for the answer file name.\\nYou can use \\\"\\\\1\\\" for the first captured group.\"}}",
         "tip": "Pairs of regular expressions used when adding pairs of test cases from files. Each pair of regular expressions represents a test case."
     },
     {
@@ -588,5 +588,12 @@
         "type": "QString",
         "default": "./${basename}_${1-index}.ans",
         "tip": "The path where the answer files are saved.\nThis setting is a relative path to the source file.\nYou can use \"${filename}\" for the complete file name,\n\"${basename}\" for the base file name without the suffix,\n\"${0-index}\" for the index of the test case started from 0,\n\"${1-index}\" for the index of the test case started from 1."
+    },
+    {
+        "name": "Default File Paths For Problem URLs",
+        "type": "QList<QVariant>",
+        "default": "QList<QVariant> {}",
+        "param": "QList<QVariant> { QStringList {\"Problem URL\", \"The regular expression for the problem URL\"}, QStringList {\"File Path\", \"The replace expression for the file path, without file name suffix.\\nYou can use \\\"\\\\1\\\" for the first captured group.\"}}",
+        "tip": "The default file path used when saving a new file while the problem URL is set"
     }
 ]


### PR DESCRIPTION
## Description

Now you can set different default file paths for different problem URLs.

## Related Issue

This closes #200.

## Motivation and Context

With this, users don't have to manually set the saving path when using Competitive Companion.

## How Has This Been Tested?

On Manjaro KDE.

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->

- [x] New feature (changes which add functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
