### PR TITLE
feat(UpdateChecker): skip beta changelogs in the latest stable minor

### DIFF
--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -156,13 +156,24 @@ void UpdateChecker::managerFinished(QNetworkReply *reply)
             bool used = false;
             if (currentVersion < version)
             {
-                if ((version.major == latestVersion.major && version.minor == latestVersion.minor) ||
-                    (version.major != last.major || version.minor != last.minor))
+                do
                 {
+                    if (version.major == latestVersion.major && version.minor == latestVersion.minor)
+                    {
+                        if (!latestInfo.preview && release.second.preview)
+                        {
+                            break;
+                        }
+                    }
+                    else if (version.major == last.major && version.minor == last.minor)
+                    {
+                        break;
+                    }
+
                     used = true;
                     last = version;
                     changelog.push_back(release.second.changelog);
-                }
+                } while (false);
             }
             LOG_INFO(QString("Version %1 is %2 the changelog")
                          .arg(release.second.version)


### PR DESCRIPTION
## Description

Skip the changelog of `x.y.z` if:
    
1. `x.y` is the latest minor (the beta minor version is not counted if check beta update is disabled) version.
2. There's a stable version in the minor `x.y`.
3. `x.y.z` is a beta version.

## Motivation and Context

With the old updater, we have to put only the changelog of the current version in the GitHub Releases.

With the new updater, we can include all changelogs of the minor version when a new stable version is released.

## How Has This Been Tested?

Tested on Arch Linux, with the version set to 6.2.0, and both enabled and disabled beta update.