### PR TITLE
chore: add config for the stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - critical_priority
+  - high_priority
+  - medium_priority
+  - low_priority
+  - work in progress
+  - good first issue
+  - help wanted
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
## Description

Add config for the stale bot.

The app: https://github.com/apps/stale/

## Motivation and Context

Use the bot to close inactive issues.

Don't mark issues with labels for the priority as stale issues.