### PR TITLE
Update QCodeEditor

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -13,11 +13,13 @@ Now error linting is available with Language Server. Linting can be helpful when
 - Now when saving the source file, if the parent directory of the file does not exist, it will be automatically created.
 - Now you can set different default file paths for different problem URLs. (#200)
 - Now you can set font for test cases.
+- Now you can enable extra bottom margin with the height of a page. (#230)
 
 ### Changed
 
 - Word selection in editor is highlighted with change of background color instead of an underline. Underlined text now represent linting of type "Hint".
 - The shortcut of Detached Run is changed from Ctrl+Shift+D to Ctrl+Alt+D. (#237)
+- Now after deleting the current line/selected lines, the cursor will keep its place if possible, instead of moving to the start of the previous line.
 
 ### Fixed
 
@@ -25,6 +27,7 @@ Now error linting is available with Language Server. Linting can be helpful when
 - Fix preferences window loses focus after picking the font. (#260)
 - Fix Ctrl+Enter and Ctrl+Shift+Enter in the code editor.
 - Fix lost of code snippets and hot exit status on some platforms.
+- Fix the unexpected behaviour of Shift+Enter.
 
 ## v6.3
 

--- a/src/Settings/AppearancePage.cpp
+++ b/src/Settings/AppearancePage.cpp
@@ -25,7 +25,7 @@
 
 AppearancePage::AppearancePage(QWidget *parent)
     : PreferencesPageTemplate({"Editor Theme", "Editor Font", "Test Cases Font", "Opacity", "Show Compile And Run Only",
-                               "Display EOLN In Diff"},
+                               "Display EOLN In Diff", "Extra Bottom Margin"},
                               true, parent)
 {
 }

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -603,5 +603,11 @@
         "type": "QFont",
         "default": "QFont(\"monospace\")",
         "tip": "The font of test cases"
+    },
+    {
+        "name": "Extra Bottom Margin",
+        "desc": "Add extra margin at the bottom of the code editor",
+        "type": "bool",
+        "tip": "Add an extra margin with the height of a page at the bottom of the code editor.\nDue to technical reasons, changing the height of the margin affects the undo history."
     }
 ]

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -154,6 +154,8 @@ void applySettingsToEditor(QCodeEditor *editor)
         editor->setSyntaxStyle(Extensions::EditorTheme::getSolarizedDarkTheme());
     else
         editor->setSyntaxStyle(Extensions::EditorTheme::getLightTheme());
+
+    editor->setExtraBottomMargin(SettingsHelper::isExtraBottomMargin());
 }
 
 void setEditorLanguage(QCodeEditor *editor, const QString &language)


### PR DESCRIPTION
## Description

Add bottom margin with the height of a page

## Related Issue

This closes #230.

## Motivation and Context

In this way, users can scroll the screen less when appending codes.

## How Has This Been Tested?

On Manjaro KDE.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/81392438-438e5000-9151-11ea-970d-ac5bd787c370.png)

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
