### PR TITLE
feat: abort saving all when cancelling one

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - Open an empty untitled tab when the open file length limit is exceeded. (#353)
 - When parsing a problem while it is already parsed and opened in a tab, the new test cases will override the old test cases.
+- If you click "Cancel" when saving all files, the action will be aborted instead of saving the next file.
 
 ## v6.4
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -711,7 +711,8 @@ void AppWindow::on_actionSave_All_triggered()
     for (int t = 0; t < ui->tabWidget->count(); ++t)
     {
         auto tmp = windowAt(t);
-        tmp->save(true, "Save All");
+        if (!tmp->save(true, "Save All"))
+            break;
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -538,10 +538,10 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
         updateChecker();
 }
 
-void MainWindow::save(bool force, const QString &head, bool safe)
+bool MainWindow::save(bool force, const QString &head, bool safe)
 {
     LOG_INFO("Save " << BOOL_INFO_OF(force) << INFO_OF(head) << BOOL_INFO_OF(safe));
-    saveFile(force ? AlwaysSave : IgnoreUntitled, head, safe);
+    return saveFile(force ? AlwaysSave : IgnoreUntitled, head, safe);
 }
 
 void MainWindow::saveAs()

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -90,7 +90,7 @@ class MainWindow : public QMainWindow
     EditorStatus toStatus() const;
     void loadStatus(const EditorStatus &status);
 
-    void save(bool force, const QString &head, bool safe = true);
+    bool save(bool force, const QString &head, bool safe = true);
     void saveAs();
 
     bool isTextChanged() const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If you click "Cancel" when saving all files, the action will be aborted instead of saving the next file.

## Motivation and Context

1 .If you are in a contest and you accidentally triggered Save All, you want to cancel it in one click.
2. If you do want to save all files, but found something incorrect (some files are saved to the wrong place, etc.) so you want to abort the whole action, fix that error, and then continue.

## How Has This Been Tested?

On Arch Linux with KDE.