### PR TITLE
refactor(locale): remove locations in the translations

### DIFF
--- a/tools/updateTranslation.sh
+++ b/tools/updateTranslation.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [[ $1 == 'r' ]]; then
+	LOCATIONS=relative
+elif [[ $1 == 'a' ]]; then
+	LOCATIONS=absolute
+else
+	LOCATIONS=none
+fi
+
 declare -a SOURCES
 declare -a DIRS
 declare -a INCS
@@ -13,5 +21,5 @@ for i in "${DIRS[@]}"; do
 done
 
 for i in zh_CN ru_RU; do
-	lupdate -no-obsolete "${SOURCES[@]}" -ts translations/$i.ts -I src "${INCS[@]}"
+	lupdate -no-obsolete "${SOURCES[@]}" -locations "$LOCATIONS" -ts translations/$i.ts -I src "${INCS[@]}"
 done

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -4,642 +4,502 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="91"/>
         <source>Hot Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="92"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="102"/>
         <source>Restoring Last Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="279"/>
         <source>Show Main Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="433"/>
         <source>Opening Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="593"/>
         <source>https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL.md</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="599"/>
         <source>About CP Editor %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="600"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2020 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="652"/>
         <source>Open Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="660"/>
-        <location filename="../src/appwindow.cpp" line="665"/>
-        <location filename="../src/appwindow.cpp" line="673"/>
         <source>Open Contest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="665"/>
         <source>Number of problems in this contest:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="673"/>
         <source>Choose a language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="735"/>
         <source>Reset preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="736"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="960"/>
         <source>Auto Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1188"/>
-        <location filename="../src/appwindow.cpp" line="1206"/>
         <source>Snippets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1189"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1194"/>
         <source>Use Snippets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1194"/>
         <source>Choose a snippet:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1206"/>
         <source>There is no snippet named %1 for %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1330"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1332"/>
         <source>Close Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1338"/>
         <source>Close to the Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1344"/>
         <source>Close to the Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1360"/>
         <source>Copy File Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1363"/>
         <source>Reveal in Finder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1376"/>
         <source>Reveal in Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1421"/>
-        <location filename="../src/appwindow.cpp" line="1436"/>
-        <location filename="../src/appwindow.cpp" line="1441"/>
-        <location filename="../src/appwindow.cpp" line="1455"/>
         <source>Open Containing Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1427"/>
         <source>Reveal in File Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1451"/>
         <source>Copy path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1462"/>
         <source>Open problem in browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1464"/>
         <source>Copy Problem URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1467"/>
         <source>Set Codeforces URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1471"/>
-        <location filename="../src/appwindow.cpp" line="1474"/>
         <source>Set CF URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1471"/>
         <source>Enter the contest ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1474"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1482"/>
-        <location filename="../src/appwindow.cpp" line="1484"/>
         <source>Set Problem URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1484"/>
         <source>Enter the new problem URL:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1560"/>
         <source>EventLogger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>All logs except for current session has been deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="829"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="266"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="272"/>
         <source>Ctrl+N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="687"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="274"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="279"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="281"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="283"/>
         <source>Save as new file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="286"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="701"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="288"/>
         <source>Save All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="290"/>
         <source>Save all opened files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="293"/>
         <source>Ctrl+Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="295"/>
         <source>Close Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="297"/>
         <source>Close current tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="300"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1349"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="302"/>
         <source>Close Saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="304"/>
         <source>Close saved tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="307"/>
         <source>Ctrl+Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1351"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="309"/>
         <source>Close All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="311"/>
         <source>Close All the tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="314"/>
         <source>Ctrl+Shift+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="281"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="316"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="318"/>
         <source>Quit the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="321"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="323"/>
         <source>Open File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="325"/>
         <source>Open files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="328"/>
         <source>Ctrl+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="330"/>
         <source>Open Contest...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="332"/>
         <source>Open a Contest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="335"/>
         <source>Ctrl+Shift+O</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="337"/>
         <source>Indent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="339"/>
         <source>Ctrl+]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="341"/>
         <source>Unindent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="343"/>
         <source>Ctrl+[</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="345"/>
         <source>Swap Line Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="347"/>
         <source>Ctrl+Shift+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="349"/>
         <source>Swap Line Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="351"/>
         <source>Ctrl+Shift+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="353"/>
         <source>Duplicate Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="355"/>
         <source>Ctrl+Shift+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="357"/>
         <source>Delete Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="359"/>
         <source>Ctrl+Shift+K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="361"/>
         <source>Toggle Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="363"/>
         <source>Ctrl+/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="365"/>
         <source>Toggle Block Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="367"/>
         <source>Ctrl+Shift+/</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="369"/>
         <source>Compile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="371"/>
         <source>Ctrl+Shift+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="373"/>
         <source>Compile and Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="375"/>
         <source>Ctrl+Shift+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="377"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="379"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="381"/>
         <source>Format code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="383"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="385"/>
         <source>Run Detached</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="387"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="389"/>
         <source>Kill Processes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="391"/>
         <source>Ctrl+K</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="393"/>
         <source>Find and Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="401"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="410"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="411"/>
         <source>Build Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="412"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="395"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="267"/>
         <source>New File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="269"/>
         <source>Open a new tab in the editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="276"/>
         <source>Save the file on the disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="397"/>
         <source>Use Snippet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="399"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="406"/>
         <source>Export Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="407"/>
         <source>Import Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="403"/>
         <source>Ctrl+P</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="405"/>
         <source>Reset Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="408"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="280"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="409"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="413"/>
         <source>Support me</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="414"/>
         <source>Editor Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="415"/>
         <source>IO Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="416"/>
         <source>Split Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="417"/>
         <source>Show Log Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="418"/>
         <source>Delete Log Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="419"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="420"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="421"/>
         <source>&amp;Actions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="422"/>
         <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="423"/>
         <source>&amp;Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="424"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -647,12 +507,10 @@
 <context>
     <name>AppearancePage</name>
     <message>
-        <location filename="../src/Settings/AppearancePage.cpp" line="42"/>
         <source>Change Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/AppearancePage.cpp" line="43"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -660,121 +518,96 @@
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>Unsaved Snippets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="257"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Delete Snippet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="289"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -782,73 +615,51 @@
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="103"/>
         <source>Read Checker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="111"/>
-        <location filename="../src/Core/Checker.cpp" line="117"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="288"/>
-        <location filename="../src/Core/Checker.cpp" line="289"/>
-        <location filename="../src/Core/Checker.cpp" line="290"/>
         <source>Checker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="111"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="121"/>
         <source>Read testlib.h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="124"/>
         <source>Save testlib.h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="174"/>
-        <location filename="../src/Core/Checker.cpp" line="181"/>
-        <location filename="../src/Core/Checker.cpp" line="189"/>
-        <location filename="../src/Core/Checker.cpp" line="197"/>
-        <location filename="../src/Core/Checker.cpp" line="202"/>
-        <location filename="../src/Core/Checker.cpp" line="207"/>
         <source>Checker[%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="181"/>
         <source>Checker exited with exit code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="189"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="202"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="208"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="218"/>
         <source>Killed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -856,17 +667,14 @@
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="57"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="73"/>
         <source>The compile command for %1 is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="89"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -874,22 +682,18 @@
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="65"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="73"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="101"/>
         <source>Failed to start running. Please compile first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="124"/>
         <source>Please install xterm in order to use Detached Run.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -897,63 +701,42 @@
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="155"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="162"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="176"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="180"/>
         <source>CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="175"/>
         <source>CF Tool failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="176"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="185"/>
         <source>Contest %1 Problem %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,48 +744,34 @@
 <context>
     <name>Extensions::ClangFormatter</name>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="51"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="55"/>
         <source>Formatter/check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="123"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="128"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="132"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="171"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="187"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="198"/>
         <source>Formatter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="123"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="171"/>
         <source>Formatting completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="188"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format in Preferences-&gt;Extensions-&gt;Clang Format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="198"/>
         <source>The format command is: %1 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="201"/>
         <source>Formatter[stdout]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="204"/>
         <source>Formatter[stderr]</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1010,42 +779,30 @@
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="51"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="62"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="65"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="76"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="98"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="140"/>
         <source>Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="51"/>
         <source>Server is closed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="62"/>
         <source>Port is set to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="66"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="76"/>
         <source>Stopped Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="98"/>
         <source>Got a POST Request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="140"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation type="unfinished"></translation>
@@ -1054,42 +811,30 @@
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="277"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="290"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="300"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="303"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="306"/>
         <source>Langauge Server [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="278"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="291"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program in Preferences-&gt;Extensions-&gt;Language Server?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
         <source>LSP Process timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="300"/>
         <source>LSP Process Read Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="303"/>
         <source>LSP Process Write Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="306"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,7 +842,6 @@
 <context>
     <name>FindReplaceDialog</name>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplacedialog.h" line="46"/>
         <source>Find/Replace</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1105,57 +849,46 @@
 <context>
     <name>FindReplaceForm</name>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="188"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="189"/>
         <source>Find:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="190"/>
         <source>Replace with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="191"/>
         <source>errorLabel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="192"/>
         <source>Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="193"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="194"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="195"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="196"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="197"/>
         <source>Whole words only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="199"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1167,22 +900,18 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="209"/>
         <source>Regular Expression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="210"/>
         <source>Find</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="211"/>
         <source>Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="212"/>
         <source>Replace All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1190,57 +919,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="125"/>
-        <location filename="../src/mainwindow.cpp" line="142"/>
-        <location filename="../src/mainwindow.cpp" line="1129"/>
-        <location filename="../src/mainwindow.cpp" line="1141"/>
-        <location filename="../src/mainwindow.cpp" line="1148"/>
-        <location filename="../src/mainwindow.cpp" line="1185"/>
-        <location filename="../src/mainwindow.cpp" line="1192"/>
         <source>Compiler</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="142"/>
-        <location filename="../src/mainwindow.cpp" line="932"/>
         <source>Please set the language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="157"/>
-        <location filename="../src/mainwindow.cpp" line="165"/>
-        <location filename="../src/mainwindow.cpp" line="179"/>
-        <location filename="../src/mainwindow.cpp" line="208"/>
-        <location filename="../src/mainwindow.cpp" line="1133"/>
-        <location filename="../src/mainwindow.cpp" line="1162"/>
-        <location filename="../src/mainwindow.cpp" line="1168"/>
         <source>Runner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="165"/>
-        <location filename="../src/mainwindow.cpp" line="208"/>
-        <location filename="../src/mainwindow.cpp" line="1168"/>
         <source>Wrong language, please set the language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="179"/>
         <source>All inputs are empty, nothing to run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="231"/>
         <source>Submit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="239"/>
         <source>Sure to submit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="240"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1248,106 +954,82 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="249"/>
-        <location filename="../src/mainwindow.cpp" line="263"/>
         <source>CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="250"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="264"/>
         <source>You will not be able to submit code to Codeforces because CF Tool is not installed or is not on SYSTEM PATH. You can set it manually in settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="280"/>
         <source>Untitled-%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="552"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="613"/>
         <source>Open %1 Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="755"/>
-        <location filename="../src/mainwindow.cpp" line="763"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="764"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Open File Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="868"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="918"/>
-        <location filename="../src/mainwindow.cpp" line="932"/>
-        <location filename="../src/mainwindow.cpp" line="936"/>
         <source>Temp File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="918"/>
         <source>Failed to create the temporary directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="948"/>
         <source>Read %1 Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="973"/>
         <source>Save changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="974"/>
         <source>Save changes to [%1] before closing?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="974"/>
         <source>New File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="977"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1003"/>
         <source>Set Tab language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1003"/>
         <source>Set the language to use in this Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1040"/>
         <source>Reload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1040"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1355,152 +1037,122 @@ Do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1075"/>
         <source>Line %1, Column %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1087"/>
         <source>%1 lines, %2 charachters selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1089"/>
         <source>%1 characters selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1130"/>
         <source>The compile command for %1 is invalid. Is the compiler in the system PATH?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1134"/>
         <source>The run command for %1 is invalid. Is the runner in the system Path?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1141"/>
         <source>Compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1148"/>
         <source>Compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1151"/>
         <source>Compile Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1185"/>
         <source>Error occurred while compiling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1187"/>
         <source>Compile Errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1192"/>
         <source>Compilation is killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1200"/>
         <source>Detached Runner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1201"/>
         <source>Runner[%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1206"/>
         <source>Execution has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1215"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1220"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1227"/>
         <source>/stderr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1240"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1246"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1257"/>
         <source>%1 has been killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>Detached runner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>Runner for testcase #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="188"/>
         <source>CP Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="189"/>
         <source>cursor info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="190"/>
         <source>Compile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="191"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="192"/>
         <source>Compile and Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="193"/>
         <source>Messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="194"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="195"/>
         <source>C++</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1508,7 +1160,6 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="43"/>
         <source>
 ... The message is too long</source>
         <translation type="unfinished"></translation>
@@ -1517,42 +1168,34 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="108"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="113"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="135"/>
         <source>No Parenthesis Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="171"/>
         <source>New Parenthesis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="171"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="184"/>
         <source>Delete Parenthesis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1560,28 +1203,23 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1589,37 +1227,30 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="44"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="52"/>
         <source>Code Editor Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="53"/>
         <source>C++ Compile and Run Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="54"/>
         <source>Java Compile and Run Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="55"/>
         <source>Python Run Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="56"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>You can read the &lt;a href=&quot;https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL.md&quot;&gt;Manual&lt;/a&gt; or go through the settings for more information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1627,42 +1258,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="39"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="41"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="43"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="58"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="81"/>
         <source>Unsaved Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="81"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1670,183 +1293,126 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="106"/>
         <source>Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="122"/>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="126"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="128"/>
         <source>Go to the home page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="167"/>
         <source>Code Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="170"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="171"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="172"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="173"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="175"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="178"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="180"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="219"/>
         <source>C++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="184"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="185"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="187"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="190"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="192"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="220"/>
         <source>Java</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="196"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>Python</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="210"/>
         <source>Actions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="212"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
         <source>Bind file and problem</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
         <source>Extensions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="217"/>
         <source>Clang Format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="218"/>
         <source>Language Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="173"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="185"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
         <source>%1 Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="175"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="187"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
         <source>%1 Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="178"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="190"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
         <source>%1 Snippets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="180"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="192"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
         <source>%1 Parentheses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="219"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="220"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>Competitive Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="225"/>
         <source>CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="227"/>
         <source>File Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="229"/>
         <source>Problem URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="231"/>
         <source>Key Bindings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="233"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="234"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="235"/>
         <source>Limits</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1854,139 +1420,106 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>Setting</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="29"/>
         <source>Tab Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="29"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="30"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="31"/>
         <source>Editor Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="31"/>
         <source>The font of the code editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="32"/>
         <source>Default Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="32"/>
         <source>The default language used when opening new tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="33"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="33"/>
         <source>The path to the Clang Format executable file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="34"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="34"/>
         <source>The Clang Format style options, which are often saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="35"/>
         <source>The template used when creating a new C++ file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="36"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="37"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The template used when creating a new Java file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Run Command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>%1 Class Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>%1 Class Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -1995,82 +1528,66 @@ You can use &quot;${filename}&quot; for the complete file name,
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new Python file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
         <source>Editor Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>Auto Complete Parentheses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>Auto Remove Parentheses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>Auto Indent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>Enable Auto Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>Automatically save the file every 3 seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>Wrap Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
         <source>Use the beta version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Save the status of the editor when the application exits and
 load the status of the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save
@@ -2078,59 +1595,41 @@ the unsaved files or not when exiting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="35"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>%1 Template Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="36"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="37"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>%1 Compile Command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
         <source>%1 Executable File Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2140,424 +1639,326 @@ You can use &quot;${filename}&quot; for the complete file name,
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>%1 Run Arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>%1 Parentheses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The name of the non-public main class of your solution.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
         <source>Use spaces instead of a tab character.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
         <source>Replace tabs by spaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
         <source>Save Testcases on Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
         <source>Save the testcases on the disk when saving a file, and load the saved testcases when opening a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
         <source>Maximized Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>Check for updates on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>Format Codes on Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>Use Clang Format to format the codes when saving it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>The opacity of the main window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>View Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>Splitter Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>Right Splitter Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
         <source>Enable Competitive Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
         <source>Receive data sent by Competitive Companion and load the example testcases.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Connection Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Open New Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Format Codes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Kill All Processes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Compile and Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Run Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Compile Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Change View Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Use Snippets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Enable Hot Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Hot Exit Tab Count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Hot Exit Current Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Force Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>The path to the CF Tool executable file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Save Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Show Compile And Run Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
         <source>Display EOLN In Diff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Save Files Faster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Time Limit (ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
         <source>Output Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
         <source>Message Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Open File Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Load Test Case File Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The maximum number of characters in a testcase file to load.
 A testcase file won&apos;t be loaded if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Path to LSP executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>The path to the C++ Language Server executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>The path to the Java Language Server executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The path to the Python Language Server executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Use Linting with Language Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Langauge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Langauge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Langauge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Use auto complete with Language Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Use autocomplete results from Language server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Delay in Linting (ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Delay in linting in miliseconds after last modification to code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Arguments for Language Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Arguments to pass to Language server executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Testcases Matching Rules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Input Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Answer Replace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>Input File Save Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2567,12 +1968,10 @@ You can use &quot;${filename}&quot; for the complete file name,
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Answer File Save Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2582,136 +1981,110 @@ You can use &quot;${filename}&quot; for the complete file name,
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Default File Paths For Problem URLs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Problem URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>File Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Test Cases Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>The font of test cases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Message Logger Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>The font of the message logger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Save File On Compilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Save File On Execution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Restore the problem URL when opening a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>UI Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The language displayed in the UI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>UI Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The style of the whole application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Run your codes on empty test cases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2719,17 +2092,14 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Settings::PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="34"/>
         <source>Excutable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="50"/>
         <source>Choose Excutable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="54"/>
         <source>Choose %1 Sources</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2737,7 +2107,6 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2745,52 +2114,42 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2798,12 +2157,10 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="135"/>
         <source>No release is found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="146"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2811,29 +2168,22 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="50"/>
         <source>%1Source Files (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="67"/>
-        <location filename="../src/Util/FileUtil.cpp" line="90"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="77"/>
-        <location filename="../src/Util/FileUtil.cpp" line="99"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="118"/>
         <source>The file [%1] does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="128"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2841,17 +2191,14 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="50"/>
         <source>Expected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2859,87 +2206,70 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="47"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="48"/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="49"/>
         <source>Expected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="50"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="52"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="86"/>
         <source>Test on a single testcase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="87"/>
         <source>Open the Diff Viewer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="107"/>
         <source>Output Length Limit Exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="108"/>
         <source>Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="109"/>
         <source>The output #%1 contains more than %2 characters, so it&apos;s not displayed. You can set the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="154"/>
         <source>Input #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="155"/>
         <source>Output #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="156"/>
         <source>Expected #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="243"/>
         <source>Delete Testcase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="244"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="252"/>
         <source>Diff Viewer[%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="253"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;HTML Diff Viewer Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2947,28 +2277,22 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="101"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="103"/>
         <source>Load From File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="107"/>
         <source>Edit in Bigger Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="110"/>
         <source>Edit Testcase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="125"/>
         <source>Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="126"/>
         <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2976,198 +2300,154 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="45"/>
         <source>Test Cases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="47"/>
         <source>Checker:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Add Test</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="49"/>
         <source>More</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="458"/>
         <source>Add Checker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="69"/>
         <source>Wrong Answer / Accepted / Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="70"/>
         <source>Add a custom testlib checker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="76"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="77"/>
         <source>Choose Testcase Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="139"/>
         <source>Load Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="110"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>An input [%1] is loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="140"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at Preferences-&gt;File Path-&gt;Testcases-&gt;Add Testcases From Files Rules.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="147"/>
         <source>Remove Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="159"/>
         <source>Remove All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="162"/>
         <source>Clear Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="162"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="173"/>
         <source>Hide AC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
         <source>Show All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="186"/>
         <source>Hide All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="192"/>
         <source>Invert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
         <source>Ignore trailing spaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
         <source>Strictly the same</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
         <source>ncmp - Compare int64s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="206"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="207"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>wcmp - Compare tokens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="237"/>
         <source>Add Test Case</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="315"/>
         <source>Input #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="316"/>
         <source>Expected #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="331"/>
         <source>Save Input #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="333"/>
         <source>Save Expected #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="349"/>
         <source>Load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="104"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="105"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="126"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="352"/>
         <source>Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="353"/>
         <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3175,32 +2455,26 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3208,37 +2482,30 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="36"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="37"/>
         <source>Close this dialog and abort the update check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="45"/>
         <source>Update Checker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="55"/>
         <source>Fetching the list of releases...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="63"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.github.io/download&quot;&gt;https://cpeditor.github.io/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="73"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="74"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -4,642 +4,502 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="91"/>
         <source>Hot Exit</source>
         <translation>热退出</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="92"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>在最后一次会话中，CP Editor 被意外关闭，你希望从最后一次会话中恢复吗？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="102"/>
         <source>Restoring Last Session</source>
         <translation>恢复最后一次会话</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="279"/>
         <source>Show Main Window</source>
         <translation>显示主窗口</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="433"/>
         <source>Opening Files</source>
         <translation>打开文件中</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="593"/>
         <source>https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL.md</source>
         <translation>https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL_zh-CN.md</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="599"/>
         <source>About CP Editor %1</source>
         <translation>关于 CP Editor %1</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="600"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2020 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; 是一个基于 Qt 的原生态 IDE。它专为算法竞赛设计，不像其它 IDE 主要是为了开发设计。它可以帮助你自动化编译、运行、测试，从而让你专注于算法设计。它甚至可以从各种算法竞赛网站上获取样例，将代码提交到 Codeforces 上！&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2020 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;本程序是自由软件；请参看源代码的版权声明。本软件没有任何担保；包括没有适销性和某一专用目的下的适用性担保。CP Editor 的代码可以在 &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt; 获取。&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="652"/>
         <source>Open Files</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="660"/>
-        <location filename="../src/appwindow.cpp" line="665"/>
-        <location filename="../src/appwindow.cpp" line="673"/>
         <source>Open Contest</source>
         <translation>打开比赛</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="665"/>
         <source>Number of problems in this contest:</source>
         <translation>比赛题目数量：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="673"/>
         <source>Choose a language</source>
         <translation>选择语言</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="735"/>
         <source>Reset preferences</source>
         <translation>重置设置</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="736"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>你确定要重置所有设置吗？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="960"/>
         <source>Auto Save</source>
         <translation>自动保存</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1188"/>
-        <location filename="../src/appwindow.cpp" line="1206"/>
         <source>Snippets</source>
         <translation>代码片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1189"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>语言 %1 没有任何代码片段。请在设置窗口中添加。</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1194"/>
         <source>Use Snippets</source>
         <translation>使用代码片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1194"/>
         <source>Choose a snippet:</source>
         <translation>选择一个代码片段：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1206"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>语言 %2 没有叫做 %1 的代码片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1330"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1332"/>
         <source>Close Others</source>
         <translation>关闭其它标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1338"/>
         <source>Close to the Left</source>
         <translation>关闭左侧标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1344"/>
         <source>Close to the Right</source>
         <translation>关闭右侧标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1360"/>
         <source>Copy File Path</source>
         <translation>复制文件路径</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1363"/>
         <source>Reveal in Finder</source>
         <translation>在访达中打开</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1376"/>
         <source>Reveal in Explorer</source>
         <translation>在资源管理器中打开</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1421"/>
-        <location filename="../src/appwindow.cpp" line="1436"/>
-        <location filename="../src/appwindow.cpp" line="1441"/>
-        <location filename="../src/appwindow.cpp" line="1455"/>
         <source>Open Containing Folder</source>
         <translation>打开文件所在的目录</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1427"/>
         <source>Reveal in File Manager</source>
         <translation>在文件管理器中打开</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1451"/>
         <source>Copy path</source>
         <translation>复制路径</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1462"/>
         <source>Open problem in browser</source>
         <translation>在浏览器中打开题目</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1464"/>
         <source>Copy Problem URL</source>
         <translation>复制题目链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1467"/>
         <source>Set Codeforces URL</source>
         <translation>设置 Codeforces 链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1471"/>
-        <location filename="../src/appwindow.cpp" line="1474"/>
         <source>Set CF URL</source>
         <translation>设置 CF 链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1471"/>
         <source>Enter the contest ID:</source>
         <translation>输入比赛 ID：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1474"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>输入题目编号（A-Z）：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1482"/>
-        <location filename="../src/appwindow.cpp" line="1484"/>
         <source>Set Problem URL</source>
         <translation>设置题目链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1484"/>
         <source>Enter the new problem URL:</source>
         <translation>输入新的题目链接：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1560"/>
         <source>EventLogger</source>
         <translation>事件日志器</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>All logs except for current session has been deleted</source>
         <translation>除当前会话外所有日志已被删除</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="829"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="266"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: 一款为算法竞赛量身定制的编辑器</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="272"/>
         <source>Ctrl+N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="687"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="274"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="279"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="281"/>
         <source>Save As...</source>
         <translation>另存为...</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="283"/>
         <source>Save as new file</source>
         <translation>保存到一个新文件</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="286"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="701"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="288"/>
         <source>Save All</source>
         <translation>保存所有</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="290"/>
         <source>Save all opened files</source>
         <translation>保存所有打开的文件</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="293"/>
         <source>Ctrl+Alt+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="295"/>
         <source>Close Current</source>
         <translation>关闭当前</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="297"/>
         <source>Close current tab</source>
         <translation>关闭当前标签页</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="300"/>
         <source>Ctrl+W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1349"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="302"/>
         <source>Close Saved</source>
         <translation>关闭已保存</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="304"/>
         <source>Close saved tabs</source>
         <translation>关闭已保存的标签页</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="307"/>
         <source>Ctrl+Alt+W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1351"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="309"/>
         <source>Close All</source>
         <translation>关闭所有</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="311"/>
         <source>Close All the tabs</source>
         <translation>关闭所有标签页</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="314"/>
         <source>Ctrl+Shift+W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="281"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="316"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="318"/>
         <source>Quit the application</source>
         <translation>退出程序</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="321"/>
         <source>Ctrl+Q</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="323"/>
         <source>Open File...</source>
         <translation>打开文件...</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="325"/>
         <source>Open files</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="328"/>
         <source>Ctrl+O</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="330"/>
         <source>Open Contest...</source>
         <translation>打开比赛...</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="332"/>
         <source>Open a Contest</source>
         <translation>打开一个比赛</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="335"/>
         <source>Ctrl+Shift+O</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="337"/>
         <source>Indent</source>
         <translation>增加缩进</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="339"/>
         <source>Ctrl+]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="341"/>
         <source>Unindent</source>
         <translation>减少缩进</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="343"/>
         <source>Ctrl+[</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="345"/>
         <source>Swap Line Up</source>
         <translation>向上交换当前行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="347"/>
         <source>Ctrl+Shift+Up</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="349"/>
         <source>Swap Line Down</source>
         <translation>向下交换当前行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="351"/>
         <source>Ctrl+Shift+Down</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="353"/>
         <source>Duplicate Line</source>
         <translation>复制当前行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="355"/>
         <source>Ctrl+Shift+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="357"/>
         <source>Delete Line</source>
         <translation>删除当前行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="359"/>
         <source>Ctrl+Shift+K</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="361"/>
         <source>Toggle Comment</source>
         <translation>开启/关闭单行注释</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="363"/>
         <source>Ctrl+/</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="365"/>
         <source>Toggle Block Comment</source>
         <translation>开启/关闭多行注释</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="367"/>
         <source>Ctrl+Shift+/</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="369"/>
         <source>Compile</source>
         <translation>编译</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="371"/>
         <source>Ctrl+Shift+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="373"/>
         <source>Compile and Run</source>
         <translation>编译并运行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="375"/>
         <source>Ctrl+Shift+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="377"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="379"/>
         <source>Ctrl+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="381"/>
         <source>Format code</source>
         <translation>格式化代码</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="383"/>
         <source>Ctrl+Alt+L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="385"/>
         <source>Run Detached</source>
         <translation>在终端中运行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="387"/>
         <source>Ctrl+Alt+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="389"/>
         <source>Kill Processes</source>
         <translation>终止所有进程</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="391"/>
         <source>Ctrl+K</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="393"/>
         <source>Find and Replace</source>
         <translation>查找和替换</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="401"/>
         <source>Preferences</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="410"/>
         <source>About Qt</source>
         <translation>关于 Qt</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="411"/>
         <source>Build Info</source>
         <translation>构建信息</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="412"/>
         <source>Check for updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="395"/>
         <source>Ctrl+F</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="267"/>
         <source>New File</source>
         <translation>新建文件</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="269"/>
         <source>Open a new tab in the editor</source>
         <translation>在编辑器中打开一个新标签页</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="276"/>
         <source>Save the file on the disk</source>
         <translation>在磁盘上保存文件</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="397"/>
         <source>Use Snippet...</source>
         <translation>使用代码片段...</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="399"/>
         <source>Ctrl+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="406"/>
         <source>Export Settings...</source>
         <translation>导出设置...</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="407"/>
         <source>Import Settings...</source>
         <translation>导入设置...</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="403"/>
         <source>Ctrl+P</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="405"/>
         <source>Reset Settings</source>
         <translation>重置设置</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="408"/>
         <source>Manual</source>
         <translation>帮助手册</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="280"/>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="409"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="413"/>
         <source>Support me</source>
         <translation>支持作者</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="414"/>
         <source>Editor Mode</source>
         <translation>编辑器模式</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="415"/>
         <source>IO Mode</source>
         <translation>IO 模式</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="416"/>
         <source>Split Mode</source>
         <translation>分屏模式</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="417"/>
         <source>Show Log Files</source>
         <translation>显示日志文件</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="418"/>
         <source>Delete Log Files</source>
         <translation>删除日志文件</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="419"/>
         <source>&amp;File</source>
         <translation>文件(&amp;F)</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="420"/>
         <source>&amp;Edit</source>
         <translation>编辑(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="421"/>
         <source>&amp;Actions</source>
         <translation>动作(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="422"/>
         <source>&amp;View</source>
         <translation>视图(&amp;V)</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="423"/>
         <source>&amp;Options</source>
         <translation>选项(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_appwindow.h" line="424"/>
         <source>&amp;Help</source>
         <translation>帮助(&amp;H)</translation>
     </message>
@@ -647,12 +507,10 @@
 <context>
     <name>AppearancePage</name>
     <message>
-        <location filename="../src/Settings/AppearancePage.cpp" line="42"/>
         <source>Change Locale</source>
         <translation>改变语言</translation>
     </message>
     <message>
-        <location filename="../src/Settings/AppearancePage.cpp" line="43"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>你需要重启程序以彻底地改变语言。</translation>
     </message>
@@ -660,123 +518,98 @@
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>搜索...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>从文件中加载代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>导出代码片段到文件</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>无代码片段被选择</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>Unsaved Snippets</source>
         <translation>未保存的代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="257"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>代码片段 [%1] 已被更改。你希望保存更改还是丢弃更改？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Delete Snippet</source>
         <translation>删除代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="289"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>你真的要删除代码片段 [%1] 吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>加载代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>打开 [%1] 失败。你拥有读取权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>导出代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>导出代码片段：%1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>写入 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>代码片段的名称不能为空白。
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>代码片段名称冲突</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>名称 &quot;%1&quot; 已经被使用了。你希望覆盖吗？（对应旧片段将会被删除。）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>名称 &quot;%1&quot; 已经被使用了。
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>添加代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>新代码片段的名称：</translation>
     </message>
@@ -784,74 +617,52 @@
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="103"/>
         <source>Read Checker</source>
         <translation>读取评测器代码</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="111"/>
-        <location filename="../src/Core/Checker.cpp" line="117"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="288"/>
-        <location filename="../src/Core/Checker.cpp" line="289"/>
-        <location filename="../src/Core/Checker.cpp" line="290"/>
         <source>Checker</source>
         <translation>评测器</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="111"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="121"/>
         <source>Read testlib.h</source>
         <translation>读取 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="124"/>
         <source>Save testlib.h</source>
         <translation>保存 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>编译评测器时发生错误：
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="174"/>
-        <location filename="../src/Core/Checker.cpp" line="181"/>
-        <location filename="../src/Core/Checker.cpp" line="189"/>
-        <location filename="../src/Core/Checker.cpp" line="197"/>
-        <location filename="../src/Core/Checker.cpp" line="202"/>
-        <location filename="../src/Core/Checker.cpp" line="207"/>
         <source>Checker[%1]</source>
         <translation>评测器[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="181"/>
         <source>Checker exited with exit code %1</source>
         <translation>评测器退出，返回值: %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="189"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>评测器退出，未知返回值: %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="202"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="208"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation>测试点 #%2 的 %1 超过 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在设置-&gt;高级-&gt;限制-&gt;输出长度限制中更改限制大小</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="218"/>
         <source>Killed</source>
         <translation>被终止</translation>
     </message>
@@ -859,17 +670,14 @@
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="57"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>源文件 [%1] 不存在</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="73"/>
         <source>The compile command for %1 is empty</source>
         <translation>%1 的编译命令为空</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="89"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>编程语言“%1”不受支持</translation>
     </message>
@@ -877,22 +685,18 @@
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="65"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>源文件 [%1] 不存在。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="73"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>未能成功获取运行指令。这可能是一个 bug。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="101"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>未能成功运行。请先编译。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="124"/>
         <source>Please install xterm in order to use Detached Run.</source>
         <translation>请安装 xterm 以使用在终端中运行。</translation>
     </message>
@@ -900,63 +704,42 @@
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="155"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="162"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="176"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="180"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>CF Tool 已被终止</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>题目编号为 0，将自动使用 A 作为题目编号。如果题目的实际编号不是 A，请在当前标签页的右键菜单中手动设置。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>未能成功获取 CF Tool 版本。你在设置中填写的 CF Tool 路径是否正确？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool 已启动</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>未能成功在两秒内启动 CF Tool。你在设置中填写的 CF Tool 路径是否正确？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>未能成功解析链接 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="175"/>
         <source>CF Tool failed</source>
         <translation>CF Tool 运行出错</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="176"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool 以非零返回值 %1 结束</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="185"/>
         <source>Contest %1 Problem %2</source>
         <translation>比赛 %1 题目 %2</translation>
     </message>
@@ -964,48 +747,34 @@
 <context>
     <name>Extensions::ClangFormatter</name>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="51"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="55"/>
         <source>Formatter/check</source>
         <translation>格式化工具/检查</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="123"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="128"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="132"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="171"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="187"/>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="198"/>
         <source>Formatter</source>
         <translation>格式化工具</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="123"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="171"/>
         <source>Formatting completed</source>
         <translation>格式化完毕</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="188"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format in Preferences-&gt;Extensions-&gt;Clang Format.</source>
         <translation>格式化进程未能在 2 秒内结束。这可能是因为 CP Editor 未能找到 clang-format 的可执行文件。你可以在 设置-&gt;扩展-&gt;Clang Format 中设置 clang-format 可执行文件的路径。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="198"/>
         <source>The format command is: %1 %2</source>
         <translation>格式化指令为: %1 %2</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="201"/>
         <source>Formatter[stdout]</source>
         <translation>格式化工具[stdout]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/ClangFormatter.cpp" line="204"/>
         <source>Formatter[stderr]</source>
         <translation>格式化工具[stderr]</translation>
     </message>
@@ -1013,42 +782,30 @@
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="51"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="62"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="65"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="76"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="98"/>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="140"/>
         <source>Companion</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="51"/>
         <source>Server is closed</source>
         <translation>服务器已关闭</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="62"/>
         <source>Port is set to %1</source>
         <translation>端口已被设置为 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="66"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>监听端口 %1 失败。是否有其它进程正在占用？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="76"/>
         <source>Stopped Server</source>
         <translation>服务器已停止</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="98"/>
         <source>Got a POST Request</source>
         <translation>收到了一个 POST 请求</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="140"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>JSON 解析器报告了错误：
@@ -1058,42 +815,30 @@
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="277"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="290"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="300"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="303"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="306"/>
         <source>Langauge Server [%1]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="278"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Language server 出现错误。请检查日志文件以获取详细信息。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="291"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program in Preferences-&gt;Extensions-&gt;Language Server?</source>
         <translation>启动 Language server 进程失败。你是否已在设置-&gt;扩展-&gt;Language Server 中设置语言服务器的路径？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
         <source>LSP Process timed out</source>
         <translation>Language server 超时</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="300"/>
         <source>LSP Process Read Error</source>
         <translation>Language server 读取错误</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="303"/>
         <source>LSP Process Write Error</source>
         <translation>Language server 写入错误</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="306"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Language server 发生未知错误</translation>
     </message>
@@ -1101,7 +846,6 @@
 <context>
     <name>FindReplaceDialog</name>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplacedialog.h" line="46"/>
         <source>Find/Replace</source>
         <translation>查找/替换</translation>
     </message>
@@ -1109,57 +853,46 @@
 <context>
     <name>FindReplaceForm</name>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="188"/>
         <source>Form</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="189"/>
         <source>Find:</source>
         <translation>查找：</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="190"/>
         <source>Replace with:</source>
         <translation>替换为：</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="191"/>
         <source>errorLabel</source>
         <translation>错误信息</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="192"/>
         <source>Direction</source>
         <translation>方向</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="193"/>
         <source>Up</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="194"/>
         <source>Down</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="195"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="196"/>
         <source>Case sensitive</source>
         <translation>区分大小写</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="197"/>
         <source>Whole words only</source>
         <translation>全字匹配</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="199"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -1178,22 +911,18 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://deerchao.cn/tutorials/regex/regex.htm&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://deerchao.cn/tutorials/regex/regex.htm&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="209"/>
         <source>Regular Expression</source>
         <translation>正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="210"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="211"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/ui_findreplaceform.h" line="212"/>
         <source>Replace All</source>
         <translation>替换全部</translation>
     </message>
@@ -1201,57 +930,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="125"/>
-        <location filename="../src/mainwindow.cpp" line="142"/>
-        <location filename="../src/mainwindow.cpp" line="1129"/>
-        <location filename="../src/mainwindow.cpp" line="1141"/>
-        <location filename="../src/mainwindow.cpp" line="1148"/>
-        <location filename="../src/mainwindow.cpp" line="1185"/>
-        <location filename="../src/mainwindow.cpp" line="1192"/>
         <source>Compiler</source>
         <translation>编译器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="142"/>
-        <location filename="../src/mainwindow.cpp" line="932"/>
         <source>Please set the language</source>
         <translation>请设置语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="157"/>
-        <location filename="../src/mainwindow.cpp" line="165"/>
-        <location filename="../src/mainwindow.cpp" line="179"/>
-        <location filename="../src/mainwindow.cpp" line="208"/>
-        <location filename="../src/mainwindow.cpp" line="1133"/>
-        <location filename="../src/mainwindow.cpp" line="1162"/>
-        <location filename="../src/mainwindow.cpp" line="1168"/>
         <source>Runner</source>
         <translation>运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="165"/>
-        <location filename="../src/mainwindow.cpp" line="208"/>
-        <location filename="../src/mainwindow.cpp" line="1168"/>
         <source>Wrong language, please set the language</source>
         <translation>语言错误，请设置语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="179"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>所有输入均为空，没有需要运行的</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="231"/>
         <source>Submit</source>
         <translation>提交</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="239"/>
         <source>Sure to submit</source>
         <translation>确认提交</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="240"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1262,106 +968,82 @@ p, li { white-space: pre-wrap; }
 语言：%2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="249"/>
-        <location filename="../src/mainwindow.cpp" line="263"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="250"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>保存临时文件失败，代码未提交。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="264"/>
         <source>You will not be able to submit code to Codeforces because CF Tool is not installed or is not on SYSTEM PATH. You can set it manually in settings.</source>
         <translation>你无法将代码提交至 Codeforces，因为 CF Tool 没有安装，或是它不在 PATH 环境变量里。你可以在设置中手动设置 CF Tool 的路径。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="280"/>
         <source>Untitled-%1</source>
         <translation>未命名-%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="552"/>
         <source>Save as</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="613"/>
         <source>Open %1 Template</source>
         <translation>打开 %1 的模板</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="755"/>
-        <location filename="../src/mainwindow.cpp" line="763"/>
         <source>Open File</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="764"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Open File Length Limit</source>
         <translation>文件 [%1] 包含超过 %2 个字符，因此没有被打开。你可以在设置-&gt;高级-&gt;限制-&gt;打开文件长度限制中更改长度限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="868"/>
         <source>Save File</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="918"/>
-        <location filename="../src/mainwindow.cpp" line="932"/>
-        <location filename="../src/mainwindow.cpp" line="936"/>
         <source>Temp File</source>
         <translation>临时文件</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="918"/>
         <source>Failed to create the temporary directory</source>
         <translation>未能成功创建临时文件夹</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="948"/>
         <source>Read %1 Template</source>
         <translation>读取 %1 的模板</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="973"/>
         <source>Save changes</source>
         <translation>保存更改</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="974"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>关闭前将更改保存至 [%1]？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="974"/>
         <source>New File</source>
         <translation>新文件</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="977"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1003"/>
         <source>Set Tab language</source>
         <translation>设置标签页语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1003"/>
         <source>Set the language to use in this Tab</source>
         <translation>设置该标签页所使用的语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1040"/>
         <source>Reload</source>
         <translation>重载</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1040"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1372,152 +1054,122 @@ Do you want to reload it?</source>
 你希望重新加载它吗？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1075"/>
         <source>Line %1, Column %2</source>
         <translation>行 %1，列 %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1087"/>
         <source>%1 lines, %2 charachters selected</source>
         <translation>共有 %1 行，%2 个字符被选择</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1089"/>
         <source>%1 characters selected</source>
         <translation>共有 %1 个字符被选择</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1130"/>
         <source>The compile command for %1 is invalid. Is the compiler in the system PATH?</source>
         <translation>语言 %1 的编译命令不可用。编译器是否在环境变量 PATH 中？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1134"/>
         <source>The run command for %1 is invalid. Is the runner in the system Path?</source>
         <translation>语言 %1 的运行命令不可用。解释器是否在环境变量 PATH 中？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1141"/>
         <source>Compilation has started</source>
         <translation>编译已开始</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1148"/>
         <source>Compilation has finished</source>
         <translation>编译已结束</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1151"/>
         <source>Compile Warnings</source>
         <translation>编译警告</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1185"/>
         <source>Error occurred while compiling</source>
         <translation>编译时发生错误</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1187"/>
         <source>Compile Errors</source>
         <translation>编译错误</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1192"/>
         <source>Compilation is killed</source>
         <translation>编译已终止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1200"/>
         <source>Detached Runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1201"/>
         <source>Runner[%1]</source>
         <translation>运行器[%1]</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1206"/>
         <source>Execution has started</source>
         <translation>程序已开始运行</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1215"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>程序在测试点 #%1 上运行了 %2ms 后终止了</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1220"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>程序在测试点 #%1 上运行了 %3ms 后以非零返回值 %2 终止了</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1227"/>
         <source>/stderr</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1240"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1246"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation>在测试点 #%2 上运行的程序的 %1 包含多于 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在设置-&gt;高级-&gt;限制-&gt;输出限制中更改长度限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1257"/>
         <source>%1 has been killed</source>
         <translation>%1 已被终止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>Detached runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1258"/>
         <source>Runner for testcase #%1</source>
         <translation>在测试点 #%1 上运行的程序</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="188"/>
         <source>CP Editor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="189"/>
         <source>cursor info</source>
         <translation>光标信息</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="190"/>
         <source>Compile</source>
         <translation>编译</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="191"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="192"/>
         <source>Compile and Run</source>
         <translation>编译并运行</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="193"/>
         <source>Messages</source>
         <translation>消息</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="194"/>
         <source>Clear</source>
         <translation>清除</translation>
     </message>
     <message>
-        <location filename="../build/cpeditor_autogen/ui/ui_mainwindow.h" line="195"/>
         <source>C++</source>
         <translation></translation>
     </message>
@@ -1525,7 +1177,6 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="43"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1535,42 +1186,34 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 括号</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="108"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="113"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="135"/>
         <source>No Parenthesis Selected</source>
         <translation>没有括号对被选择</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="171"/>
         <source>New Parenthesis</source>
         <translation>新的括号对</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="171"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>输入一对括号（例如: {}）：</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="184"/>
         <source>Delete Parenthesis</source>
         <translation>删除括号对</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>你真的要删除括号对 %1 吗？</translation>
     </message>
@@ -1578,29 +1221,24 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>括号对：%1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>在 %3 中为括号对 %2 启用 %1。
 如果复选框被部分选择，则会使用全局设置。</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>自动补全</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>自动删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>按 Tab 键跳出</translation>
     </message>
@@ -1608,37 +1246,30 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="44"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>欢迎使用 CP Editor！让我们开始吧。</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="52"/>
         <source>Code Editor Settings</source>
         <translation>代码编辑器设置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="53"/>
         <source>C++ Compile and Run Commands</source>
         <translation>C++ 编译运行命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="54"/>
         <source>Java Compile and Run Commands</source>
         <translation>Java 编译运行命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="55"/>
         <source>Python Run Commands</source>
         <translation>Python 运行命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="56"/>
         <source>Appearance</source>
         <translation>外观</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>You can read the &lt;a href=&quot;https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL.md&quot;&gt;Manual&lt;/a&gt; or go through the settings for more information.</source>
         <translation>你可以阅读 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL-zh_CN.md&quot;&gt;手册&lt;/a&gt; 或在设置中浏览以获取更多信息。</translation>
     </message>
@@ -1646,42 +1277,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="39"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="41"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="43"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="58"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>将当前页设置重置为默认（Ctrl+D）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>丢弃当前页的更改（Ctrl+R）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>保存当前页设置（Ctrl+S）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="81"/>
         <source>Unsaved Settings</source>
         <translation>未保存的设置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="81"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>设置已变更。你希望保存设置还是丢弃更改？</translation>
     </message>
@@ -1689,183 +1312,126 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="106"/>
         <source>Preferences</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="122"/>
         <source>Search...</source>
         <translation>搜索...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="126"/>
         <source>Home</source>
         <translation>主页</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="128"/>
         <source>Go to the home page</source>
         <translation>回到主页</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="167"/>
         <source>Code Edit</source>
         <translation>代码编辑</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="170"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="171"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
         <source>General</source>
         <translation>通用</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="172"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="173"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="175"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="178"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="180"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="219"/>
         <source>C++</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="184"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="185"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="187"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="190"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="192"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="220"/>
         <source>Java</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="196"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>Python</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
         <source>Appearance</source>
         <translation>外观</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="210"/>
         <source>Actions</source>
         <translation>动作</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="212"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
         <source>Bind file and problem</source>
         <translation>关联文件和题目</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
         <source>Extensions</source>
         <translation>扩展</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="217"/>
         <source>Clang Format</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="218"/>
         <source>Language Server</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="173"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="185"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
         <source>%1 Commands</source>
         <translation>%1 命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="175"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="187"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
         <source>%1 Template</source>
         <translation>%1 模板</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="178"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="190"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
         <source>%1 Snippets</source>
         <translation>%1 代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="180"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="192"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
         <source>%1 Parentheses</source>
         <translation>%1 括号</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="219"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="220"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Server</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>Competitive Companion</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="225"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="227"/>
         <source>File Path</source>
         <translation>文件路径</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>Testcases</source>
         <translation>测试点</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="229"/>
         <source>Problem URL</source>
         <translation>题目链接</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="231"/>
         <source>Key Bindings</source>
         <translation>热键</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="233"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="234"/>
         <source>Update</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="235"/>
         <source>Limits</source>
         <translation>限制</translation>
     </message>
@@ -1873,72 +1439,56 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>Setting</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="29"/>
         <source>Tab Width</source>
         <translation>缩进宽度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="29"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>制表符的宽度或缩进的空格个数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="30"/>
         <source>Geometry</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="31"/>
         <source>Editor Font</source>
         <translation>编辑器字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="31"/>
         <source>The font of the code editor</source>
         <translation>代码编辑器的字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="32"/>
         <source>Default Language</source>
         <translation>默认编程语言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="32"/>
         <source>The default language used when opening new tabs</source>
         <translation>打开新标签页时默认的编程语言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="33"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Path</source>
         <translation>路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="33"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Clang Format 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="34"/>
         <source>Style</source>
         <translation>风格</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="34"/>
         <source>The Clang Format style options, which are often saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Clang Format 格式化所用风格，通常存储为 .clang-format。
 你可以在 &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt; 上了解更多。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="35"/>
         <source>The template used when creating a new C++ file</source>
         <translation>新建 C++ 代码时所用模板的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="36"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -1947,68 +1497,51 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 如果没有匹配，光标将会在模板结尾。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="37"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>偏移是基于正则表达式匹配的开头还是结尾。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>包含空白字符的偏移字符数，相对于正则表达式的匹配位置。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>编译 C++ 代码所用命令。这里不应该包含源代码路径或是&quot;-o &lt;output file&gt;&quot;。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>执行 C++ 程序时提供的命令行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The template used when creating a new Java file</source>
         <translation>新建 Java 代码时所用模板的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>编译 Java 代码所用命令。这里不应该包含源代码路径或是输出的 class 文件路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>执行 Java 程序时提供的命令行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>执行 Java 程序时的命令。这里不应该包含&quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Run Command</source>
         <translation>%1 运行命令</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>%1 Class Name</source>
         <translation>%1 类名称</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>%1 Class Path</source>
         <translation>%1 类路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2021,82 +1554,66 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用 &quot;${tmpdir}&quot; 或 &quot;${tempdir}&quot; 来代指临时目录的绝对路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new Python file</source>
         <translation>新建 Python 代码时所用模板的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>执行 Python 程序时提供的命令行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>执行 Python 程序时的命令。这里不应该包含源代码路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
         <source>Editor Theme</source>
         <translation>编辑器主题</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>代码编辑器高亮所用的主题</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>Auto Complete Parentheses</source>
         <translation>自动补全括号</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>Auto Remove Parentheses</source>
         <translation>自动删除括号</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>Auto Indent</source>
         <translation>自动缩进</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>在&quot;{&quot;后换行时插入一个缩进。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>Enable Auto Save</source>
         <translation>自动保存</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>Automatically save the file every 3 seconds.</source>
         <translation>每 3 秒自动保存代码。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>Wrap Text</source>
         <translation>文本自动换行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>当单行超出屏幕时折成多行。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
         <source>Use the beta version</source>
         <translation>使用测试版本</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>检查更新时包含测试版本。测试版将会包含更多功能，但可能不太稳定。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Save the status of the editor when the application exits and
 load the status of the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save
@@ -2105,14 +1622,12 @@ the unsaved files or not when exiting.</source>
 若这项设置已启用，退出时你将不会被询问是否保存已更改的文件。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>从文件添加成对测试用例时使用的成对的正则表达式。
 每对正则表达式代表一个测试点。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -2120,46 +1635,30 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="35"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>%1 Template Path</source>
         <translation>%1 模板路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="36"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>使用 %1 模板时光标初始位置定位使用的正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="37"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>使用 %1 模板时光标初始位置的偏移类型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>使用 %1 模板时光标初始位置的偏移字符量</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>%1 Compile Command</source>
         <translation>%1 编译命令</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
         <source>%1 Executable File Path</source>
         <translation>%1 可执行文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2174,26 +1673,18 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用 &quot;${tmpdir}&quot; 或 &quot;${tempdir}&quot; 来代指临时目录的绝对路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>%1 Run Arguments</source>
         <translation>%1 运行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>%1 Parentheses</source>
         <translation>%1 括号</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The name of the non-public main class of your solution.</source>
         <translation>你的代码中非 public 主类的名称。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -2201,12 +1692,10 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>在按下 Tab 键时跳出括号</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -2214,394 +1703,306 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>输入制表符时插入空格代替。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
         <source>Replace tabs by spaces</source>
         <translation>将制表符替换为空格</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
         <source>Save Testcases on Save</source>
         <translation>保存文件时保存测试用例</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
         <source>Save the testcases on the disk when saving a file, and load the saved testcases when opening a file.</source>
         <translation>在保存文件时一并保存测试用例，在加载时一并加载。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
         <source>Maximized Window</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>Check for updates on startup</source>
         <translation>启动时检查更新</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>在启动程序时检查有无新版本。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>Format Codes on Save</source>
         <translation>保存时自动格式化代码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>Use Clang Format to format the codes when saving it.</source>
         <translation>在保存文件时使用 Clang Format 格式化代码。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>The opacity of the main window</source>
         <translation>主窗口的不透明度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>View Mode</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>Splitter Size</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>Right Splitter Size</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
         <source>Enable Competitive Companion</source>
         <translation>启用 Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
         <source>Receive data sent by Competitive Companion and load the example testcases.</source>
         <translation>接受 Competitive Companion 发送的数据并加载测试数据。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Connection Port</source>
         <translation>连接端口</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>从 Competitive Companion 接受数据使用的端口</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Open New Tabs</source>
         <translation>打开新标签</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>为 Competitive Companion 解析的每一个题目打开一个新标签页。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Format Codes</source>
         <translation>格式化代码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Kill All Processes</source>
         <translation>结束所有进程</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Compile and Run</source>
         <translation>编译并运行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Run Only</source>
         <translation>仅运行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Compile Only</source>
         <translation>仅编译</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Change View Mode</source>
         <translation>切换视图模式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Use Snippets</source>
         <translation>使用代码片段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Enable Hot Exit</source>
         <translation>启用热退出</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Hot Exit Tab Count</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Hot Exit Current Index</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Force Close</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>The path to the CF Tool executable file</source>
         <translation>CF Tool 可执行文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Save Path</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Show Compile And Run Only</source>
         <translation>只显示编译并运行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>在主窗口隐藏编译，运行两个按钮。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
         <source>Display EOLN In Diff</source>
         <translation>在差异查看器中显示行尾字符</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>在 HTML 差异查看器中使用 &quot;¶&quot; 表示换行符。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Save Files Faster</source>
         <translation>更快地保存文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>总是使用 QFile 而不是 QSaveFile 来保存。
 这会更快速，但更可能丢失文件（概率极小）。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Time Limit (ms)</source>
         <translation>时间限制（毫秒）</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>执行程序的时间限制。
 超时程序将会被终止。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
         <source>Output Length Limit</source>
         <translation>输出长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>程序的最大输出字符数。
 stdout 或 stderr 过长的程序将会被终止。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
         <source>Message Length Limit</source>
         <translation>消息长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>主窗口右上角内每条信息的最大长度。
 超出部分将会被省略。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>HTML 差异查看器长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>HTML 差异查看器中显示的最大长度。
 如果超长，将会使用纯文本进行显示。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Open File Length Limit</source>
         <translation>打开文件长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>允许打开的文件的最大字符数。
 如果超长，将不会打开。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Load Test Case File Length Limit</source>
         <translation>加载测试用例文件最大长度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The maximum number of characters in a testcase file to load.
 A testcase file won&apos;t be loaded if it&apos;s too long.</source>
         <translation>允许加载的测试文件的最大字符数。
 如果超长，将不会加载。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Path to LSP executable</source>
         <translation>路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>C++ Language Server 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Java Language Server 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Python Language Server 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Use Linting with Language Server</source>
         <translation>启用 Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Langauge</source>
         <translation>在编辑器中为 C++ 显示错误、警告、信息和提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Langauge</source>
         <translation>在编辑器中为 Java 显示错误、警告、信息和提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Langauge</source>
         <translation>在编辑器中为 Python 显示错误、警告、信息和提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Use auto complete with Language Server</source>
         <translation>使用 Language Server 的自动补全</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Use autocomplete results from Language server</source>
         <translation>使用由 Language Server 提供的自动补全</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Delay in Linting (ms)</source>
         <translation>提示延迟（毫秒）</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Delay in linting in miliseconds after last modification to code</source>
         <translation>最后一次修改后，延迟进行提示的时间间隔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Arguments for Language Server</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>传给 Language Server 程序的参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Testcases Matching Rules</source>
         <translation>测试数据匹配规则</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Input Regex</source>
         <translation>输入正则</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>匹配整个输入文件名的正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>Answer Replace</source>
         <translation>答案替换</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>答案文件名的替换表达式。
 你可以使用 &quot;\1&quot; 来代指匹配中的第一个捕获组。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>Input File Save Path</source>
         <translation>输入文件保存路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2616,12 +2017,10 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用&quot;${1-index}&quot;来代指以 1 起始的编号。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Answer File Save Path</source>
         <translation>答案文件保存路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2636,103 +2035,84 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用&quot;${1-index}&quot;来代指以 1 起始的编号。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>针对题目链接的默认保存路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>在设置了题目链接时，保存新文件使用的默认文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Problem URL</source>
         <translation>题目链接</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>能够匹配题目链接的一部分的正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>File Path</source>
         <translation>文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>默认保存路径的替换表达式，不含文件后缀名。
 你可以使用 &quot;\1&quot; 来代指匹配中的第一个捕获组。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Test Cases Font</source>
         <translation>测试用例字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>The font of test cases</source>
         <translation>显示测试用例所用字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>在代码编辑器底部添加额外的边距</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>在代码编辑器底部添加额外的边距。
 由于技术原因，改变边距会影响撤销/重做历史。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Message Logger Font</source>
         <translation>消息字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>The font of the message logger</source>
         <translation>显示消息所用字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Save File On Compilation</source>
         <translation>编译时保存文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>在编译前保存代码。如果是未命名标签页，则不会保存。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Save File On Execution</source>
         <translation>执行时保存文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>在运行前保存代码。如果是未命名标签页，则不会保存。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>打开文件时加载对应题目</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>如果一个文件曾经被设置过题目链接，当你再次
 打开这个文件时，会继续使用原来那个题目链接。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>如果一个文件曾经被设置过题目链接，
@@ -2740,37 +2120,30 @@ from Competitive Companion again, the old file will be opened.</source>
 解析这道题目时，以前的那个文件会被打开。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>加载以前的题目时打开以前的文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>UI Language</source>
         <translation>界面语言 (UI Language)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The language displayed in the UI.</source>
         <translation>在用户界面中显示的语言。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>UI Style</source>
         <translation>界面风格</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The style of the whole application.</source>
         <translation>整个应用程序的风格。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Run your codes on empty test cases</source>
         <translation>在空的测试点上运行你的代码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>在所有未隐藏的测试点运行你的代码，即使输入为空。</translation>
     </message>
@@ -2778,17 +2151,14 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Settings::PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="34"/>
         <source>Excutable</source>
         <translation>可执行文件</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="50"/>
         <source>Choose Excutable</source>
         <translation>选择可执行文件</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="54"/>
         <source>Choose %1 Sources</source>
         <translation>选择 %1 源代码</translation>
     </message>
@@ -2796,7 +2166,6 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>清除快捷键</translation>
     </message>
@@ -2804,52 +2173,42 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>插入一行（Ctrl+N）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>删除当前行（Ctrl+W）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>删除项目</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>你真的要删除当前行吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>上移</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>将当前行上移一行（Ctrl+Shift+↑）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>下移</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>将当前行下移一行（Ctrl+Shift+↓）</translation>
     </message>
@@ -2857,12 +2216,10 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="135"/>
         <source>No release is found.</source>
         <translation>未发现更新。</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="146"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>没有发现版本 [%1] 可用的下载链接。</translation>
     </message>
@@ -2870,29 +2227,22 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="50"/>
         <source>%1Source Files (%2)</source>
         <translation>%1 源代码 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="67"/>
-        <location filename="../src/Util/FileUtil.cpp" line="90"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>打开 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="77"/>
-        <location filename="../src/Util/FileUtil.cpp" line="99"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>保存 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="118"/>
         <source>The file [%1] does not exist</source>
         <translation>文件 [%1] 不存在</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="128"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>打开 [%1] 失败。你拥有读取权限吗？</translation>
     </message>
@@ -2900,17 +2250,14 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>差异查看器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="50"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
@@ -2918,87 +2265,70 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="47"/>
         <source>Input</source>
         <translation>输入</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="48"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="49"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="50"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="52"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="86"/>
         <source>Test on a single testcase</source>
         <translation>在单个测试点上进行测试</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="87"/>
         <source>Open the Diff Viewer</source>
         <translation>打开差异查看器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="107"/>
         <source>Output Length Limit Exceeded</source>
         <translation>超出输出长度限制（OLE）</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="108"/>
         <source>Testcases</source>
         <translation>测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="109"/>
         <source>The output #%1 contains more than %2 characters, so it&apos;s not displayed. You can set the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
         <translation>测试点 #%1 的输出包含超过 %2 个字符，因此没有显示。你可以在设置-&gt;高级-&gt;限制-&gt;输出限制中更改限制大小</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="154"/>
         <source>Input #%1</source>
         <translation>输入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="155"/>
         <source>Output #%1</source>
         <translation>输出 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="156"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="243"/>
         <source>Delete Testcase</source>
         <translation>删除测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="244"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>你确定要删除测试点 #%1 吗？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="252"/>
         <source>Diff Viewer[%1]</source>
         <translation>差异查看器[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="253"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;HTML Diff Viewer Length Limit</source>
         <translation>输出或答案超过了 %1 个字符，因此 HTML 差异查看器已被禁用。你可以在设置-&gt;高级-&gt;限制-&gt;HTML 差异查看器长度限制中更改限制大小</translation>
     </message>
@@ -3006,28 +2336,22 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="101"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="103"/>
         <source>Load From File</source>
         <translation>从文件中加载</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="107"/>
         <source>Edit in Bigger Window</source>
         <translation>在更大的窗口中编辑</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="110"/>
         <source>Edit Testcase</source>
         <translation>编辑测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="125"/>
         <source>Testcases</source>
         <translation>测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="126"/>
         <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
         <translation>测试点文件 [%1] 包含超过 %2 个字符，因此没有被加载。你可以在设置-&gt;高级-&gt;限制-&gt;加载测试用例文件最大长度长度限制中更改限制大小</translation>
     </message>
@@ -3035,198 +2359,154 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="45"/>
         <source>Test Cases</source>
         <translation>测试用例</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="47"/>
         <source>Checker:</source>
         <translation>评测器：</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Add Test</source>
         <translation>添加测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="49"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="458"/>
         <source>Add Checker</source>
         <translation>添加评测器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="69"/>
         <source>Wrong Answer / Accepted / Total</source>
         <translation>答案错误 / 通过 / 总计</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="70"/>
         <source>Add a custom testlib checker</source>
         <translation>添加基于 testlib 的自定义评测器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="76"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>从文件添加成对的测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="77"/>
         <source>Choose Testcase Files</source>
         <translation>选择测试点文件</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="139"/>
         <source>Load Testcases</source>
         <translation>加载测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="110"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>已加载一对测试点 [%1] 和 [%2]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>An input [%1] is loaded</source>
         <translation>已加载输入 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="140"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at Preferences-&gt;File Path-&gt;Testcases-&gt;Add Testcases From Files Rules.</source>
         <translation>下列文件由于没有匹配而未加载：%1。你可以在设置-&gt;文件路径-&gt;测试点-&gt;测试数据匹配规则中设置匹配规则。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="147"/>
         <source>Remove Empty</source>
         <translation>删除空测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="159"/>
         <source>Remove All</source>
         <translation>删除全部测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="162"/>
         <source>Clear Testcases</source>
         <translation>清除测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="162"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>你确定要删除所有测试点吗？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="173"/>
         <source>Hide AC</source>
         <translation>隐藏已通过的测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
         <source>Show All</source>
         <translation>显示所有测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="186"/>
         <source>Hide All</source>
         <translation>隐藏所有测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="192"/>
         <source>Invert</source>
         <translation>反转显示状态</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
         <source>Ignore trailing spaces</source>
         <translation>忽略行末空格和文末换行</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
         <source>Strictly the same</source>
         <translation>严格一致</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - 匹配 64 位整数</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="206"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - 匹配浮点数，最大允许误差 1e-4</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="207"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - 匹配浮点数，最大允许误差 1e-6</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - 匹配浮点数，最大允许误差 1e-9</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - 匹配字符串</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - 匹配 YES 和 NO，大小写不敏感</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="237"/>
         <source>Add Test Case</source>
         <translation>添加测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>已经有 %1 个测试点了，你不能继续添加更多了。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="315"/>
         <source>Input #%1</source>
         <translation>输入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="316"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="331"/>
         <source>Save Input #%1</source>
         <translation>保存输入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="333"/>
         <source>Save Expected #%1</source>
         <translation>保存答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="349"/>
         <source>Load %1</source>
         <translation>加载 %1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="104"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="105"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="126"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="352"/>
         <source>Testcases</source>
         <translation>测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="353"/>
         <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
         <translation>测试点文件 [%1] 包含超过 %2 个字符，因此没有被加载。你可以在设置-&gt;高级-&gt;限制-&gt;加载测试用例文件最大长度长度限制中更改限制大小</translation>
     </message>
@@ -3234,32 +2514,26 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>新更新可用</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>一个新的 %1 更新 &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; 可用。更新日志在下方。&lt;br /&gt;我们强烈建议您更新至最新版本，这样你才不会错过新的特性和 bug 修复。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>测试</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>稳定</translation>
     </message>
@@ -3267,37 +2541,30 @@ from Competitive Companion again, the old file will be opened.</source>
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="36"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="37"/>
         <source>Close this dialog and abort the update check</source>
         <translation>关闭对话框并终止检查更新</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="45"/>
         <source>Update Checker</source>
         <translation>更新检查器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="55"/>
         <source>Fetching the list of releases...</source>
         <translation>获取更新列表中...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="63"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.github.io/download&quot;&gt;https://cpeditor.github.io/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>错误：%1&lt;br /&gt;&lt;br /&gt;检查更新失败。请前往 &lt;br /&gt;&lt;a href=&quot;https://cpeditor.github.io/download&quot;&gt;https://cpeditor.github.io/download&lt;/a&gt; 或 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt; 手动检查更新。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="73"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="74"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation>恭喜！！你已经在使用最新版本的 CP Editor 了。</translation>
     </message>


### PR DESCRIPTION
## Description

Remove locations in the translations in git, and if the author wants to see the source file at local, he/she can run `tools/updateTranslation.sh r` when editing and run `tools/updateTranslation.sh` after finished.

## Motivation and Context

The location changes are useless and big, which are not good for version control.