### PR TITLE
feat: Use Alt to choose the menu in the main window

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Now you can change the font of the message logger. (#331 and #334)
 - Now besides the name of a setting, you can also search for the desciption, tool tip and help information of a setting in the preferences window. (#337)
+- Now you can use Alt to choose the menu in the main window. (#344)
 
 ## v6.4
 

--- a/ui/appwindow.ui
+++ b/ui/appwindow.ui
@@ -50,7 +50,7 @@
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">
-     <string>File</string>
+     <string>&amp;File</string>
     </property>
     <addaction name="actionNew_Tab"/>
     <addaction name="actionOpen"/>
@@ -67,7 +67,7 @@
    </widget>
    <widget class="QMenu" name="menuEdit">
     <property name="title">
-     <string>Edit</string>
+     <string>&amp;Edit</string>
     </property>
     <addaction name="action_indent"/>
     <addaction name="action_unindent"/>
@@ -84,7 +84,7 @@
    </widget>
    <widget class="QMenu" name="menuActions">
     <property name="title">
-     <string>Actions</string>
+     <string>&amp;Actions</string>
     </property>
     <addaction name="actionCompile"/>
     <addaction name="actionCompile_Run"/>
@@ -97,7 +97,7 @@
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>View</string>
+     <string>&amp;View</string>
     </property>
     <addaction name="actionEditor_Mode"/>
     <addaction name="actionIO_Mode"/>
@@ -105,7 +105,7 @@
    </widget>
    <widget class="QMenu" name="menuOptions">
     <property name="title">
-     <string>Options</string>
+     <string>&amp;Options</string>
     </property>
     <addaction name="actionSettings"/>
     <addaction name="separator"/>
@@ -116,7 +116,7 @@
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
-     <string>Help</string>
+     <string>&amp;Help</string>
     </property>
     <addaction name="actionManual"/>
     <addaction name="actionAbout"/>


### PR DESCRIPTION
## Description

Make it able to use Alt to choose the menu in the main window. For example, you can use "Alt+F" to choose the "File" menu.

## Motivation and Context

Make it easier to choose the menu.

## How Has This Been Tested?

On Manjaro KDE.

## Screenshots (if appropriate)

When pressing <kbd>Alt</kbd>:

![image](https://user-images.githubusercontent.com/30581822/81774642-a733c700-951d-11ea-9b01-30ff544a464a.png)

## Type of changes

- [x] New feature (changes which add functionality)