### PR TITLE
build(aur): add quotes to variables and fix $_pkgdir

### DIFF
--- a/.ci/aur/PKGBUILD
+++ b/.ci/aur/PKGBUILD
@@ -30,30 +30,30 @@ source=('git://github.com/cpeditor/cpeditor.git'
 md5sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
 pkgver() {
-	cd $_pkgname
+	cd "$_pkgname"
 	git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {
-	cd $_pkgname
+	cd "$_pkgname"
 	git submodule init
 
-	git config submodule.third_party/QCodeEditor.url $srcdir/QCodeEditor
-	git config submodule.third_party/QtFindReplaceDialog.url $srcdir/QtFindReplaceDialog
-	git config submodule.third_party/lsp-cpp.url $srcdir/lsp-cpp
-	git config submodule.third_party/singleapplication.url $srcdir/singleapplication
-	git config submodule.third_party/testlib.url $srcdir/testlib
+	git config submodule.third_party/QCodeEditor.url "$srcdir/QCodeEditor"
+	git config submodule.third_party/QtFindReplaceDialog.url "$srcdir/QtFindReplaceDialog"
+	git config submodule.third_party/lsp-cpp.url "$srcdir/lsp-cpp"
+	git config submodule.third_party/singleapplication.url "$srcdir/singleapplication"
+	git config submodule.third_party/testlib.url "$srcdir/testlib"
 
 	git submodule update
 }
 
 build() {
-	cd $_pkgname
+	cd "$_pkgname"
 	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr
 	cmake --build build -j$(nproc)
 }
 
 package() {
-	cd $_pkgname/build
+	cd "$_pkgname/build"
 	make DESTDIR="$pkgdir" install
 }

--- a/cmake/aur/PKGBUILD.in
+++ b/cmake/aur/PKGBUILD.in
@@ -2,7 +2,7 @@
 
 pkgname=cpeditor
 pkgver=@PROJECT_VERSION@
-_pkgdir=cpeditor-full-source-$pkgver
+_pkgdir=cpeditor-$pkgver-full-source
 pkgrel=1
 pkgdesc='The editor for competitive programming'
 arch=('x86_64')
@@ -23,12 +23,12 @@ source=("https://github.com/cpeditor/$pkgname/releases/download/$pkgver/cpeditor
 sha256sums=('SKIP')
 
 build() {
-	cd $_pkgdir
+	cd "$_pkgdir"
 	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr
 	cmake --build build -j$(nproc)
 }
 
 package() {
-	cd $_pkgdir/build
+	cd "$_pkgdir/build"
 	make DESTDIR="$pkgdir" install
 }


### PR DESCRIPTION
## Description

1. Add quotes to variables.
2. Fix `_pkgdir` in the stable release PKGBUILD.