### PR TITLE
Default font set to consolas for windows os

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -20,6 +20,7 @@ With the portable version, you can easily store it in something like a USB disk,
 ### Changed
 
 - Now the lengths of the files added by "Add Pairs of Testcases From Files" are limited by Preferences->Advanced->Limits->Load Test Case File Length Limit. (#405)
+- Default font is set to consolas for windows operating system. (#422)
 
 ## v6.5
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@ With the portable version, you can easily store it in something like a USB disk,
 ### Fixed
 
 - Fix the wrong default setting for C++ executable file path.
+- Fix Font Size restores to small size after set to default or first launch.
 
 ### Changed
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -16,7 +16,10 @@
     {
         "name": "Editor Font",
         "type": "QFont",
-        "default": "QFont(\"monospace\")",
+        "default": {
+            "Windows": "QFont(\"Consolas\")",
+            "other": "QFont(\"monospace\")"
+        },
         "old": [
             "font"
         ],
@@ -700,7 +703,10 @@
     {
         "name": "Test Cases Font",
         "type": "QFont",
-        "default": "QFont(\"monospace\")",
+        "default": {
+            "Windows": "QFont(\"Consolas\")",
+            "other": "QFont(\"monospace\")"
+        },
         "tip": "The font of test cases"
     },
     {
@@ -712,7 +718,10 @@
     {
         "name": "Message Logger Font",
         "type": "QFont",
-        "default": "QFont(\"monospace\")",
+        "default": {
+            "Windows": "QFont(\"Consolas\")",
+            "other": "QFont(\"monospace\")"
+        },
         "tip": "The font of the message logger"
     },
     {

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -17,7 +17,7 @@
         "name": "Editor Font",
         "type": "QFont",
         "default": {
-            "Windows": "QFont(\"Consolas\")",
+            "Windows": "QFont(\"Consolas\", 12)",
             "other": "QFont(\"monospace\")"
         },
         "old": [

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -704,7 +704,7 @@
         "name": "Test Cases Font",
         "type": "QFont",
         "default": {
-            "Windows": "QFont(\"Consolas\")",
+            "Windows": "QFont(\"Consolas\", 12)",
             "other": "QFont(\"monospace\")"
         },
         "tip": "The font of test cases"

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -719,7 +719,7 @@
         "name": "Message Logger Font",
         "type": "QFont",
         "default": {
-            "Windows": "QFont(\"Consolas\")",
+            "Windows": "QFont(\"Consolas\", 12)",
             "other": "QFont(\"monospace\")"
         },
         "tip": "The font of the message logger"

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -150,12 +150,11 @@ void updateSettingInfo()
                 if isinstance(t["default"], bool):
                     setting_info.write(str(t["default"]).lower())
                 elif isinstance(t["default"], dict):
-                    if typename == "QFont":
-                        platform_name = platform.system()
-                        if t["default"].get(platform_name):
-                            setting_info.write(str(t["default"][platform_name]))
-                        else:
-                            setting_info.write(str(t["default"]["other"]))
+                    platform_name = platform.system()
+                    if t["default"].get(platform_name):
+                        setting_info.write(str(t["default"][platform_name]))
+                    else:
+                        setting_info.write(str(t["default"]["other"]))
                 else:
                     setting_info.write(str(t["default"]))
         else:

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -1,8 +1,10 @@
+
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import sys
 import json
+import platform
 
 if __name__ == "__main__":
     obj = json.load(open(sys.argv[1], mode="r", encoding="utf-8"))
@@ -147,6 +149,13 @@ void updateSettingInfo()
             else:
                 if isinstance(t["default"], bool):
                     setting_info.write(str(t["default"]).lower())
+                elif isinstance(t["default"], dict):
+                    if typename == "QFont":
+                        platform_name = platform.system()
+                        if t["default"].get(platform_name):
+                            setting_info.write(str(t["default"][platform_name]))
+                        else:
+                            setting_info.write(str(t["default"]["other"]))
                 else:
                     setting_info.write(str(t["default"]))
         else:


### PR DESCRIPTION
Default font in windows is by-default set to **monospace** which is incorrect. This PR fixes the default font to consolas

Issue: https://github.com/cpeditor/cpeditor/issues/422 https://github.com/cpeditor/cpeditor/issues/425