### PR TITLE
feat: display git commit hash in `cpeditor --version`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   ENDIF(GIT_FOUND)
 ENDIF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
-configure_file(cmake/gitsha.hpp.in ${CMAKE_BINARY_DIR}/generated/gitsha.hpp)
 configure_file(cmake/version.hpp.in ${CMAKE_BINARY_DIR}/generated/version.hpp)
 configure_file(cmake/aur/PKGBUILD.in ${CMAKE_BINARY_DIR}/aur/PKGBUILD)
 configure_file(cmake/aur/.SRCINFO.in ${CMAKE_BINARY_DIR}/aur/.SRCINFO)
@@ -141,7 +140,6 @@ add_executable(cpeditor
     ui/mainwindow.ui
     ui/appwindow.ui
 
-    ${CMAKE_BINARY_DIR}/generated/gitsha.hpp
     ${CMAKE_BINARY_DIR}/generated/version.hpp
     ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp
     ${CMAKE_BINARY_DIR}/generated/SettingsInfo.hpp

--- a/cmake/gitsha.hpp.in
+++ b/cmake/gitsha.hpp.in
@@ -1,6 +1,0 @@
-#ifndef GITSHA_HPP
-#define GITSHA_HPP
-
-#define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
-
-#endif

--- a/cmake/version.hpp.in
+++ b/cmake/version.hpp.in
@@ -2,5 +2,6 @@
 #define VERSION_HPP
 
 #define APP_VERSION "@PROJECT_VERSION@"
+#define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
 
 #endif

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Now you can use Alt to choose the menu in the main window. (#344)
 - Now it's optional to save the file on compilation and execution or not.
 - Now you can choose the path of the executable file for C++ and the path of the parent directory of the class file for Java. (#271)
+- Now you can get the git commit hash when executing `cpeditor --version` in the terminal.
 
 ### Fixed
 

--- a/src/Core/EventLogger.cpp
+++ b/src/Core/EventLogger.cpp
@@ -24,7 +24,6 @@
 #include <QStandardPaths>
 #include <QSysInfo>
 #include <QUrl>
-#include <generated/gitsha.hpp>
 #include <generated/version.hpp>
 
 namespace Core

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -43,7 +43,6 @@
 #include <QUrl>
 #include <findreplacedialog.h>
 #include <generated/SettingsHelper.hpp>
-#include <generated/gitsha.hpp>
 #include <generated/version.hpp>
 
 #ifdef Q_OS_WIN

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 {
     SingleApplication app(argc, argv, true);
     SingleApplication::setApplicationName("CP Editor");
-    SingleApplication::setApplicationVersion(APP_VERSION);
+    SingleApplication::setApplicationVersion(APP_VERSION "+g" GIT_COMMIT_HASH);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QApplication::setWindowIcon(QIcon(":/icon.png"));
 


### PR DESCRIPTION
## Description

Display git commit hash in `cpeditor --version`, `gitsha.hpp` is also moved into `version.hpp`.

## Motivation and Context

Can get the commit hash without opening in GUI.

## How Has This Been Tested?

On Manjaro KDE.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/82147971-ee0a1f80-9883-11ea-90da-039b97318965.png)