### PR TITLE
fix: Don't save non-exist file when getting temp path

### DIFF
--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -165,7 +165,8 @@ class MainWindow : public QMainWindow
     enum SaveMode
     {
         IgnoreUntitled, // save only when filePath is not empty
-        SaveUntitled,   // save to filePath if it's not empty, otherwise ask for new path
+        IgnoreNonExist, // don't save if the file doesn't exist, this implies IgnoreUntitled
+        AlwaysSave,     // save to filePath if it's not empty, otherwise ask for new path
         SaveAs,         // ask for new path no matter filePath is empty or not
     };
     enum AfterCompile
@@ -223,7 +224,7 @@ class MainWindow : public QMainWindow
     void updateWatcher();
     void loadFile(const QString &loadPath);
     bool saveFile(SaveMode, const QString &head, bool safe);
-    SaveTempStatus saveTemp(const QString &head);
+    SaveTempStatus saveTemp(const QString &head, SaveMode mode = IgnoreUntitled);
     void performCompileAndRunDiagonistics();
     QString getRunnerHead(int index);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Don't save non-exist files when getting the temp path.

## Motivation and Context

Because of the language server, now the temp path is often requested.

However, a tab with a non-exist file path shouldn't be automatically saved. Like when opening a contest, or open a non-exist file in the terminal.

## How Has This Been Tested?

On Manjaro KDE.

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [x] Bug fix (changes which fix an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
