### PR TITLE
fix: Don't load invalid settings

### DIFF
--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -64,11 +64,11 @@ void SettingsManager::init()
         // load most of settings
         for (const SettingInfo &si : settingInfo)
         {
-            if (setting.contains(si.key()))
+            if (setting.contains(si.key()) && setting.value(si.key()).isValid())
                 set(si.name, setting.value(si.key()));
             else
                 for (const QString &old : si.old)
-                    if (setting.contains(old))
+                    if (setting.contains(old) && setting.value(old).isValid())
                     {
                         set(si.name, setting.value(old));
                         break;


### PR DESCRIPTION
## Description

Don't load invalid settings.

## Motivation and Context

Empty QVariantList is saved as an invalid QVariant in the settings.
Though I don't know why it is invalid, it makes the setting always
modified when it's empty, and the user will be warned by unsaved
settings.

## How Has This Been Tested?

On Manjaro KDE.

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [x] Bug fix (changes which fix an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
