### PR TITLE
fix(default save path): Ignore empty regex and replace captured string

### DIFF
--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -574,7 +574,7 @@
         "name": "Testcases Matching Rules",
         "type": "QList<QVariant>",
         "default": "QList<QVariant> { QStringList {\"(.*)\\\\.in\", \"\\\\1.ans\"}, QStringList {\"(.*)\\\\.in\", \"\\\\1.out\"}}",
-        "param": "QList<QVariant> { QStringList {\"Input Regex\", \"The regular expression for the input file name\"}, QStringList {\"Answer Replace\", \"The replace expression for the answer file name.\\nYou can use \\\"\\\\1\\\" for the first captured group.\"}}",
+        "param": "QList<QVariant> { QStringList {\"Input Regex\", \"The regular expression which matches the whole input file name\"}, QStringList {\"Answer Replace\", \"The replace expression for the answer file name.\\nYou can use \\\"\\\\1\\\" for the first captured group.\"}}",
         "tip": "Pairs of regular expressions used when adding pairs of test cases from files. Each pair of regular expressions represents a test case."
     },
     {
@@ -593,7 +593,7 @@
         "name": "Default File Paths For Problem URLs",
         "type": "QList<QVariant>",
         "default": "QList<QVariant> {}",
-        "param": "QList<QVariant> { QStringList {\"Problem URL\", \"The regular expression for the problem URL\"}, QStringList {\"File Path\", \"The replace expression for the file path, without file name suffix.\\nYou can use \\\"\\\\1\\\" for the first captured group.\"}}",
+        "param": "QList<QVariant> { QStringList {\"Problem URL\", \"The regular expression which matches a part of the problem URL\"}, QStringList {\"File Path\", \"The replace expression for the file path, without file name suffix.\\nYou can use \\\"\\\\1\\\" for the first captured group.\"}}",
         "tip": "The default file path used when saving a new file while the problem URL is set"
     }
 ]

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -758,10 +758,13 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
                 auto rules = SettingsHelper::getDefaultFilePathsForProblemURLs();
                 for (auto rule : rules)
                 {
+                    if (rule.toStringList().front().isEmpty())
+                        continue;
                     auto url = QRegularExpression(rule.toStringList().front());
-                    if (url.match(problemURL).hasMatch())
+                    auto match = url.match(problemURL);
+                    if (match.hasMatch())
                     {
-                        defaultPath = getProblemURL().replace(url, rule.toStringList().back());
+                        defaultPath = match.captured().replace(url, rule.toStringList().back());
                         break;
                     }
                 }


### PR DESCRIPTION
The bug:

1. Empty regexes match everything.
2. If the regex matches only a part of the problem URL, other parts won't be replaced and will be in the saving path.

Now it's fixed.

And the tooltips are modified to point out that the regexes in the Testcases Matching Rules should match the whole string, and the regexes in Default File Paths For Problem URLs can match only a part of the problem URL.

The regexes in the Testcases Matching Rules should match the whole string, because it's common that a testcase file is a substring of another.

The regexes in Default File Paths For Problem URLs can match only a part of the problem URL, because it's nearly impossible that one problem URL is the substring of another, but sometimes there are suffixes like "#" or "?" in the problem URL, and users may forget to include them in the regexes. The user still can enforce whole-string match by adding "^" at the front of the regex and "$" at the end of the regex.

## Related Issue

#200 

## How Has This Been Tested?

On Manjaro KDE.

## Type of changes

- [x] Bug fix (changes which fix an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
