### PR TITLE
feat(MainWindow): add a button to clear the message logger

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Now you can set a initial position for the code template. (#352)
 - Use tab to jump out of a parenthesis. (#256)
 - Parentheses settings for each parenthesis in each language. (#206)
+- A button to clear the messages.
 
 ### Fixed
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -973,6 +973,11 @@ bool MainWindow::closeConfirm()
     return confirmed;
 }
 
+void MainWindow::on_clear_messages_button_clicked()
+{
+    log->clear();
+}
+
 void MainWindow::on_changeLanguageButton_clicked()
 {
     LOG_INFO("Window language change button requested");

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -135,6 +135,8 @@ class MainWindow : public QMainWindow
     void onRunOutputLimitExceeded(int index, const QString &type);
     void onRunKilled(int index);
 
+    void on_clear_messages_button_clicked();
+
     void on_changeLanguageButton_clicked();
 
     void onFileWatcherChanged(const QString &);

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -91,7 +91,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Messages and stderr</string>
+               <string>Messages</string>
               </property>
              </widget>
             </item>
@@ -107,6 +107,13 @@
                </size>
               </property>
              </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="clear_messages_button">
+              <property name="text">
+               <string>Clear</string>
+              </property>
+             </widget>
             </item>
             <item>
              <widget class="QPushButton" name="changeLanguageButton">


### PR DESCRIPTION
## Description

Added a button to clear the messages.

"Messages and stderr" is also changed to "Messages", otherwise, it
will be the bottleneck of the minimum width.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/83354598-49600580-a38c-11ea-8428-a2f90182fe9c.png)

## Type of changes

- [x] New feature (changes which add functionality)