### PR TITLE
Fix #271 and #353

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It makes your competitive coding life easier :grin: by automating many things fo
 ## FAQ
 
 - I am using Java and the editor can't run my codes.
-   - You have to use a **non-public** class named **a** for your solution.
+   - You have to use a **non-public** class for your solution, its name can be configured in Preferences->Language->Commands->Java Class Name.
 - I get **DLL Missing error** when launching the application?
    - Please download  [Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads).
 - How to use whole-application dark theme?

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -55,7 +55,7 @@ CP Editor 是一个基于 Qt 的轻量级跨平台代码编辑器，专为算法
 ## FAQ
 
 - 我在写 Java，代码不能正常运行。
-   - 你的代码使用的类名需要是 `a`，而且不能是 public class。
+   - 你的代码需要使用一个 non-public class，名称可以在 Preferences->Language->Commands->Java Class Name 中设定。
 - 打开程序时提示缺失 DLL。
    - 请下载并安装 [Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)。
 - 如何使整个界面都是暗色主题？

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 - Now it's optional to save the file on compilation and execution or not.
-- Now you can choose the path of the executable file of C++. (#271)
+- Now you can choose the path of the executable file for C++ and the path of the parent directory of the class file for Java. (#271)
 
 ### Fixed
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Fixed
+
+- Fixed some unexpected file saving. (#353)
+
 ## 6.4.1 (Beta)
 
 ### Linting with Language Server

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Now it's optional to save the file on compilation and execution or not.
+- Now you can choose the path of the executable file of C++. (#271)
 
 ### Fixed
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Added
+
+- Now it's optional to save the file on compilation and execution or not.
+
 ### Fixed
 
 - Fixed some unexpected file saving. (#353)

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Fixed some unexpected file saving. (#353)
 
+### Changed
+
+- Open an empty untitled tab when the open file length limit is exceeded. (#353)
+
 ## 6.4.1 (Beta)
 
 ### Linting with Language Server

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -20,7 +20,7 @@ You have to either parse the problem from Competitive Companion, or set the prob
 
 ## For Java users
 
-You have to use a **non-public** class named **a** for your solution.
+You have to use a **non-public** class for your solution, its name can be configured in Preferences->Language->Commands->Java Class Name.
 
 ## Language Server
 

--- a/doc/MANUAL_zh-CN.md
+++ b/doc/MANUAL_zh-CN.md
@@ -22,7 +22,7 @@
 
 ## 如果你使用 Java
 
-你的代码使用的类名需要是 `a`，而且不能是 public class。
+你的代码需要使用一个 non-public class，名称可以在 Preferences->Language->Commands->Java Class Name 中设定。
 
 ## 设置
 

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -303,8 +303,9 @@ void Checker::check(int index, const QString &input, const QString &output, cons
             connect(tmp, SIGNAL(runOutputLimitExceeded(int, const QString &)), this,
                     SLOT(onRunOutputLimitExceeded(int, const QString &)));
             connect(tmp, SIGNAL(runKilled(int)), this, SLOT(onRunKilled(int)));
-            tmp->run(checkerPath, "", "C++", "", "\"" + inputPath + "\" \"" + outputPath + "\" \"" + expectedPath + "\"",
-                     "", SettingsHelper::getTimeLimit());
+            tmp->run(checkerPath, "", "C++", "",
+                     "\"" + inputPath + "\" \"" + outputPath + "\" \"" + expectedPath + "\"", "",
+                     SettingsHelper::getTimeLimit());
         }
         break;
     }

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -130,7 +130,7 @@ void Checker::prepare(const QString &compileCommand)
         connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
                 SLOT(onCompilationErrorOccurred(const QString &)));
         connect(compiler, SIGNAL(compilationKilled()), this, SLOT(onCompilationKilled()));
-        compiler->start(checkerPath, compileCommand, "C++");
+        compiler->start(checkerPath, "", compileCommand, "C++");
     }
 }
 
@@ -303,7 +303,7 @@ void Checker::check(int index, const QString &input, const QString &output, cons
             connect(tmp, SIGNAL(runOutputLimitExceeded(int, const QString &)), this,
                     SLOT(onRunOutputLimitExceeded(int, const QString &)));
             connect(tmp, SIGNAL(runKilled(int)), this, SLOT(onRunKilled(int)));
-            tmp->run(checkerPath, "C++", "", "\"" + inputPath + "\" \"" + outputPath + "\" \"" + expectedPath + "\"",
+            tmp->run(checkerPath, "", "C++", "", "\"" + inputPath + "\" \"" + outputPath + "\" \"" + expectedPath + "\"",
                      "", SettingsHelper::getTimeLimit());
         }
         break;

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -113,10 +113,10 @@ bool Compiler::check(const QString &compileCommand)
 QString Compiler::cppOutputPath(const QString &tmpFilePath, const QString &sourceFilePath)
 {
     QFileInfo fileInfo(sourceFilePath.isEmpty() ? tmpFilePath : sourceFilePath);
-    QString res =  fileInfo.dir().filePath(SettingsHelper::getCppExecutableFilePath()
-                                       .replace("${filename}", fileInfo.fileName())
-                                       .replace("${basename}", fileInfo.completeBaseName())
-                                       .replace("${tmpdir}", QFileInfo(tmpFilePath).absolutePath()));
+    QString res = fileInfo.dir().filePath(SettingsHelper::getCppExecutableFilePath()
+                                              .replace("${filename}", fileInfo.fileName())
+                                              .replace("${basename}", fileInfo.completeBaseName())
+                                              .replace("${tmpdir}", QFileInfo(tmpFilePath).absolutePath()));
     QDir().mkpath(QFileInfo(res).absolutePath());
     return res;
 }

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -69,12 +69,14 @@ class Compiler : public QObject
     static bool check(const QString &compileCommand);
 
     /**
-     * @brief get the output path (executable file path) when compiling C++
+     * @brief get the output path (executable file path when compiling C++, class path when compiling Java)
      * @param tmpFilePath the path to the temporary file which is compiled
      * @param sourceFilePath the path to the original source file, if it's empty, tmpFilePath will be used instead of it
-     * @note the parent directory of the result will be created
+     * @param lang the language being compiled
+     * @note if lang is C++, the parent directory of the result will be created; if lang is Java, the result directory
+     * will be created
      */
-    static QString cppOutputPath(const QString &tmpFilePath, const QString &sourceFilePath);
+    static QString outputPath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang);
 
   signals:
     /**

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -52,12 +52,14 @@ class Compiler : public QObject
 
     /**
      * @brief start the compilation
-     * @param filePath the file path to the source file
+     * @param tmpFilePath the path to the temporary file which is compiled
+     * @param sourceFilePath the path to the original source file
      * @param compileCommand the command for compiling
      * @param lang the language to compile, one of "C++", "Java", "Python"
      * @note this should be called only once per Compiler
      */
-    void start(const QString &filePath, const QString &compileCommand, const QString &lang);
+    void start(const QString &tmpFilePath, const QString &sourceFilePath, const QString &compileCommand,
+               const QString &lang);
 
     /**
      * @brief check whether a compile command is valid or not
@@ -65,6 +67,14 @@ class Compiler : public QObject
      * @note this only checks whether the program of the command works
      */
     static bool check(const QString &compileCommand);
+
+    /**
+     * @brief get the output path (executable file path) when compiling C++
+     * @param tmpFilePath the path to the temporary file which is compiled
+     * @param sourceFilePath the path to the original source file, if it's empty, tmpFilePath will be used instead of it
+     * @note the parent directory of the result will be created
+     */
+    static QString cppOutputPath(const QString &tmpFilePath, const QString &sourceFilePath);
 
   signals:
     /**

--- a/src/Core/Runner.cpp
+++ b/src/Core/Runner.cpp
@@ -202,13 +202,13 @@ QString Runner::getCommand(const QString &tmpFilePath, const QString &sourceFile
 
     if (lang == "C++")
     {
-        res = QString("\"%1\" %2").arg(Compiler::cppOutputPath(tmpFilePath, sourceFilePath)).arg(args);
+        res = QString("\"%1\" %2").arg(Compiler::outputPath(tmpFilePath, sourceFilePath, "C++")).arg(args);
     }
     else if (lang == "Java")
     {
         res = QString("%1 -classpath \"%2\" %3 %4")
                   .arg(runCommand)
-                  .arg(QFileInfo(tmpFilePath).canonicalPath())
+                  .arg(Compiler::outputPath(tmpFilePath, sourceFilePath, "Java"))
                   .arg(SettingsHelper::getJavaClassName())
                   .arg(args);
     }

--- a/src/Core/Runner.hpp
+++ b/src/Core/Runner.hpp
@@ -52,7 +52,8 @@ class Runner : public QObject
 
     /**
      * @brief run a program on a given input
-     * @param filePath the path to the source file
+     * @param tmpFilePath the path to the temporary file which is compiled
+     * @param sourceFilePath the path to the original source file
      * @param lang the language to run, one of "C++", "Java" and "Python"
      * @param runCommand the command for running a program
      * @param args the command line arguments added at the back to start the program
@@ -60,19 +61,21 @@ class Runner : public QObject
      * @param timeLimit the maximum time for the program to run, in milliseconds
      * @note This should be called only once. Please create multiple Runners for multiple runs.
      */
-    void run(const QString &filePath, const QString &lang, const QString &runCommand, const QString &args,
-             const QString &input, int timeLimit);
+    void run(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang, const QString &runCommand,
+             const QString &args, const QString &input, int timeLimit);
 
     /**
      * @brief run a program in a pop-up terminal
-     * @param filePath the path to the source file
+     * @param tmpFilePath the path to the temporary file which is compiled
+     * @param sourceFilePath the path to the original source file
      * @param lang the language to run, one of "C++", "Java" and "Python"
      * @param runCommand the command for running a program
      * @param args the command line arguments added at the back to start the program
      * @note runFinished, runTimeout and runKilled won't be emitted when using runDetached. failedToStartRun will only
      *       be emitted when xterm is not installed on Linux, it's not emitted even the source file is not compiled.
      */
-    void runDetached(const QString &filePath, const QString &lang, const QString &runCommand, const QString &args);
+    void runDetached(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
+                     const QString &runCommand, const QString &args);
 
   signals:
     /**
@@ -153,12 +156,14 @@ class Runner : public QObject
   private:
     /**
      * @brief get the command to run a program
-     * @param filePath the path to the source file
+     * @param tmpFilePath the path to the temporary file which is compiled
+     * @param sourceFilePath the path to the original source file
      * @param lang the language to run, one of "C++", "Java" and "Python"
      * @param runCommand the command for running a program
      * @param args the command line arguments added at the back to start the program
      */
-    QString getCommand(const QString &filePath, const QString &lang, const QString &runCommand, const QString &args);
+    static QString getCommand(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
+                              const QString &runCommand, const QString &args);
 
     const int runnerIndex;                   // the index of the testcase
     QProcess *runProcess = nullptr;          // the process to run the program

--- a/src/Settings/PreferencesHomePage.cpp
+++ b/src/Settings/PreferencesHomePage.cpp
@@ -27,6 +27,8 @@ PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
     // construct the layout
     layout = new QVBoxLayout(this);
 
+    layout->addSpacing(20);
+
     // add stretch so that the contents are vertically centered
     layout->addStretch();
 
@@ -48,7 +50,9 @@ PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
 
     // add buttons
     addButton("Code Edit", "Code Editor Settings");
-    addButton("Language/Commands", "Compile and Run Commands");
+    addButton("Language/Commands/C++ Commands", "C++ Compile and Run Commands");
+    addButton("Language/Commands/Java Commands", "Java Compile and Run Commands");
+    addButton("Language/Commands/Python Commands", "Python Run Commands");
     addButton("Appearance", "Appearance");
 
     // add spacing between the buttons and the manual label
@@ -63,6 +67,8 @@ PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
 
     // add stretch so that the contents are vertically centered
     layout->addStretch();
+
+    layout->addSpacing(20);
 }
 
 void PreferencesHomePage::addButton(const QString &page, const QString &text)

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -120,7 +120,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     addPage("Actions/General", {"Hot Exit/Enable"});
 
-    addPage("Actions/Save", {"Auto Save", "Save Faster", "Auto Format", "Save Tests"});
+    addPage("Actions/Save", {"Auto Save", "Save Faster", "Auto Format", "Save File On Compilation", "Save File On Execution", "Save Tests"});
 
     addPage("Extensions/Clang Format", {"Clang Format/Path", "Clang Format/Style"}, false);
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -101,9 +101,10 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     addPage("Language/General", {"Default Language"});
 
-    addPage("Language/Commands", {"C++/Compile Command", "C++/Executable File Path", "C++/Run Arguments",
-                                  "Java/Compile Command", "Java/Run Arguments", "Java/Run Command", "Java/Class Name",
-                                  "Python/Run Arguments", "Python/Run Command"});
+    addPage("Language/Commands/C++ Commands", {"C++/Compile Command", "C++/Output Path", "C++/Run Arguments"});
+    addPage("Language/Commands/Java Commands",
+            {"Java/Compile Command", "Java/Output Path", "Java/Class Name", "Java/Run Command", "Java/Run Arguments"});
+    addPage("Language/Commands/Python Commands", {"Python/Run Command", "Python/Run Arguments"});
 
     addPage("Language/Code Template", {"C++/Template Path", "Java/Template Path", "Python/Template Path"});
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -101,9 +101,9 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     addPage("Language/General", {"Default Language"});
 
-    addPage("Language/Commands",
-            {"C++/Compile Command", "C++/Run Arguments", "Java/Compile Command", "Java/Run Arguments",
-             "Java/Run Command", "Python/Run Arguments", "Python/Run Command"});
+    addPage("Language/Commands", {"C++/Compile Command", "C++/Executable File Path", "C++/Run Arguments",
+                                  "Java/Compile Command", "Java/Run Arguments", "Java/Run Command", "Java/Class Name",
+                                  "Python/Run Arguments", "Python/Run Command"});
 
     addPage("Language/Code Template", {"C++/Template Path", "Java/Template Path", "Python/Template Path"});
 
@@ -120,7 +120,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     addPage("Actions/General", {"Hot Exit/Enable"});
 
-    addPage("Actions/Save", {"Auto Save", "Save Faster", "Auto Format", "Save File On Compilation", "Save File On Execution", "Save Tests"});
+    addPage("Actions/Save", {"Auto Save", "Save Faster", "Auto Format", "Save File On Compilation",
+                             "Save File On Execution", "Save Tests"});
 
     addPage("Extensions/Clang Format", {"Clang Format/Path", "Clang Format/Style"}, false);
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -73,6 +73,12 @@
         "tip": "The command used to compile C++. It should NOT include the path to the source file or \"-o <output file>\"."
     },
     {
+        "name": "C++/Executable File Path",
+        "type": "QString",
+        "default": "${tempdir}/${basename}",
+        "tip": "The path of the compiled executable file, relative to the source file,\nor the temporary directory if the tab is untitled.\nNo \".exe\" is needed.\nYou can use \"${filename}\" for the complete file name,\n\"${basename}\" for the base file name without the suffix,\n\"${tmpdir}\" for the absolute path of the temporary directory."
+    },
+    {
         "name": "C++/Run Arguments",
         "type": "QString",
         "old": [
@@ -116,6 +122,12 @@
             "run_java"
         ],
         "tip": "The command to start a Java program. It should NOT include \"-classpath <path> <class name>\"."
+    },
+    {
+        "name": "Java/Class Name",
+        "type": "QString",
+        "default": "a",
+        "tip": "The non-public class name of your solution."
     },
     {
         "name": "Python/Template Path",

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -73,10 +73,11 @@
         "tip": "The command used to compile C++. It should NOT include the path to the source file or \"-o <output file>\"."
     },
     {
-        "name": "C++/Executable File Path",
+        "name": "C++/Output Path",
+        "desc": "C++ Executable File Path",
         "type": "QString",
         "default": "${tempdir}/${basename}",
-        "tip": "The path of the compiled executable file, relative to the source file,\nor the temporary directory if the tab is untitled.\nNo \".exe\" is needed.\nYou can use \"${filename}\" for the complete file name,\n\"${basename}\" for the base file name without the suffix,\n\"${tmpdir}\" for the absolute path of the temporary directory."
+        "tip": "The path of the compiled executable file.\nIt's relative to the source file, or the temporary directory if the tab is untitled.\nNo \".exe\" is needed.\nYou can use \"${filename}\" for the complete file name,\n\"${basename}\" for the base file name without the suffix,\n\"${tmpdir}\" for the absolute path of the temporary directory."
     },
     {
         "name": "C++/Run Arguments",
@@ -103,7 +104,7 @@
         "old": [
             "compile_java"
         ],
-        "tip": "The command used to compile Java. It should NOT include the path to the source file."
+        "tip": "The command used to compile Java.\nIt should NOT include the path to the source file or the path of the compiled class file."
     },
     {
         "name": "Java/Run Arguments",
@@ -128,6 +129,13 @@
         "type": "QString",
         "default": "a",
         "tip": "The non-public class name of your solution."
+    },
+    {
+        "name": "Java/Output Path",
+        "desc": "Java Class Path",
+        "type": "QString",
+        "default": "${tmpdir}",
+        "tip": "The path of the parent directory of the compiled executable file.\nIt's relative to the source file, or the temporary directory if the tab is untitled.\nYou can use \"${filename}\" for the complete file name,\n\"${basename}\" for the base file name without the suffix,\n\"${tmpdir}\" for the absolute path of the temporary directory."
     },
     {
         "name": "Python/Template Path",

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -609,5 +609,16 @@
         "desc": "Add extra margin at the bottom of the code editor",
         "type": "bool",
         "tip": "Add an extra margin with the height of a page at the bottom of the code editor.\nDue to technical reasons, changing the height of the margin affects the undo history."
+    },
+    {
+        "name": "Save File On Compilation",
+        "type": "bool",
+        "default": "true",
+        "tip": "Save the source file when compiling it. It won't be saved if the tab is untitled."
+    },
+    {
+        "name": "Save File On Execution",
+        "type": "bool",
+        "tip": "Save the source file when running it. It won't be saved if the tab is untitled."
     }
 ]

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -396,7 +396,8 @@ void AppWindow::openTab(const QString &path)
     auto fsp = new MainWindow(path, getNewUntitledIndex(), this);
     connect(fsp, SIGNAL(confirmTriggered(MainWindow *)), this, SLOT(on_confirmTriggered(MainWindow *)));
     connect(fsp, SIGNAL(editorFileChanged()), this, SLOT(onEditorFileChanged()));
-    connect(fsp, SIGNAL(editorTmpPathChanged(MainWindow *)), this, SLOT(onEditorTmpPathChanged(MainWindow *)));
+    connect(fsp, SIGNAL(editorTmpPathChanged(MainWindow *, const QString &)), this,
+            SLOT(onEditorTmpPathChanged(MainWindow *, const QString &)));
     connect(fsp, SIGNAL(editorLanguageChanged(MainWindow *)), this, SLOT(onEditorLanguageChanged(MainWindow *)));
     connect(fsp, SIGNAL(editorTextChanged(MainWindow *)), this, SLOT(onEditorTextChanged(MainWindow *)));
     connect(fsp, SIGNAL(requestToastMessage(const QString &, const QString &)), trayIcon,
@@ -904,16 +905,16 @@ void AppWindow::onEditorTextChanged(MainWindow *window)
     }
 }
 
-void AppWindow::onEditorTmpPathChanged(MainWindow *window)
+void AppWindow::onEditorTmpPathChanged(MainWindow *window, const QString &path)
 {
     if (currentWindow() == window)
     {
         if (window->getLanguage() == "C++" && cppServer->isDocumentOpen())
-            cppServer->updatePath(window->tmpPath());
+            cppServer->updatePath(path);
         else if (window->getLanguage() == "Java" && javaServer->isDocumentOpen())
-            javaServer->updatePath(window->tmpPath());
+            javaServer->updatePath(path);
         else if (window->getLanguage() == "Python" && pythonServer->isDocumentOpen())
-            pythonServer->updatePath(window->tmpPath());
+            pythonServer->updatePath(path);
     }
 }
 

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -107,7 +107,7 @@ class AppWindow : public QMainWindow
 
     void onEditorTextChanged(MainWindow *window);
 
-    void onEditorTmpPathChanged(MainWindow *window);
+    void onEditorTmpPathChanged(MainWindow *window, const QString &path);
 
     void onEditorLanguageChanged(MainWindow *window);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -121,28 +121,29 @@ void MainWindow::setupCore()
 void MainWindow::compile()
 {
     killProcesses();
+
     compiler = new Core::Compiler();
-    if (saveTemp("Compiler"))
+
+    auto path = tmpPath();
+    if (path.isEmpty())
+        return;
+
+    if (language == "Python")
     {
-        if (language == "Python")
-        {
-            onCompilationFinished("");
-            return;
-        }
-        else if (language != "C++" && language != "Java")
-        {
-            log->warn("Compiler", "Please set the language");
-            return;
-        }
-        connect(compiler, SIGNAL(compilationStarted()), this, SLOT(onCompilationStarted()));
-        connect(compiler, SIGNAL(compilationFinished(const QString &)), this,
-                SLOT(onCompilationFinished(const QString &)));
-        connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
-                SLOT(onCompilationErrorOccurred(const QString &)));
-        connect(compiler, SIGNAL(compilationKilled()), this, SLOT(onCompilationKilled()));
-        compiler->start(tmpPath(), SettingsManager::get(QString("%1/Compile Command").arg(language)).toString(),
-                        language);
+        onCompilationFinished("");
+        return;
     }
+    else if (language != "C++" && language != "Java")
+    {
+        log->warn("Compiler", "Please set the language");
+        return;
+    }
+    connect(compiler, SIGNAL(compilationStarted()), this, SLOT(onCompilationStarted()));
+    connect(compiler, SIGNAL(compilationFinished(const QString &)), this, SLOT(onCompilationFinished(const QString &)));
+    connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
+            SLOT(onCompilationErrorOccurred(const QString &)));
+    connect(compiler, SIGNAL(compilationKilled()), this, SLOT(onCompilationKilled()));
+    compiler->start(path, SettingsManager::get(QString("%1/Compile Command").arg(language)).toString(), language);
 }
 
 void MainWindow::run()
@@ -232,7 +233,13 @@ void MainWindow::setCFToolUI()
 
             if (response == QMessageBox::Yes)
             {
-                if (saveTemp("CF Tool Saver"))
+                auto path = tmpPath();
+                if (path.isEmpty())
+                {
+                    QMessageBox::warning(this, "CF Tool",
+                                         "Failed to save the temp file, and the solution is not submitted.");
+                }
+                else
                 {
                     log->clear();
                     cftool->submit(tmpPath(), problemURL);
@@ -695,7 +702,6 @@ void MainWindow::setText(const QString &text, bool keep)
 void MainWindow::updateWatcher()
 {
     emit editorFileChanged();
-    emit editorTmpPathChanged(this);
     if (!fileWatcher->files().isEmpty())
         fileWatcher->removePaths(fileWatcher->files());
     if (!isUntitled())
@@ -835,7 +841,7 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
 
         beforeReturn(true);
     }
-    else if (!isUntitled() && (mode != IgnoreNonExist || QFile::exists(filePath)))
+    else if (!isUntitled() && QFile::exists(filePath))
     {
         if (!Util::saveFile(filePath, editor->toPlainText(), head, safe, log, true))
             return false;
@@ -851,64 +857,40 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
     return true;
 }
 
-MainWindow::SaveTempStatus MainWindow::saveTemp(const QString &head, SaveMode mode)
+QString MainWindow::tmpPath()
 {
-    LOG_INFO(INFO_OF(head));
-    if (!saveFile(mode, head, true))
+    bool created = false;
+    if (tmpDir == nullptr || !tmpDir->isValid())
     {
-        if (tmpDir != nullptr)
-        {
+        if (tmpDir)
             delete tmpDir;
-        }
-
         tmpDir = new QTemporaryDir();
         if (!tmpDir->isValid())
         {
-            log->error(head, "Failed to create temporary directory");
-            return Failed;
+            LOG_ERR("Failed to create the temporary directory");
+            log->error("Temp File", "Failed to create the temporary directory");
+            return QString();
         }
-
-        bool success = Util::saveFile(tmpPath(), editor->toPlainText(), head, true, log);
-
-        if (success)
-            emit editorTmpPathChanged(this);
-
-        return success ? TempSaved : Failed;
+        created = true;
     }
-
-    return NormalSaved;
-}
-
-QString MainWindow::tmpPath()
-{
-    if (!isUntitled() && !isTextChanged())
-        return filePath;
-    if (tmpDir == nullptr || !tmpDir->isValid())
-    {
-        switch (saveTemp("Temp Saver", IgnoreNonExist))
-        {
-        case Failed:
-            log->error("Temp Saver", "Error occurred when trying to save temp file");
-            return "";
-        case TempSaved:
-            break;
-        case NormalSaved:
-            return filePath;
-        }
-    }
-    QString name;
+    QString name = "sol.";
     if (language == "C++")
-        name = "sol.cpp";
+        name += Util::cppSuffix.first();
     else if (language == "Java")
-        name = "sol.java";
+        name += Util::javaSuffix.first();
     else if (language == "Python")
-        name = "sol.py";
+        name += Util::pythonSuffix.first();
     else
     {
-        log->error("Temp Saver", "Please set the language");
+        log->error("Temp File", "Please set the language");
         return "";
     }
-    return tmpDir->filePath(name);
+    QString path = tmpDir->filePath(name);
+    if (!Util::saveFile(path, editor->toPlainText(), "Temp File", false, log))
+        return QString();
+    if (created)
+        emit editorTmpPathChanged(this, path);
+    return path;
 }
 
 bool MainWindow::isTextChanged()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -120,6 +120,9 @@ void MainWindow::setupCore()
 
 void MainWindow::compile()
 {
+    if (SettingsHelper::isSaveFileOnCompilation())
+        saveFile(IgnoreUntitled, "Compiler", true);
+
     killProcesses();
 
     compiler = new Core::Compiler();
@@ -148,6 +151,9 @@ void MainWindow::compile()
 
 void MainWindow::run()
 {
+    if (SettingsHelper::isSaveFileOnExecution())
+        saveFile(IgnoreUntitled, "Runner", true);
+
     LOG_INFO("Requesting run of testcases");
     killProcesses();
     testcases->clearOutput();
@@ -1106,6 +1112,9 @@ void MainWindow::onCompilationFinished(const QString &warning)
     }
     else if (afterCompile == RunDetached)
     {
+        if (SettingsHelper::isSaveFileOnExecution())
+            saveFile(IgnoreUntitled, "Runner", true);
+
         killProcesses();
 
         if (!QStringList({"C++", "Java", "Python"}).contains(language))

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -569,15 +569,8 @@ void MainWindow::runOnly()
 {
     LOG_INFO("Requesting Run only");
     emit compileOrRunTriggered();
-    if (language == "Python")
-    {
-        compileAndRun();
-    }
-    else
-    {
-        log->clear();
-        run();
-    }
+    log->clear();
+    run();
 }
 
 void MainWindow::compileAndRun()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -750,12 +750,15 @@ void MainWindow::loadFile(const QString &loadPath)
     savedText = content;
     if (content.length() > SettingsHelper::getOpenFileLengthLimit())
     {
-        content = "Open File Length Limit Exceeded";
         log->error("Open File",
                    QString("The file [%1] contains more than %2 characters, so it's not opened. You can change the "
                            "open file length limit in Preferences->Advanced->Limits->Open File Length Limit")
                        .arg(path)
                        .arg(SettingsHelper::getOpenFileLengthLimit()));
+        setText("");
+        filePath.clear();
+        updateWatcher();
+        return;
     }
     setText(content, samePath);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -146,7 +146,8 @@ void MainWindow::compile()
     connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
             SLOT(onCompilationErrorOccurred(const QString &)));
     connect(compiler, SIGNAL(compilationKilled()), this, SLOT(onCompilationKilled()));
-    compiler->start(path, SettingsManager::get(QString("%1/Compile Command").arg(language)).toString(), language);
+    compiler->start(path, filePath, SettingsManager::get(QString("%1/Compile Command").arg(language)).toString(),
+                    language);
 }
 
 void MainWindow::run()
@@ -187,7 +188,7 @@ void MainWindow::run(int index)
     connect(tmp, SIGNAL(runOutputLimitExceeded(int, const QString &)), this,
             SLOT(onRunOutputLimitExceeded(int, const QString &)));
     connect(tmp, SIGNAL(runKilled(int)), this, SLOT(onRunKilled(int)));
-    tmp->run(tmpPath(), language, SettingsManager::get(QString("%1/Run Command").arg(language)).toString(),
+    tmp->run(tmpPath(), filePath, language, SettingsManager::get(QString("%1/Run Command").arg(language)).toString(),
              SettingsManager::get(QString("%1/Run Arguments").arg(language)).toString(), testcases->input(index),
              SettingsHelper::getTimeLimit());
     runner.push_back(tmp);
@@ -866,7 +867,7 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
 QString MainWindow::tmpPath()
 {
     bool created = false;
-    if (tmpDir == nullptr || !tmpDir->isValid())
+    if (tmpDir == nullptr || !tmpDir->isValid() || !QDir(tmpDir->path()).exists())
     {
         if (tmpDir)
             delete tmpDir;
@@ -1128,7 +1129,7 @@ void MainWindow::onCompilationFinished(const QString &warning)
         connect(detachedRunner, SIGNAL(failedToStartRun(int, const QString &)), this,
                 SLOT(onFailedToStartRun(int, const QString &)));
         connect(detachedRunner, SIGNAL(runKilled(int)), this, SLOT(onRunKilled(int)));
-        detachedRunner->runDetached(tmpPath(), language,
+        detachedRunner->runDetached(tmpPath(), filePath, language,
                                     SettingsManager::get(QString("%1/Run Command").arg(language)).toString(),
                                     SettingsManager::get(QString("%1/Run Arguments").arg(language)).toString());
     }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -154,7 +154,7 @@ class MainWindow : public QMainWindow
 
   signals:
     void editorFileChanged();
-    void editorTmpPathChanged(MainWindow *window);
+    void editorTmpPathChanged(MainWindow *window, const QString &path);
     void editorTextChanged(MainWindow *window);
     void confirmTriggered(MainWindow *widget);
     void requestToastMessage(const QString &head, const QString &body);
@@ -165,7 +165,6 @@ class MainWindow : public QMainWindow
     enum SaveMode
     {
         IgnoreUntitled, // save only when filePath is not empty
-        IgnoreNonExist, // don't save if the file doesn't exist, this implies IgnoreUntitled
         AlwaysSave,     // save to filePath if it's not empty, otherwise ask for new path
         SaveAs,         // ask for new path no matter filePath is empty or not
     };
@@ -174,13 +173,6 @@ class MainWindow : public QMainWindow
         Nothing,
         Run,
         RunDetached
-    };
-    enum SaveTempStatus
-    {
-        Failed, // There must be exactly one failed status and it must be the first one in the enum
-                // in order to cast to bool correctly.
-        TempSaved,
-        NormalSaved
     };
 
     Ui::MainWindow *ui;
@@ -223,8 +215,7 @@ class MainWindow : public QMainWindow
     void setText(const QString &text, bool keep = false);
     void updateWatcher();
     void loadFile(const QString &loadPath);
-    bool saveFile(SaveMode, const QString &head, bool safe);
-    SaveTempStatus saveTemp(const QString &head, SaveMode mode = IgnoreUntitled);
+    bool saveFile(SaveMode mode, const QString &head, bool safe);
     void performCompileAndRunDiagonistics();
     QString getRunnerHead(int index);
 };


### PR DESCRIPTION
## Description

### Added

- Now it's optional to save the file on compilation and execution or not.
- Now you can choose the path of the executable file of C++. (#271)

### Fixed

- Fixed some unexpected file saving. (#353)

### Changed

- Open an empty untitled tab when the open file length limit is exceeded. (#353)

## Related Issue

Close #271, fix #353.

## Motivation and Context

See #353.

## How Has This Been Tested?

On Manjaro KDE, tested on some basic usage.