### PR TITLE
feat(Settings): ask whether to override the snippet with the same name

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Parentheses settings for each parenthesis in each language. (#206)
 - A button to clear the messages.
 - Export and import settings. (#336)
+- Ask whether to override an existing snippet or not when there's a conflict in the snippet names. (#244)
 
 ### Fixed
 

--- a/src/Settings/CodeSnippetsPage.cpp
+++ b/src/Settings/CodeSnippetsPage.cpp
@@ -278,7 +278,7 @@ bool CodeSnippetsPage::aboutToSwitchToSnippet()
 
 void CodeSnippetsPage::addSnippet()
 {
-    auto name = getNewSnippetName();
+    auto name = getNewSnippetName(QString(), false, false);
     if (!name.isEmpty())
         addSnippet(name);
 }
@@ -378,7 +378,7 @@ void CodeSnippetsPage::extractSnippetsToFiles()
     }
 }
 
-QString CodeSnippetsPage::getNewSnippetName(const QString &oldName, bool avoidConflictWithSettings)
+QString CodeSnippetsPage::getNewSnippetName(const QString &oldName, bool avoidConflictWithSettings, bool askOverride)
 {
     QString name;
     bool firstTime = true;
@@ -395,7 +395,25 @@ QString CodeSnippetsPage::getNewSnippetName(const QString &oldName, bool avoidCo
         else if (name.isEmpty())
             head = "Snippet name can't be empty.\n";
         else
+        {
+            if (askOverride)
+            {
+                auto res =
+                    QMessageBox::question(this, "Snippet Name Conflict",
+                                          QString("The name \"%1\" is already in use. Do you want to override it? "
+                                                  "(The old snippet with this name will be deleted.)")
+                                              .arg(name),
+                                          QMessageBox::Yes | QMessageBox::No);
+                if (res == QMessageBox::Yes)
+                {
+                    auto item = snippetItem[name];
+                    if (item)
+                        deleteSnippet(item);
+                    return name;
+                }
+            }
             head = QString("The name \"%1\" is already in use.\n").arg(name);
+        }
         name = QInputDialog::getText(this, "Add Snippet", head + "New Snippet Name:", QLineEdit::Normal, name, &ok);
         if (!ok)
             return QString();

--- a/src/Settings/CodeSnippetsPage.hpp
+++ b/src/Settings/CodeSnippetsPage.hpp
@@ -99,9 +99,11 @@ class CodeSnippetsPage : public PreferencesPage
      * @brief get a non-empty unused snippet name
      * @param oldName the old name used for the first-time place holder
      * @param avoidConflictWithSettings avoid used names in the settings as well as in the UI
+     * @param askOverride when the name is conflicted, ask whether to override the old snippet or not
      * @returns the name if succeeded, null QString if failed
      */
-    QString getNewSnippetName(const QString &oldName = QString(), bool avoidConflictWithSettings = false);
+    QString getNewSnippetName(const QString &oldName = QString(), bool avoidConflictWithSettings = false,
+                              bool askOverride = true);
 
     /**
      * @brief add a new snippet without asking for confirmation


### PR DESCRIPTION
## Description

Ask whether to override an existing snippet or not when there's a conflict in the snippet names.

## Related Issue

This closes #244.

## Motivation and Context

As an instance, I may want to import snippets from files, and I want to override the old ones, instead of deleting the old ones and then import.

## How Has This Been Tested?

On Arch Linux with KDE.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/83942313-ec999a80-a824-11ea-8fc9-69aad373f8ea.png)

