### PR TITLE
refactor: improve apply competitive companion

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Changed
 
 - Open an empty untitled tab when the open file length limit is exceeded. (#353)
+- When parsing a problem while it is already parsed and opened in a tab, the new test cases will override the old test cases.
 
 ## v6.4
 

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -244,7 +244,7 @@ void TestCase::onDelButtonClicked()
     else
     {
         auto res = QMessageBox::question(this, "Delete Testcase",
-                                         "Do you want to delete test case #" + QString::number(id + 1));
+                                         "Do you really want to delete test case #" + QString::number(id + 1));
         if (res == QMessageBox::Yes)
             emit deleted(this);
     }

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -153,7 +153,7 @@ TestCases::TestCases(MessageLogger *logger, QWidget *parent) : QWidget(parent), 
 
     moreMenu->addAction("Remove All", [this] {
         LOG_INFO("Testcases removing all testcases");
-        auto res = QMessageBox::question(this, "Clear Testcases", "Do you want to delete all test cases?");
+        auto res = QMessageBox::question(this, "Clear Testcases", "Do you really want to delete all test cases?");
         if (res == QMessageBox::Yes)
         {
             for (int i = 0; i < count(); ++i)

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -28,6 +28,8 @@
 #include "Telemetry/UpdateChecker.hpp"
 #include "Util/FileUtil.hpp"
 #include "Util/Util.hpp"
+#include "generated/SettingsHelper.hpp"
+#include "generated/version.hpp"
 #include "mainwindow.hpp"
 #include <QClipboard>
 #include <QDesktopServices>
@@ -44,11 +46,8 @@
 #include <QTimer>
 #include <QUrl>
 #include <findreplacedialog.h>
-#include <generated/SettingsHelper.hpp>
-#include <generated/version.hpp>
 
 #ifdef Q_OS_WIN
-#include "Util/Util.hpp"
 #include <QSettings>
 #include <QStyleFactory>
 #endif
@@ -1052,14 +1051,25 @@ void AppWindow::onIncomingCompanionRequest(const Extensions::CompanionData &data
         if (windowAt(i)->getProblemURL() == data.url)
         {
             ui->tabWidget->setCurrentIndex(i);
+            currentWindow()->applyCompanion(data);
             return;
         }
     }
 
-    if (SettingsHelper::isOpenOldFileForOldProblemUrl() && FileProblemBinder::containsProblem(data.url))
-        openTab(FileProblemBinder::getFileForProblem(data.url));
-    else if (SettingsHelper::isCompetitiveCompanionOpenNewTab() || currentWindow() == nullptr)
-        openTab("");
+    do
+    {
+        if (SettingsHelper::isOpenOldFileForOldProblemUrl() && FileProblemBinder::containsProblem(data.url))
+        {
+            auto oldFile = FileProblemBinder::getFileForProblem(data.url);
+            if (QFileInfo(oldFile).isReadable())
+            {
+                openTab(oldFile);
+                break;
+            }
+        }
+        if (SettingsHelper::isCompetitiveCompanionOpenNewTab() || currentWindow() == nullptr)
+            openTab("");
+    } while (false);
 
     currentWindow()->applyCompanion(data);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -453,6 +453,7 @@ void MainWindow::loadStatus(const EditorStatus &status)
 void MainWindow::applyCompanion(const Extensions::CompanionData &data)
 {
     LOG_INFO("Requesting apply from companion");
+
     if (isUntitled() && !isTextChanged())
     {
         QString meta = data.toMetaString();
@@ -464,7 +465,13 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
         else
             meta.replace('\n', "\n// ");
 
-        editor->setPlainText(meta + "\n\n" + editor->toPlainText());
+        meta.append("\n\n");
+
+        auto cursor = editor->textCursor();
+        int cursorPos = cursor.position();
+        editor->setPlainText(meta + editor->toPlainText());
+        cursor.setPosition(cursorPos + meta.length());
+        editor->setTextCursor(cursor);
     }
 
     testcases->clear();


### PR DESCRIPTION
## Description

1. When parsing a problem while it is already parsed and opened in a tab, the new test cases will override the old test cases.
2. The file bound with a problem will be opened only when it's readable (which implies it exists).
3. Fix the bug that the cursor position is reset when applying competitive companion, which breaks the initial cursor position for the template.

## How Has This Been Tested?

On Arch Linux with KDE.