### PR TITLE
build: Unhardcode icon file type for Linux launcher

### DIFF
--- a/.ci/linux/cpeditor.desktop
+++ b/.ci/linux/cpeditor.desktop
@@ -3,5 +3,5 @@ Type=Application
 Name=CP Editor
 Comment=The Editor for Competitive Programming
 Exec=cpeditor
-Icon=cpeditor-icon.png
+Icon=cpeditor-icon
 Categories=Development;

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -56,7 +56,6 @@ jobs:
           export VERSION=${{ steps.get_version.outputs.VERSION }}
           cp ../.ci/linux/cpeditor.desktop . && cp ../.ci/linux/cpeditor-icon.png .
           cp cpeditor.desktop default.desktop
-          mv cpeditor-icon.png cpeditor-icon.png.png
           ./linuxdeployqt*.AppImage ./cpeditor -appimage -qmake=/opt/qt514/bin/qmake
           mv CP_Editor-${{steps.get_version.outputs.VERSION }}-x86_64.AppImage cpeditor-${{ steps.get_version.outputs.VERSION }}-x86_64.AppImage
 


### PR DESCRIPTION
Since the icon already is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path or the file type extension in the launcher. 
The icon will be found anyway (without renaming anything).

Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.