### PR TITLE
feat(Settings): Search desc, tip and help of a setting

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Added
+
+- Now besides the name of a setting, you can also search for the desciption, tool tip and help information of a setting in the preferences window. (#337)
+
 ## v6.4
 
 ### Linting with Language Server

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -90,7 +90,18 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
 
 QStringList PreferencesPageTemplate::content()
 {
-    return options;
+    QStringList ret = options;
+    for (auto opt : options)
+    {
+        SettingInfo si = findSetting(opt);
+        if (!si.desc.isEmpty())
+            ret += si.desc;
+        if (!si.tip.isEmpty())
+            ret += si.tip;
+        if (!si.help.isEmpty())
+            ret += si.help;
+    }
+    return ret;
 }
 
 bool PreferencesPageTemplate::areSettingsChanged()


### PR DESCRIPTION
## Description

Now you can search for the desc, tip and help of a setting in the preferences window.

## Motivation and Context

In this way, it will be easier to search for a setting.

## How Has This Been Tested?

On Manjaro KDE.

## Type of changes

- [x] New feature (changes which add functionality)
