### PR TITLE
fix(QCodeEditor): scroll to show the cursor

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed some unexpected file saving. (#353)
 - Fix a bug which makes the application crash when quiting in some scenarios. (fa5259b)
 - Fix a bug which makes the saved test cases are not loaded correctly.
+- Fix the screen is not scrolled to show the cursor in some situations.
 
 ### Changed
 


### PR DESCRIPTION
## Description

Fix the screen is not scrolled to show the cursor in some situations.

## How Has This Been Tested?

On Manjaro KDE.

---

I think this is not very important so it's OK to only apply this to the master branch :thinking:.