### PR TITLE
feat: limit the lengths of files in "Add Pairs of Testcases From Files"

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Changed
+
+- Now the lengths of the files added by "Add Pairs of Testcases From Files" are limited by Preferences->Advanced->Limits->Load Test Case File Length Limit. (#405)
+
 ## v6.5
 
 ### Added

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -101,11 +101,14 @@ TestCases::TestCases(MessageLogger *logger, QWidget *parent) : QWidget(parent), 
                     remain.remove(inputFile);
                     remain.remove(answerFile);
                     auto answerPath = QFileInfo(path).dir().filePath(answerFile);
-                    auto input = Util::readFile(path, "Load Testcases", log, true);
-                    auto answer = Util::readFile(answerPath, "Load Testcases", log, true);
-                    addTestCase(input, answer);
-                    log->info("Load Testcases",
-                              QString("A pair of testcases [%1] and [%2] is loaded").arg(path).arg(answerPath));
+                    auto input = loadTestCaseFromFile(path, "Testcases");
+                    auto answer = loadTestCaseFromFile(answerPath, "Testcases");
+                    if (!input.isNull() && !answer.isNull())
+                    {
+                        addTestCase(input, answer);
+                        log->info("Load Testcases",
+                                  QString("A pair of testcases [%1] and [%2] is loaded").arg(path).arg(answerPath));
+                    }
                 }
             }
             // load single input
@@ -120,9 +123,12 @@ TestCases::TestCases(MessageLogger *logger, QWidget *parent) : QWidget(parent), 
                     if (!inputRegex.match(inputFile).hasMatch())
                         continue;
                     remain.remove(inputFile);
-                    auto input = Util::readFile(path, "Load Testcases", log, true);
-                    addTestCase(input, QString());
-                    log->info("Load Testcases", QString("An input [%1] is loaded").arg(path));
+                    auto input = loadTestCaseFromFile(path, "Testcases");
+                    if (!input.isNull())
+                    {
+                        addTestCase(input, QString());
+                        log->info("Load Testcases", QString("An input [%1] is loaded").arg(path));
+                    }
                 }
             }
             if (!remain.isEmpty())
@@ -339,7 +345,7 @@ void TestCases::saveToFiles(const QString &filePath, bool safe)
 
 QString TestCases::loadTestCaseFromFile(const QString &path, const QString &head)
 {
-    auto content = Util::readFile(path, QString("Load %1").arg(head), log);
+    auto content = Util::readFile(path, QString("Load %1").arg(head), log, true);
     if (content.length() > SettingsHelper::getLoadTestCaseFileLengthLimit())
     {
         log->error("Testcases",


### PR DESCRIPTION
## Description

Now the lengths of the files added by "Add Pairs of Testcases From Files" are limited by Preferences->Advanced->Limits->Load Test Case File Length Limit.

## How Has This Been Tested?

On Arch Linux with KDE.
