### PR TITLE
feat: add bind file and problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ add_executable(cpeditor
     src/Settings/AppearancePage.hpp
     src/Settings/CodeSnippetsPage.cpp
     src/Settings/CodeSnippetsPage.hpp
+    src/Settings/FileProblemBinder.cpp
+    src/Settings/FileProblemBinder.hpp
     src/Settings/FontItem.cpp
     src/Settings/FontItem.hpp
     src/Settings/PathItem.cpp

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Now you can choose the path of the executable file for C++ and the path of the parent directory of the class file for Java. (#271)
 - Now you can get the git commit hash when executing `cpeditor --version` in the terminal.
 - Now the application catches SIGINT, SIGTERM and SIGHUP on Linux/macOS and catches CTRL_C_EVENT, CTRL_BREAK_EVENT and CTRL_CLOSE_EVENT on Windows, it be will gracefully closed when receiving these signals. (#178 and #268) Warning: It's reported that on some environments it doesn't always work.
+- Now you can restore the problem URL when opening a file previously with a problem URL, and/or open the old file when parsing an old problem URL. (#199)
 
 ### Fixed
 

--- a/src/Settings/FileProblemBinder.cpp
+++ b/src/Settings/FileProblemBinder.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#include "Settings/FileProblemBinder.hpp"
+#include "Core/EventLogger.hpp"
+#include <QVariant>
+
+QMap<QString, QString> FileProblemBinder::fileForProblem;
+QMap<QString, QString> FileProblemBinder::problemForFile;
+
+void FileProblemBinder::set(const QString &file, const QString &problem)
+{
+    LOG_INFO(INFO_OF(file) << INFO_OF(problem));
+    if (problemForFile.contains(file))
+    {
+        fileForProblem.remove(problemForFile[file]);
+        problemForFile.remove(file);
+    }
+    if (fileForProblem.contains(problem))
+    {
+        problemForFile.remove(fileForProblem[problem]);
+        fileForProblem.remove(problem);
+    }
+    if (!file.isEmpty() && !problem.isEmpty())
+    {
+        problemForFile[file] = problem;
+        fileForProblem[problem] = file;
+    }
+}
+
+QString FileProblemBinder::getProblemForFile(const QString &file)
+{
+    return problemForFile[file];
+}
+
+QString FileProblemBinder::getFileForProblem(const QString &problem)
+{
+    return fileForProblem[problem];
+}
+
+bool FileProblemBinder::containsFile(const QString &file)
+{
+    return problemForFile.contains(file);
+}
+
+bool FileProblemBinder::containsProblem(const QString &problem)
+{
+    return fileForProblem.contains(problem);
+}
+
+QVariant FileProblemBinder::toVariant()
+{
+    QStringList res;
+    res.reserve(problemForFile.count() * 2);
+    for (auto it = problemForFile.constKeyValueBegin(); it != problemForFile.constKeyValueEnd(); ++it)
+    {
+        res.push_back((*it).first);
+        res.push_back((*it).second);
+    }
+    return res;
+}
+
+void FileProblemBinder::fromVariant(const QVariant &var)
+{
+    auto list = var.toStringList();
+    for (int i = 0; i + 1 < list.count(); i += 2)
+        set(list[i], list[i + 1]);
+}

--- a/src/Settings/FileProblemBinder.hpp
+++ b/src/Settings/FileProblemBinder.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+/**
+ * This class is used to bind the local file path with the problem URL.
+ */
+
+#ifndef FILEPROBLEMBINDER_HPP
+#define FILEPROBLEMBINDER_HPP
+
+#include <QMap>
+
+class QVariant;
+
+class FileProblemBinder
+{
+  public:
+    /**
+     * @brief add a pair of file and problem, remove the old binding of both of them
+     * @param file the path to the file
+     * @param problem the URL of the problem
+     * @note if either of *file* or *problem* is empty, the new binding won't be added, but the old binding (if exists)
+     * will be removed
+     */
+    static void set(const QString &file, const QString &problem);
+
+    /**
+     * @brief get the URL of the problem binded with the given file path
+     * @param file the path to the file; null if no problem is binded to the file
+     * @returns the URL of the problem
+     */
+    static QString getProblemForFile(const QString &file);
+
+    /**
+     * @brief get the path to the file binded with the given problem URL
+     * @param problem the URL of the problem
+     * @returns the path to the file; null if no file is binded to the problem
+     */
+    static QString getFileForProblem(const QString &problem);
+
+    /**
+     * @brief get if a file is binded to some problem
+     */
+    static bool containsFile(const QString &file);
+
+    /**
+     * @brief get if a problem is binded to some file
+     */
+    static bool containsProblem(const QString &problem);
+
+    /**
+     * @brief dump the binding to a QVariant
+     */
+    static QVariant toVariant();
+
+    /**
+     * @brief load the binding from a QVariant
+     * @param var the QVariant to load from
+     */
+    static void fromVariant(const QVariant &var);
+
+  private:
+    static QMap<QString, QString> fileForProblem;
+    static QMap<QString, QString> problemForFile;
+};
+
+#endif // FILEPROBLEMBINDER_HPP

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -125,6 +125,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
     addPage("Actions/Save", {"Auto Save", "Save Faster", "Auto Format", "Save File On Compilation",
                              "Save File On Execution", "Save Tests"});
 
+    addPage("Actions/Bind file and problem", {"Restore Old Problem Url", "Open Old File For Old Problem Url"});
+
     addPage("Extensions/Clang Format", {"Clang Format/Path", "Clang Format/Style"}, false);
 
     addPage("Extensions/Language Server/C++ Server",

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -17,6 +17,7 @@
 
 #include "Settings/SettingsManager.hpp"
 #include "Core/EventLogger.hpp"
+#include "Settings/FileProblemBinder.hpp"
 #include <QDebug>
 #include <QFile>
 #include <QFont>
@@ -103,6 +104,9 @@ void SettingsManager::init()
             set(QString("Editor Status/%1").arg(index), setting.value(index));
         setting.endGroup();
 
+        // load file problem binding
+        FileProblemBinder::fromVariant(setting.value("file_problem_binding"));
+
         // rename themes
         QString theme = get("Editor Theme")
                             .toString()
@@ -137,6 +141,9 @@ void SettingsManager::deinit()
         auto saveKey = key;
         setting.setValue(saveKey.replace("Editor Status/", "editor_status/"), get(key));
     }
+
+    // save file problem binding
+    setting.setValue("file_problem_binding", FileProblemBinder::toVariant());
 
     setting.sync();
     delete cur;

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -643,5 +643,17 @@
         "name": "Save File On Execution",
         "type": "bool",
         "tip": "Save the source file when running it. It won't be saved if the tab is untitled."
+    },
+    {
+        "name": "Restore Old Problem Url",
+        "desc": "Restore the problem URL when opening a file",
+        "type": "bool",
+        "tip": "If a file path was with a problem URL,\nwhen you open that path again,\nthe problem URL will be restored."
+    },
+    {
+        "name": "Open Old File For Old Problem Url",
+        "desc": "Open the old file when parsing an old problem URL",
+        "type": "bool",
+        "tip": "If a problem URL was set for a file path, when parsing that problem\nfrom competitive companion again, the old file will be opened."
     }
 ]

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -23,6 +23,7 @@
 #include "Extensions/CompanionServer.hpp"
 #include "Extensions/EditorTheme.hpp"
 #include "Extensions/LanguageServer.hpp"
+#include "Settings/FileProblemBinder.hpp"
 #include "Settings/PreferencesWindow.hpp"
 #include "Telemetry/UpdateNotifier.hpp"
 #include "Util/FileUtil.hpp"
@@ -1057,8 +1058,11 @@ void AppWindow::onIncomingCompanionRequest(const Extensions::CompanionData &data
         }
     }
 
-    if (SettingsHelper::isCompetitiveCompanionOpenNewTab() || currentWindow() == nullptr)
+    if (SettingsHelper::isOpenOldFileForOldProblemUrl() && FileProblemBinder::containsProblem(data.url))
+        openTab(FileProblemBinder::getFileForProblem(data.url));
+    else if (SettingsHelper::isCompetitiveCompanionOpenNewTab() || currentWindow() == nullptr)
         openTab("");
+
     currentWindow()->applyCompanion(data);
 }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -212,6 +212,7 @@ class MainWindow : public QMainWindow
     void loadTests();
     void saveTests(bool safe);
     void setCFToolUI();
+    void setFilePath(const QString &path);
     void setText(const QString &text, bool keep = false);
     void updateWatcher();
     void loadFile(const QString &loadPath);


### PR DESCRIPTION
## Description

Now you can restore the problem URL when opening a file previously with a problem URL, and/or open the old file when parsing an old problem URL.

## Related Issue

This closes #199.

## How Has This Been Tested?

On Manjaro KDE.

## Type of changes

- [x] New feature (changes which add functionality)