### PR TITLE
ci: Don't update cpeditor-git on non-code changes

### DIFF
--- a/.github/workflows/push_aur.yml
+++ b/.github/workflows/push_aur.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - ".github/**"
+      - "**.md"
+      - ".all-contributorsrc"
+      - ".gitignore"
 
 jobs:
   aur:


### PR DESCRIPTION
## Description

Don't update `cpeditor-git` on non-code changes.

## Motivation and Context

Reduce unnecessary updates for AUR users.

## Type of changes

- [x] CI (changes to CI configuration files and scripts)