### PR TITLE
refactor: fewer logs

### DIFF
--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -197,7 +197,7 @@ bool SettingsManager::contains(const QString &key)
 
 void SettingsManager::set(const QString &key, QVariant value)
 {
-    LOG_INFO(INFO_OF(key) << INFO_OF(value.toString()));
+    LOG_INFO_IF(!key.startsWith("Snippets/"), INFO_OF(key) << INFO_OF(value.toString()));
     cur->insert(key, value);
 }
 

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -95,7 +95,6 @@ TestCase::TestCase(int index, MessageLogger *logger, QWidget *parent, const QStr
 
 void TestCase::setInput(const QString &text)
 {
-    LOG_INFO("Input value updated to\n" << text);
     inputEdit->modifyText(text);
 }
 
@@ -113,7 +112,6 @@ void TestCase::setOutput(const QString &text)
                        .arg(SettingsHelper::getOutputLengthLimit()));
     }
 
-    LOG_INFO("Output value updated to\n" << text);
     outputEdit->modifyText(newOutput);
     outputEdit->startAnimation();
 
@@ -123,7 +121,6 @@ void TestCase::setOutput(const QString &text)
 
 void TestCase::setExpected(const QString &text)
 {
-    LOG_INFO("Expected value updated to\n" << text);
     expectedEdit->modifyText(text);
 }
 


### PR DESCRIPTION
## Description

Don't log the content of test cases and snippets.

## Motivation and Context

They can make the log files extremely large.

## How Has This Been Tested?

On Arch Linux.