### PR TITLE
feat(Settings): set the default font to the system fixed-width font

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,7 +21,7 @@ With the portable version, you can easily store it in something like a USB disk,
 ### Changed
 
 - Now the lengths of the files added by "Add Pairs of Testcases From Files" are limited by Preferences->Advanced->Limits->Load Test Case File Length Limit. (#405)
-- Default font is set to fixed width font. (#422)
+- The default font is set to the system fixed-width font instead of the font named "Monospace". (#422)
 
 ## v6.5
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,7 +16,7 @@ With the portable version, you can easily store it in something like a USB disk,
 ### Fixed
 
 - Fix the wrong default setting for C++ executable file path.
-- Fix Font Size restores to small size after set to default or first launch.
+- Fix the displayed size of the default font is not the same as the actual size of the default font. (#425)
 
 ### Changed
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,10 +16,12 @@ With the portable version, you can easily store it in something like a USB disk,
 ### Fixed
 
 - Fix the wrong default setting for C++ executable file path.
+- Fix Font Size restores to small size after set to default or first launch.
 
 ### Changed
 
 - Now the lengths of the files added by "Add Pairs of Testcases From Files" are limited by Preferences->Advanced->Limits->Load Test Case File Length Limit. (#405)
+- Default font is set to fixed width font. (#422)
 
 ## v6.5
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -16,7 +16,7 @@
     {
         "name": "Editor Font",
         "type": "QFont",
-        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setPointSize(12); font.setStyleHint(QFont::TypeWriter); return font; }()",
+        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
         "old": [
             "font"
         ],
@@ -700,7 +700,7 @@
     {
         "name": "Test Cases Font",
         "type": "QFont",
-        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setPointSize(12); font.setStyleHint(QFont::TypeWriter); return font; }()",
+        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
         "tip": "The font of test cases"
     },
     {
@@ -712,7 +712,7 @@
     {
         "name": "Message Logger Font",
         "type": "QFont",
-        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setPointSize(12); font.setStyleHint(QFont::TypeWriter); return font; }()",
+        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
         "tip": "The font of the message logger"
     },
     {

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -16,7 +16,7 @@
     {
         "name": "Editor Font",
         "type": "QFont",
-        "default": "QFont(\"monospace\")",
+        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setPointSize(12); font.setStyleHint(QFont::TypeWriter); return font; }()",
         "old": [
             "font"
         ],
@@ -700,7 +700,7 @@
     {
         "name": "Test Cases Font",
         "type": "QFont",
-        "default": "QFont(\"monospace\")",
+        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setPointSize(12); font.setStyleHint(QFont::TypeWriter); return font; }()",
         "tip": "The font of test cases"
     },
     {
@@ -712,7 +712,7 @@
     {
         "name": "Message Logger Font",
         "type": "QFont",
-        "default": "QFont(\"monospace\")",
+        "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setPointSize(12); font.setStyleHint(QFont::TypeWriter); return font; }()",
         "tip": "The font of the message logger"
     },
     {

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -62,7 +62,7 @@ namespace SettingsHelper
 #define SETTINGSINFO_HPP
 
 #include <QCoreApplication>
-#include <QFont>
+#include <QFontDatabase>
 #include <QRect>
 #include <QVariant>
 #include "Core/StyleManager.hpp"


### PR DESCRIPTION
Default font in all operating system is by-default set to monospace font which is incorrect. This PR fixes the default font to fixed font.

Issue: #422  #425 