### PR TITLE
build(aur): add optdepends and a script to generate .SRCINFO

### DIFF
--- a/.ci/aur/.SRCINFO
+++ b/.ci/aur/.SRCINFO
@@ -9,6 +9,12 @@ pkgbase = cpeditor-git
 	makedepends = git
 	makedepends = python3
 	depends = qt5-base
+	optdepends = cf-tool: submit to Codeforces support
+	optdepends = clang: C++ format and language server support
+	optdepends = jdk-openjdk: compile Java support
+	optdepends = jre-openjdk: execute Java support
+	optdepends = python: execute Python support
+	optdepends = xterm: detached run support
 	conflicts = cpeditor
 	source = git://github.com/cpeditor/cpeditor.git
 	source = git://github.com/cpeditor/QCodeEditor.git
@@ -24,3 +30,4 @@ pkgbase = cpeditor-git
 	md5sums = SKIP
 
 pkgname = cpeditor-git
+

--- a/.ci/aur/PKGBUILD
+++ b/.ci/aur/PKGBUILD
@@ -10,6 +10,14 @@ url='https://github.com/cpeditor/cpeditor'
 license=('GPL3')
 depends=('qt5-base')
 makedepends=("cmake" "git" "python3")
+optdepends=(
+	'cf-tool: submit to Codeforces support'
+	'clang: C++ format and language server support'
+	'jdk-openjdk: compile Java support'
+	'jre-openjdk: execute Java support'
+	'python: execute Python support'
+	'xterm: detached run support'
+)
 conflicts=("cpeditor")
 
 source=('git://github.com/cpeditor/cpeditor.git'

--- a/cmake/aur/.SRCINFO.in
+++ b/cmake/aur/.SRCINFO.in
@@ -9,8 +9,15 @@ pkgbase = cpeditor
 	makedepends = git
 	makedepends = python3
 	depends = qt5-base
+	optdepends = cf-tool: submit to Codeforces support
+	optdepends = clang: C++ format and language server support
+	optdepends = jdk-openjdk: compile Java support
+	optdepends = jre-openjdk: execute Java support
+	optdepends = python: execute Python support
+	optdepends = xterm: detached run support
 	conflicts = cpeditor-git
 	source = https://github.com/cpeditor/cpeditor/releases/download/@PROJECT_VERSION@/cpeditor-@PROJECT_VERSION@-full-source.tar.gz
 	sha256sums = SKIP
 
 pkgname = cpeditor
+

--- a/cmake/aur/PKGBUILD.in
+++ b/cmake/aur/PKGBUILD.in
@@ -10,6 +10,14 @@ url='https://github.com/cpeditor/cpeditor'
 license=('GPL3')
 depends=('qt5-base')
 makedepends=("cmake" "git" "python3")
+optdepends=(
+	'cf-tool: submit to Codeforces support'
+	'clang: C++ format and language server support'
+	'jdk-openjdk: compile Java support'
+	'jre-openjdk: execute Java support'
+	'python: execute Python support'
+	'xterm: detached run support'
+)
 conflicts=("cpeditor-git")
 source=("https://github.com/cpeditor/$pkgname/releases/download/$pkgver/cpeditor-$pkgver-full-source.tar.gz")
 sha256sums=('SKIP')

--- a/tools/genSRCINFO.sh
+++ b/tools/genSRCINFO.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd .ci/aur
+makepkg --printsrcinfo > .SRCINFO
+cd ../../cmake/aur
+cp PKGBUILD.in PKGBUILD
+makepkg --printsrcinfo > .SRCINFO.in
+rm PKGBUILD


### PR DESCRIPTION
I use the format

```
       (
    ...
    ...
)
```

because in this way the items are aligned and each change only affects one line.

[cf-tool](https://aur.archlinux.org/packages/cf-tool) is in AUR so I added it.