### PR TITLE
ci(aur): don't update AUR in forks

### DIFF
--- a/.github/workflows/push_aur.yml
+++ b/.github/workflows/push_aur.yml
@@ -14,6 +14,7 @@ jobs:
   aur:
     name: "Update AUR"
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'cpeditor'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Don't update AUR in forks.

## Motivation and Context

Now CI fails in forks because there's no SSH key of the AUR repo in forks.

## Type of changes

- [x] CI (changes to CI configuration files and scripts)