### PR TITLE
feat: Set font for test cases

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@ Now error linting is available with Language Server. Linting can be helpful when
 - Now you can choose where to save the test case files in Preferences->File Path->Testcases. (#176)
 - Now when saving the source file, if the parent directory of the file does not exist, it will be automatically created.
 - Now you can set different default file paths for different problem URLs. (#200)
+- Now you can set font for test cases.
 
 ### Changed
 

--- a/src/Settings/AppearancePage.cpp
+++ b/src/Settings/AppearancePage.cpp
@@ -24,8 +24,9 @@
 #include <generated/SettingsInfo.hpp>
 
 AppearancePage::AppearancePage(QWidget *parent)
-    : PreferencesPageTemplate({"Editor Theme", "Font", "Opacity", "Show Compile And Run Only", "Display EOLN In Diff"},
-                              true, parent)
+    : PreferencesPageTemplate(
+          {"Editor Theme", "Font", "Test Cases Font", "Opacity", "Show Compile And Run Only", "Display EOLN In Diff"},
+          true, parent)
 {
 }
 

--- a/src/Settings/AppearancePage.cpp
+++ b/src/Settings/AppearancePage.cpp
@@ -24,9 +24,9 @@
 #include <generated/SettingsInfo.hpp>
 
 AppearancePage::AppearancePage(QWidget *parent)
-    : PreferencesPageTemplate(
-          {"Editor Theme", "Font", "Test Cases Font", "Opacity", "Show Compile And Run Only", "Display EOLN In Diff"},
-          true, parent)
+    : PreferencesPageTemplate({"Editor Theme", "Editor Font", "Test Cases Font", "Opacity", "Show Compile And Run Only",
+                               "Display EOLN In Diff"},
+                              true, parent)
 {
 }
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -14,10 +14,12 @@
         "type": "QRect"
     },
     {
-        "name": "Font",
-        "desc": "Editor Font",
+        "name": "Editor Font",
         "type": "QFont",
         "default": "QFont(\"monospace\")",
+        "old": [
+            "font"
+        ],
         "tip": "The font of the code editor"
     },
     {

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -595,5 +595,11 @@
         "default": "QVariantList {}",
         "param": "QVariantList { QStringList {\"Problem URL\", \"The regular expression which matches a part of the problem URL\"}, QStringList {\"File Path\", \"The replace expression for the file path, without file name suffix.\\nYou can use \\\"\\\\1\\\" for the first captured group.\"}}",
         "tip": "The default file path used when saving a new file while the problem URL is set"
+    },
+    {
+        "name": "Test Cases Font",
+        "type": "QFont",
+        "default": "QFont(\"monospace\")",
+        "tip": "The font of test cases"
     }
 ]

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -131,7 +131,7 @@ void applySettingsToEditor(QCodeEditor *editor)
     editor->setAutoParentheses(SettingsHelper::isAutoCompleteParentheses());
     editor->setAutoRemoveParentheses(SettingsHelper::isAutoRemoveParentheses());
 
-    editor->setFont(SettingsHelper::getFont());
+    editor->setFont(SettingsHelper::getEditorFont());
 
     const int tabStop = SettingsHelper::getTabWidth();
     QFontMetrics metric(editor->font());

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -197,6 +197,13 @@ bool TestCase::isShow() const
     return showCheckBox->isChecked();
 }
 
+void TestCase::setTestCaseEditFont(const QFont &font)
+{
+    inputEdit->setFont(font);
+    outputEdit->setFont(font);
+    expectedEdit->setFont(font);
+}
+
 void TestCase::onShowCheckBoxToggled(bool checked)
 {
     if (checked)

--- a/src/Widgets/TestCase.hpp
+++ b/src/Widgets/TestCase.hpp
@@ -53,6 +53,7 @@ class TestCase : public QWidget
     Core::Checker::Verdict verdict() const;
     void setShow(bool show);
     bool isShow() const;
+    void setTestCaseEditFont(const QFont &font);
 
   signals:
     void deleted(TestCase *widget);

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -33,6 +33,7 @@ namespace Widgets
 TestCaseEdit::TestCaseEdit(bool autoAnimation, MessageLogger *logger, const QString &text, QWidget *parent)
     : QPlainTextEdit(text, parent), log(logger)
 {
+    setFont(SettingsHelper::getTestCasesFont());
     animation = new QPropertyAnimation(this, "minimumHeight", this);
     if (autoAnimation)
         connect(this, SIGNAL(textChanged()), this, SLOT(startAnimation()));

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -352,6 +352,12 @@ QString TestCases::loadTestCaseFromFile(const QString &path, const QString &head
     return content;
 }
 
+void TestCases::setTestCaseEditFont(const QFont &font)
+{
+    for (auto t : testcases)
+        t->setTestCaseEditFont(font);
+}
+
 int TestCases::id(TestCase *testcase) const
 {
     return testcases.indexOf(testcase);

--- a/src/Widgets/TestCases.hpp
+++ b/src/Widgets/TestCases.hpp
@@ -77,6 +77,8 @@ class TestCases : public QWidget
 
     QString loadTestCaseFromFile(const QString &path, const QString &head);
 
+    void setTestCaseEditFont(const QFont &font);
+
   public slots:
     void setVerdict(int index, Core::Checker::Verdict verdict);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -481,6 +481,9 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
     if (pagePath.isEmpty() || pagePath == "Code Edit" || pagePath == "Appearance")
         Util::applySettingsToEditor(editor);
 
+    if (pagePath.isEmpty() || pagePath == "Appearance")
+        testcases->setTestCaseEditFont(SettingsHelper::getTestCasesFont());
+
     if (!isLanguageSet && (pagePath.isEmpty() || pagePath == "Language/General"))
     {
         setLanguage(SettingsHelper::getDefaultLanguage());


### PR DESCRIPTION
## Description

Now users can set the font for test cases.

## Motivation and Context

In the input of some problems, there's a board consisting of `.` and `*`, which requires a monospace font to be readable.

## How Has This Been Tested?

On Manjaro KDE.

## Screenshots (if appropriate)

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist

- [x I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
