### PR TITLE
feat & fix(auto-save): add auto save interval and fix #392

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -13,11 +13,13 @@ With the portable version, you can easily store it in something like a USB disk,
 - Add the translation system and Simplified Chinese translation. (#377 and #384)
 - In-application UI style setting and built-in light/dark style. (#265 and #404)
 - Now testcases with empty outputs can also be checked. (#208 and #430)
+- Auto-save time interval.
 
 ### Fixed
 
 - Fix the wrong default setting for C++ executable file path.
 - Fix the displayed size of the default font is not the same as the actual size of the default font. (#425)
+- Fix false external file changes when auto-save is enabled. (#392)
 
 ### Changed
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -209,8 +209,9 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .page("Appearance", tr("Appearance"), new AppearancePage())
         .dir("Actions", tr("Actions"))
             .page("General", tr("General"), {"Hot Exit/Enable", "Run On Empty Testcase", "Check On Testcases With Empty Output"})
-            .page("Save", tr("Save"), {"Auto Save", "Save Faster", "Auto Format", "Save File On Compilation",
+            .page("Save", tr("Save"), {"Save Faster", "Auto Format", "Save File On Compilation",
                                "Save File On Execution", "Save Tests"})
+            .page("Auto Save", tr("Auto Save"), {"Auto Save", "Auto Save Interval", "Auto Save Interval Type"})
             .page("Bind file and problem", tr("Bind file and problem"), {"Restore Old Problem Url", "Open Old File For Old Problem Url"})
         .end()
         .dir("Extensions", tr("Extensions"))

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -287,6 +287,22 @@
         "tip": "Automatically save the file every 3 seconds."
     },
     {
+        "name": "Auto Save Interval",
+        "desc": "Auto Save Interval (ms)",
+        "type": "int",
+        "default": 1000,
+        "param": "QVariantList {100, 36000000}",
+        "tip": "The time interval between a modification and an auto-save, or between two auto-saves."
+    },
+    {
+        "name": "Auto Save Interval Type",
+        "type": "QString",
+        "ui": "QComboBox",
+        "param": "QStringList { \"After the last modification\", \"After the first modification\", \"Without modification\" }",
+        "default": "After the last modification",
+        "tip": "After the last modification: the timer will be reset after a modification to the code.\nAfter the first modification: the timer will start after a modification, if at that time the timer is not running.\nWithout modification: auto-save happens with an constant inverval no matter there are modifications or not."
+    },
+    {
         "name": "Wrap Text",
         "type": "bool",
         "tip": "Wrap a line into several lines if it doesn't fit into the screen."

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -177,7 +177,6 @@ AppWindow::~AppWindow()
     Extensions::EditorTheme::release();
     delete ui;
     delete preferencesWindow;
-    delete autoSaveTimer;
     delete lspTimerCpp;
     delete lspTimerJava;
     delete lspTimerPython;
@@ -228,7 +227,6 @@ void AppWindow::setConnections()
     ui->tabWidget->tabBar()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->tabWidget->tabBar(), SIGNAL(customContextMenuRequested(const QPoint &)), this,
             SLOT(onTabContextMenuRequested(const QPoint &)));
-    connect(autoSaveTimer, SIGNAL(timeout()), this, SLOT(onSaveTimerElapsed()));
 
     connect(lspTimerCpp, SIGNAL(timeout()), this, SLOT(onLSPTimerElapsedCpp()));
     connect(lspTimerJava, SIGNAL(timeout()), this, SLOT(onLSPTimerElapsedJava()));
@@ -246,7 +244,6 @@ void AppWindow::setConnections()
 
 void AppWindow::allocate()
 {
-    autoSaveTimer = new QTimer();
     lspTimerCpp = new QTimer();
     lspTimerJava = new QTimer();
     lspTimerPython = new QTimer();
@@ -264,16 +261,9 @@ void AppWindow::allocate()
     findReplaceDialog->setWindowFlags(Qt::Window | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint |
                                       Qt::WindowCloseButtonHint);
 
-    autoSaveTimer->setInterval(3000);
-    autoSaveTimer->setSingleShot(false);
-
     lspTimerCpp->setInterval(SettingsHelper::getLSPDelayCpp());
     lspTimerJava->setInterval(SettingsHelper::getLSPDelayJava());
     lspTimerPython->setInterval(SettingsHelper::getLSPDelayPython());
-
-    lspTimerCpp->setSingleShot(false);
-    lspTimerJava->setSingleShot(false);
-    lspTimerPython->setSingleShot(false);
 
     trayIconMenu = new QMenu();
     trayIconMenu->addAction(tr("Show Main Window"), this, SLOT(showOnTop()));
@@ -950,18 +940,6 @@ void AppWindow::onEditorLanguageChanged(MainWindow *window)
         reAttachLanguageServer(window);
 }
 
-void AppWindow::onSaveTimerElapsed()
-{
-    for (int t = 0; t < ui->tabWidget->count(); t++)
-    {
-        auto tmp = windowAt(t);
-        if (!tmp->isUntitled())
-        {
-            tmp->save(false, tr("Auto Save"), false);
-        }
-    }
-}
-
 void AppWindow::onLSPTimerElapsedCpp()
 {
     auto tab = currentWindow();
@@ -1017,14 +995,6 @@ void AppWindow::onSettingsApplied(const QString &pagePath)
             server->updatePort(SettingsHelper::getCompetitiveCompanionConnectionPort());
         else
             server->updatePort(0);
-    }
-
-    if (pagePath.isEmpty() || pagePath == "Actions/Save")
-    {
-        if (SettingsHelper::isAutoSave())
-            autoSaveTimer->start();
-        else
-            autoSaveTimer->stop();
     }
 
     if (pagePath.isEmpty() || pagePath == "Appearance")

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -123,8 +123,6 @@ class AppWindow : public QMainWindow
 
     void onTabChanged(int);
 
-    void onSaveTimerElapsed();
-
     void onLSPTimerElapsedCpp();
 
     void onLSPTimerElapsedPython();
@@ -194,7 +192,6 @@ class AppWindow : public QMainWindow
   private:
     Ui::AppWindow *ui;
     MessageLogger *activeLogger = nullptr;
-    QTimer *autoSaveTimer = nullptr;
 
     QTimer *lspTimerCpp = nullptr;
     QTimer *lspTimerPython = nullptr;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -200,6 +200,8 @@ class MainWindow : public QMainWindow
 
     Widgets::TestCases *testcases = nullptr;
 
+    QTimer *autoSaveTimer = nullptr;
+
     void setTestCases();
     void setEditor();
     void setupCore();

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -60,10 +60,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Snippets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1156,6 +1152,10 @@ Do you want to reload it?</source>
         <source>C++</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Auto Save</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1414,6 +1414,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
     <message>
         <source>Limits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Save</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2094,6 +2098,24 @@ from Competitive Companion again, the old file will be opened.</source>
     </message>
     <message>
         <source>Check your answer even if your output or the expected the output is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Save Interval (ms)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Save Interval Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>After the last modification: the timer will be reset after a modification to the code.
+After the first modification: the timer will start after a modification, if at that time the timer is not running.
+Without modification: auto-save happens with an constant inverval no matter there are modifications or not.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -60,10 +60,6 @@
         <translation>你确定要重置所有设置吗？</translation>
     </message>
     <message>
-        <source>Auto Save</source>
-        <translation>自动保存</translation>
-    </message>
-    <message>
         <source>Snippets</source>
         <translation>代码片段</translation>
     </message>
@@ -1173,6 +1169,10 @@ Do you want to reload it?</source>
         <source>C++</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Auto Save</source>
+        <translation>自动保存</translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1434,6 +1434,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     <message>
         <source>Limits</source>
         <translation>限制</translation>
+    </message>
+    <message>
+        <source>Auto Save</source>
+        <translation>自动保存</translation>
     </message>
 </context>
 <context>
@@ -2154,6 +2158,26 @@ from Competitive Companion again, the old file will be opened.</source>
     <message>
         <source>Check your answer even if your output or the expected the output is empty.</source>
         <translation>即使你的输出或答案的输出为空，依然检查输出的正确性。</translation>
+    </message>
+    <message>
+        <source>Auto Save Interval (ms)</source>
+        <translation>自动保存间隔 (ms)</translation>
+    </message>
+    <message>
+        <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
+        <translation>修改代码到自动保存之间或两次自动保存之间的时间间隔。</translation>
+    </message>
+    <message>
+        <source>Auto Save Interval Type</source>
+        <translation>自动保存间隔类型</translation>
+    </message>
+    <message>
+        <source>After the last modification: the timer will be reset after a modification to the code.
+After the first modification: the timer will start after a modification, if at that time the timer is not running.
+Without modification: auto-save happens with an constant inverval no matter there are modifications or not.</source>
+        <translation>After the last modification: 计时器会在修改代码后重置。
+After the first modification: 在修改代码时，若计时器未在运行，则计时器会开始运行。
+Without modification: 以恒定的时间间隔自动保存，无论是否进行了修改。</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

1. Add auto-save time interval, which can be one of "After the last modification", "After the first modification" or "Without modification".
2. Fix #392.
3. Move the auto-save timer into the MainWindow, which is separated for each tab. This improves performance as it only saves one tab each time.

I think this is better than #412, not only for the functionalities but also for more clear logic and fewer codes.

## How Has This Been Tested?

On Arch Linux.