### PR TITLE
fix: Use /bin/bash instead

### DIFF
--- a/tools/newFile.sh
+++ b/tools/newFile.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if (($# != 1)); then
   echo 'newFile.sh <file name>

--- a/tools/newReleaseCycle.sh
+++ b/tools/newReleaseCycle.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if (($# != 8)); then
   echo 'newReleaseCycle.sh <stable major> <stable minor> <stable patch> <beta major> <beta minor> <beta patch> <new major> <new minor>'


### PR DESCRIPTION
Change /bin/sh to /bin/bash.

These two scripts use the feature provided by bash.
On some systems /bin/sh links to dash, which cannot run the script.