### PR TITLE
build: Update AUR packages

### DIFF
--- a/.ci/aur/.SRCINFO
+++ b/.ci/aur/.SRCINFO
@@ -5,7 +5,6 @@ pkgbase = cpeditor-git
 	url = https://github.com/cpeditor/cpeditor
 	arch = x86_64
 	license = GPL3
-	makedepends = gcc
 	makedepends = cmake
 	makedepends = git
 	makedepends = python3

--- a/.ci/aur/PKGBUILD
+++ b/.ci/aur/PKGBUILD
@@ -9,7 +9,7 @@ arch=('x86_64')
 url='https://github.com/cpeditor/cpeditor'
 license=('GPL3')
 depends=('qt5-base')
-makedepends=("gcc" "cmake" "git" "python3")
+makedepends=("cmake" "git" "python3")
 conflicts=("cpeditor")
 
 source=('git://github.com/cpeditor/cpeditor.git'
@@ -41,7 +41,7 @@ prepare() {
 
 build() {
 	cd $_pkgname
-	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_CXX_COMPILER=g++
+	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr
 	cmake --build build -j$(nproc)
 }
 

--- a/.github/workflows/release_aur.yml
+++ b/.github/workflows/release_aur.yml
@@ -13,10 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check beta
-        id: check_beta
+      - name: Get the version
+        id: get_version
         run: |
           VERSION=${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=VERSION::$VERSION
           read STABLE_VERSION < .ci/STABLE_VERSION
           if [ "${VERSION:0:${#STABLE_VERSION}}" == "$STABLE_VERSION" ]; then
             echo ::set-output name=ISSTABLE::true
@@ -25,7 +26,7 @@ jobs:
           fi
 
       - name: Install SSH key
-        if: steps.check_beta.outputs.ISSTABLE == 'true'
+        if: steps.get_version.outputs.ISSTABLE == 'true'
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.SSH_KEY }}
@@ -33,7 +34,7 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOST }}
 
       - name: Install Qt
-        if: steps.check_beta.outputs.ISSTABLE == 'true'
+        if: steps.get_version.outputs.ISSTABLE == 'true'
         run: |
           sudo add-apt-repository ppa:beineri/opt-qt-5.12.8-xenial -y
           sudo apt-get update -qq
@@ -41,7 +42,7 @@ jobs:
           bash /opt/qt*/bin/qt*-env.sh
 
       - name: Generate AUR files
-        if: steps.check_beta.outputs.ISSTABLE == 'true'
+        if: steps.get_version.outputs.ISSTABLE == 'true'
         run: |
           mkdir build
           git submodule update --init
@@ -49,20 +50,24 @@ jobs:
           cmake ..
 
       - name: Fetch AUR Remote
-        if: steps.check_beta.outputs.ISSTABLE == 'true'
+        if: steps.get_version.outputs.ISSTABLE == 'true'
         run: |
           git clone ssh://aur@aur.archlinux.org/cpeditor.git
 
       - name: Update files
-        if: steps.check_beta.outputs.ISSTABLE == 'true'
+        if: steps.get_version.outputs.ISSTABLE == 'true'
         run: |
+          wget -c https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/cpeditor-${{ steps.get_version.outputs.VERSION }}-full-source.tar.gz
+          sha256sum=$(shasum -a 256 cpeditor-${{ steps.get_version.outputs.VERSION }}-full-source.tar.gz | cut -d ' ' -f 1)
           cd cpeditor
           rm PKGBUILD .SRCINFO
           mv ../build/aur/PKGBUILD .
           mv ../build/aur/.SRCINFO .
+          sed -i "s/SKIP/${sha256sum}/" PKGBUILD
+          sed -i "s/SKIP/${sha256sum}/" .SRCINFO
 
       - name: Publish to AUR
-        if: steps.check_beta.outputs.ISSTABLE == 'true'
+        if: steps.get_version.outputs.ISSTABLE == 'true'
         run: |
           cd cpeditor
           git config --global user.email "ashar786khan@gmail.com"

--- a/cmake/aur/.SRCINFO.in
+++ b/cmake/aur/.SRCINFO.in
@@ -7,7 +7,6 @@ pkgbase = cpeditor
 	license = GPL3
 	makedepends = cmake
 	makedepends = git
-	makedepends = gcc
 	makedepends = python3
 	depends = qt5-base
 	conflicts = cpeditor-git

--- a/cmake/aur/.SRCINFO.in
+++ b/cmake/aur/.SRCINFO.in
@@ -11,6 +11,6 @@ pkgbase = cpeditor
 	depends = qt5-base
 	conflicts = cpeditor-git
 	source = https://github.com/cpeditor/cpeditor/releases/download/@PROJECT_VERSION@/cpeditor-@PROJECT_VERSION@-full-source.tar.gz
-	md5sums = SKIP
+	sha256sums = SKIP
 
 pkgname = cpeditor

--- a/cmake/aur/PKGBUILD.in
+++ b/cmake/aur/PKGBUILD.in
@@ -9,14 +9,14 @@ arch=('x86_64')
 url='https://github.com/cpeditor/cpeditor'
 license=('GPL3')
 depends=('qt5-base')
-makedepends=("cmake" "git" "gcc" "python3")
+makedepends=("cmake" "git" "python3")
 conflicts=("cpeditor-git")
 source=("https://github.com/cpeditor/$pkgname/releases/download/$pkgver/cpeditor-$pkgver-full-source.tar.gz")
 md5sums=('SKIP')
 
 build() {
 	cd $_pkgdir
-	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_CXX_COMPILER=g++
+	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr
 	cmake --build build -j$(nproc)
 }
 

--- a/cmake/aur/PKGBUILD.in
+++ b/cmake/aur/PKGBUILD.in
@@ -12,7 +12,7 @@ depends=('qt5-base')
 makedepends=("cmake" "git" "python3")
 conflicts=("cpeditor-git")
 source=("https://github.com/cpeditor/$pkgname/releases/download/$pkgver/cpeditor-$pkgver-full-source.tar.gz")
-md5sums=('SKIP')
+sha256sums=('SKIP')
 
 build() {
 	cd $_pkgdir


### PR DESCRIPTION
According to https://wiki.archlinux.org/index.php/PKGBUILD#makedepends :

> The group [base-devel](https://www.archlinux.org/groups/x86_64/base-devel/) is assumed to be already installed when building with *makepkg*. Members of this group **should not** be included in `makedepends` array.

And remove the compiler setting makes it possible to use other compilers like clang or ccache.