### PR TITLE
feat: Add option Check On Testcases With Empty Output

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,6 +12,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now you can use `${tempdir}` as an alternative of `${tmpdir}` in C++ executable file path setting and Java class file path setting.
 - Add the translation system and Simplified Chinese translation. (#377 and #384)
 - In-application UI style setting and built-in light/dark style. (#265 and #404)
+- Now testcases with empty outputs can also be checked. (#208 and #430)
 
 ### Fixed
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -208,7 +208,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .end()
         .page("Appearance", tr("Appearance"), new AppearancePage())
         .dir("Actions", tr("Actions"))
-            .page("General", tr("General"), {"Hot Exit/Enable", "Run On Empty Testcase"})
+            .page("General", tr("General"), {"Hot Exit/Enable", "Run On Empty Testcase", "Check On Empty Output"})
             .page("Save", tr("Save"), {"Auto Save", "Save Faster", "Auto Format", "Save File On Compilation",
                                "Save File On Execution", "Save Tests"})
             .page("Bind file and problem", tr("Bind file and problem"), {"Restore Old Problem Url", "Open Old File For Old Problem Url"})

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -208,7 +208,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .end()
         .page("Appearance", tr("Appearance"), new AppearancePage())
         .dir("Actions", tr("Actions"))
-            .page("General", tr("General"), {"Hot Exit/Enable", "Run On Empty Testcase", "Check On Empty Output"})
+            .page("General", tr("General"), {"Hot Exit/Enable", "Run On Empty Testcase", "Check On Testcases With Empty Output"})
             .page("Save", tr("Save"), {"Auto Save", "Save Faster", "Auto Format", "Save File On Compilation",
                                "Save File On Execution", "Save Tests"})
             .page("Bind file and problem", tr("Bind file and problem"), {"Restore Old Problem Url", "Open Old File For Old Problem Url"})

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -765,7 +765,7 @@
         "tip": "Run your code on all non-hidden test cases even if the input is empty."
     },
     {
-        "name": "Check On Empty Output",
+        "name": "Check On Testcases With Empty Output",
         "desc": "Check your answer on test cases with empty output",
         "type": "bool",
         "tip": "Check your answer on all non-hidden test cases even if the output is empty."

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -763,5 +763,11 @@
         "desc": "Run your codes on empty test cases",
         "type": "bool",
         "tip": "Run your code on all non-hidden test cases even if the input is empty."
+    },
+    {
+        "name": "Check On Empty Output",
+        "desc": "Check your answer on test cases with empty output",
+        "type": "bool",
+        "tip": "Check your answer on all non-hidden test cases even if the output is empty."
     }
 ]

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -768,6 +768,6 @@
         "name": "Check On Testcases With Empty Output",
         "desc": "Check your answer on test cases with empty output",
         "type": "bool",
-        "tip": "Check your answer on all non-hidden test cases even if the output is empty."
+        "tip": "Check your answer even if your output or the expected the output is empty."
     }
 ]

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1226,7 +1226,8 @@ void MainWindow::onRunFinished(int index, const QString &out, const QString &err
     if (!err.trimmed().isEmpty())
         log->error(head + tr("/stderr"), err);
     testcases->setOutput(index, out);
-    if ((!out.isEmpty() && !testcases->expected(index).isEmpty()) || (SettingsHelper::isCheckOnTestcasesWithEmptyOutput() && exitCode == 0))
+    if ((!out.isEmpty() && !testcases->expected(index).isEmpty()) ||
+        (SettingsHelper::isCheckOnTestcasesWithEmptyOutput() && exitCode == 0))
         checker->reqeustCheck(index, testcases->input(index), out, testcases->expected(index));
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1226,7 +1226,7 @@ void MainWindow::onRunFinished(int index, const QString &out, const QString &err
     if (!err.trimmed().isEmpty())
         log->error(head + tr("/stderr"), err);
     testcases->setOutput(index, out);
-    if ((!out.isEmpty() && !testcases->expected(index).isEmpty())||(SettingsHelper::isCheckOnEmptyOutput() && exitCode == 0))
+    if ((!out.isEmpty() && !testcases->expected(index).isEmpty())||(SettingsHelper::isCheckOnTestcasesWithEmptyOutput() && exitCode == 0))
         checker->reqeustCheck(index, testcases->input(index), out, testcases->expected(index));
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1226,7 +1226,7 @@ void MainWindow::onRunFinished(int index, const QString &out, const QString &err
     if (!err.trimmed().isEmpty())
         log->error(head + tr("/stderr"), err);
     testcases->setOutput(index, out);
-    if (!out.isEmpty() && !testcases->expected(index).isEmpty())
+    if ((!out.isEmpty() && !testcases->expected(index).isEmpty())||(SettingsHelper::isCheckOnEmptyOutput() && exitCode == 0))
         checker->reqeustCheck(index, testcases->input(index), out, testcases->expected(index));
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1226,7 +1226,7 @@ void MainWindow::onRunFinished(int index, const QString &out, const QString &err
     if (!err.trimmed().isEmpty())
         log->error(head + tr("/stderr"), err);
     testcases->setOutput(index, out);
-    if ((!out.isEmpty() && !testcases->expected(index).isEmpty())||(SettingsHelper::isCheckOnTestcasesWithEmptyOutput() && exitCode == 0))
+    if ((!out.isEmpty() && !testcases->expected(index).isEmpty()) || (SettingsHelper::isCheckOnTestcasesWithEmptyOutput() && exitCode == 0))
         checker->reqeustCheck(index, testcases->input(index), out, testcases->expected(index));
 }
 

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1105,27 +1105,22 @@ Do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1241"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1247"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>%1 has been killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Detached runner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Runner for testcase #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2091,6 +2086,14 @@ from Competitive Companion again, the old file will be opened.</source>
     </message>
     <message>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check your answer on test cases with empty output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check your answer even if your output or the expected the output is empty.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1440,27 +1440,27 @@ Do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1240"/>
+        <location filename="../src/mainwindow.cpp" line="1241"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1246"/>
+        <location filename="../src/mainwindow.cpp" line="1247"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1257"/>
+        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>%1 has been killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
+        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Detached runner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
+        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Runner for testcase #%1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2147,13 +2147,11 @@ from Competitive Companion again, the old file will be opened.</source>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>在所有未隐藏的测试点运行你的代码，即使输入为空。</translation>
     </message>
-	<message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+    <message>
         <source>Check your answer on test cases with empty output</source>
         <translation>在输出为空的测试点上检查输出的正确性</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>Check your answer even if your output or the expected the output is empty.</source>
         <translation>即使你的输出或答案的输出为空，依然检查输出的正确性。</translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1457,27 +1457,27 @@ Do you want to reload it?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1240"/>
+        <location filename="../src/mainwindow.cpp" line="1241"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1246"/>
+        <location filename="../src/mainwindow.cpp" line="1247"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation>在测试点 #%2 上运行的程序的 %1 包含多于 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在设置-&gt;高级-&gt;限制-&gt;输出限制中更改长度限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1257"/>
+        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>%1 has been killed</source>
         <translation>%1 已被终止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
+        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Detached runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
+        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Runner for testcase #%1</source>
         <translation>在测试点 #%1 上运行的程序</translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2160,7 +2160,7 @@ from Competitive Companion again, the old file will be opened.</source>
     <message>
         <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>Check your answer even if your output or the expected the output is empty.</source>
-        <translation>在所有测试点评测你的代码，即使输出为空。</translation>
+        <translation>即使你的输出或答案的输出为空，依然检查输出的正确性。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2774,6 +2774,16 @@ from Competitive Companion again, the old file will be opened.</source>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>在所有未隐藏的测试点运行你的代码，即使输入为空。</translation>
     </message>
+	<message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <source>Check your answer on test cases with empty output</source>
+        <translation>在标准输出为空的测试点上评测你的代码</translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <source>Check your answer even if your output or the expected the output is empty.</source>
+        <translation>在所有测试点评测你的代码，即使输出为空。</translation>
+    </message>
 </context>
 <context>
     <name>Settings::PathItem</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2155,7 +2155,7 @@ from Competitive Companion again, the old file will be opened.</source>
 	<message>
         <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>Check your answer on test cases with empty output</source>
-        <translation>在标准输出为空的测试点上评测你的代码</translation>
+        <translation>在输出为空的测试点上检查输出的正确性</translation>
     </message>
     <message>
         <location filename="../build/generated/SettingsInfo.cpp" line="131"/>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1122,27 +1122,22 @@ Do you want to reload it?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1241"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1247"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation>在测试点 #%2 上运行的程序的 %1 包含多于 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在设置-&gt;高级-&gt;限制-&gt;输出限制中更改长度限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>%1 has been killed</source>
         <translation>%1 已被终止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Detached runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1259"/>
         <source>Runner for testcase #%1</source>
         <translation>在测试点 #%1 上运行的程序</translation>
     </message>


### PR DESCRIPTION
Add an option to check answers on testcases with empty outputs.

## Description

## Related Issue
Fix #208.

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [x] Bug fix (changes which fix an issue)
- [ ] New feature (changes which add functionality)
- [ ] Documentation (changes which modify the documentation only)
- [ ] Style change (changes which do not affect the meaning of the code: code formatting, etc.)
- [ ] Refactor (changes which affect the meaning of the code but neither fix a bug nor add a feature)
- [ ] Performance improve (changes which improve performance)
- [ ] Test (changes which add tests)
- [ ] Build (Changes that affect the build system or external dependencies)
- [ ] CI (changes to CI configuration files and scripts)
- [ ] Chore (changes which do not belong to any type above)
- [ ] Revert (revert previous changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [ ] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [ ] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [ ] If there are changes of the text displayed in the UI, I have wrapped them in `tr()` or `QCoreApplication::translate()`.
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
