### PR TITLE
feat(TestCase): adjustable width and customizable max-height

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -15,6 +15,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now testcases with empty outputs can also be checked. (#208 and #430)
 - Auto-save time interval.
 - Now you can auto-save the current session, besides saving it when the application exists. (#437 and #442)
+- Now the width of the input/output/expected of each test case is adjustable, and the maximum height of a test case can be set in the preferences. (#414 and #444)
 
 ### Fixed
 

--- a/src/Settings/AppearancePage.cpp
+++ b/src/Settings/AppearancePage.cpp
@@ -25,7 +25,7 @@
 AppearancePage::AppearancePage(QWidget *parent)
     : PreferencesPageTemplate({"Locale", "UI Style", "Editor Theme", "Editor Font", "Test Cases Font",
                                "Message Logger Font", "Opacity", "Show Compile And Run Only", "Display EOLN In Diff",
-                               "Extra Bottom Margin"},
+                               "Extra Bottom Margin", "Test Case Maximum Height"},
                               true, parent)
 {
 }

--- a/src/Settings/AppearancePage.cpp
+++ b/src/Settings/AppearancePage.cpp
@@ -24,8 +24,8 @@
 
 AppearancePage::AppearancePage(QWidget *parent)
     : PreferencesPageTemplate({"Locale", "UI Style", "Editor Theme", "Editor Font", "Test Cases Font",
-                               "Message Logger Font", "Opacity", "Show Compile And Run Only", "Display EOLN In Diff",
-                               "Extra Bottom Margin", "Test Case Maximum Height"},
+                               "Message Logger Font", "Opacity", "Test Case Maximum Height",
+                               "Show Compile And Run Only", "Display EOLN In Diff", "Extra Bottom Margin"},
                               true, parent)
 {
 }

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -743,6 +743,6 @@
         "type": "int",
         "default": 300,
         "param": "QVariantList {30, 2000}",
-        "tip": "The maximum height of a test case without a scrollbar."
+        "tip": "The maximum height of a test case without a scrollbar in pixel."
     }
 ]

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -743,6 +743,6 @@
         "type": "int",
         "default": 300,
         "param": "QVariantList {30, 2000}",
-        "tip": "The maximum height of a test case without a scrollbar in pixel."
+        "tip": "The maximum height of a test case without a scrollbar in pixels."
     }
 ]

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -737,5 +737,12 @@
         "desc": "Check your answer on test cases with empty output",
         "type": "bool",
         "tip": "Check your answer even if your output or the expected the output is empty."
+    },
+    {
+        "name": "Test Case Maximum Height",
+        "type": "int",
+        "default": 300,
+        "param": "QVariantList {30, 2000}",
+        "tip": "The maximum height of a test case without a scrollbar."
     }
 ]

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -27,6 +27,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QSplitter>
 #include <QVBoxLayout>
 #include <generated/SettingsHelper.hpp>
 
@@ -40,19 +41,23 @@ TestCase::TestCase(int index, MessageLogger *logger, QWidget *parent, const QStr
     inputUpLayout = new QHBoxLayout();
     outputUpLayout = new QHBoxLayout();
     expectedUpLayout = new QHBoxLayout();
-    inputLayout = new QVBoxLayout();
-    outputLayout = new QVBoxLayout();
-    expectedLayout = new QVBoxLayout();
-    showCheckBox = new QCheckBox();
-    inputLabel = new QLabel(tr("Input"));
-    outputLabel = new QLabel(tr("Output"));
-    expectedLabel = new QLabel(tr("Expected"));
-    runButton = new QPushButton(tr("Run"));
-    diffButton = new QPushButton("**");
-    delButton = new QPushButton(tr("Del"));
-    inputEdit = new TestCaseEdit(true, log, in);
-    outputEdit = new TestCaseEdit(false, log);
-    expectedEdit = new TestCaseEdit(true, log, exp);
+    splitter = new QSplitter(this);
+    inputWidget = new QWidget(this);
+    outputWidget = new QWidget(this);
+    expectedWidget = new QWidget(this);
+    inputLayout = new QVBoxLayout(inputWidget);
+    outputLayout = new QVBoxLayout(outputWidget);
+    expectedLayout = new QVBoxLayout(expectedWidget);
+    showCheckBox = new QCheckBox(this);
+    inputLabel = new QLabel(tr("Input"), this);
+    outputLabel = new QLabel(tr("Output"), this);
+    expectedLabel = new QLabel(tr("Expected"), this);
+    runButton = new QPushButton(tr("Run"), this);
+    diffButton = new QPushButton("**", this);
+    delButton = new QPushButton(tr("Del"), this);
+    inputEdit = new TestCaseEdit(true, log, in, this);
+    outputEdit = new TestCaseEdit(false, log, QString(), this);
+    expectedEdit = new TestCaseEdit(true, log, exp, this);
     diffViewer = new DiffViewer(this);
 
     setID(index);
@@ -76,12 +81,18 @@ TestCase::TestCase(int index, MessageLogger *logger, QWidget *parent, const QStr
     inputLayout->addWidget(inputEdit);
     outputLayout->addLayout(outputUpLayout);
     outputLayout->addWidget(outputEdit);
-
     expectedLayout->addLayout(expectedUpLayout);
     expectedLayout->addWidget(expectedEdit);
-    mainLayout->addLayout(inputLayout);
-    mainLayout->addLayout(outputLayout);
-    mainLayout->addLayout(expectedLayout);
+    splitter->addWidget(inputWidget);
+    splitter->addWidget(outputWidget);
+    splitter->addWidget(expectedWidget);
+    mainLayout->addWidget(splitter);
+
+    inputLayout->setContentsMargins(3, 0, 3, 0);
+    outputLayout->setContentsMargins(3, 0, 3, 0);
+    expectedLayout->setContentsMargins(3, 0, 3, 0);
+
+    splitter->setChildrenCollapsible(false);
 
     runButton->setToolTip(tr("Test on a single testcase"));
     diffButton->setToolTip(tr("Open the Diff Viewer"));

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -212,6 +212,13 @@ void TestCase::setTestCaseEditFont(const QFont &font)
     expectedEdit->setFont(font);
 }
 
+void TestCase::updateSize()
+{
+    inputEdit->startAnimation();
+    outputEdit->startAnimation();
+    expectedEdit->startAnimation();
+}
+
 void TestCase::onShowCheckBoxToggled(bool checked)
 {
     if (checked)

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -212,7 +212,7 @@ void TestCase::setTestCaseEditFont(const QFont &font)
     expectedEdit->setFont(font);
 }
 
-void TestCase::updateSize()
+void TestCase::updateHeight()
 {
     inputEdit->startAnimation();
     outputEdit->startAnimation();

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -219,6 +219,16 @@ void TestCase::updateHeight()
     expectedEdit->startAnimation();
 }
 
+QList<int> TestCase::splitterSizes() const
+{
+    return splitter->sizes();
+}
+
+void TestCase::restoreSplitterSizes(const QList<int> &sizes)
+{
+    splitter->setSizes(sizes);
+}
+
 void TestCase::onShowCheckBoxToggled(bool checked)
 {
     if (checked)

--- a/src/Widgets/TestCase.hpp
+++ b/src/Widgets/TestCase.hpp
@@ -55,7 +55,7 @@ class TestCase : public QWidget
     void setShow(bool show);
     bool isShow() const;
     void setTestCaseEditFont(const QFont &font);
-    void updateSize();
+    void updateHeight();
 
   signals:
     void deleted(TestCase *widget);

--- a/src/Widgets/TestCase.hpp
+++ b/src/Widgets/TestCase.hpp
@@ -55,6 +55,7 @@ class TestCase : public QWidget
     void setShow(bool show);
     bool isShow() const;
     void setTestCaseEditFont(const QFont &font);
+    void updateSize();
 
   signals:
     void deleted(TestCase *widget);

--- a/src/Widgets/TestCase.hpp
+++ b/src/Widgets/TestCase.hpp
@@ -56,6 +56,8 @@ class TestCase : public QWidget
     bool isShow() const;
     void setTestCaseEditFont(const QFont &font);
     void updateHeight();
+    QList<int> splitterSizes() const;
+    void restoreSplitterSizes(const QList<int> &state);
 
   signals:
     void deleted(TestCase *widget);

--- a/src/Widgets/TestCase.hpp
+++ b/src/Widgets/TestCase.hpp
@@ -27,6 +27,7 @@ class QHBoxLayout;
 class QLabel;
 class QMenu;
 class QPushButton;
+class QSplitter;
 class QVBoxLayout;
 
 namespace Widgets
@@ -68,6 +69,8 @@ class TestCase : public QWidget
 
   private:
     QHBoxLayout *mainLayout = nullptr, *inputUpLayout = nullptr, *outputUpLayout = nullptr, *expectedUpLayout = nullptr;
+    QSplitter *splitter = nullptr;
+    QWidget *inputWidget = nullptr, *outputWidget = nullptr, *expectedWidget = nullptr;
     QVBoxLayout *inputLayout = nullptr, *outputLayout = nullptr, *expectedLayout = nullptr;
     QCheckBox *showCheckBox = nullptr;
     QLabel *inputLabel = nullptr, *outputLabel = nullptr, *expectedLabel = nullptr;

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -82,7 +82,8 @@ void TestCaseEdit::modifyText(const QString &text)
 
 void TestCaseEdit::startAnimation()
 {
-    int newHeight = qMin(fontMetrics().lineSpacing() * (document()->lineCount() + 2) + 5, 300);
+    int newHeight = qMin(fontMetrics().boundingRect("f").height() * (document()->lineCount() + 2),
+                         SettingsHelper::getTestCaseMaximumHeight());
     if (newHeight != minimumHeight())
     {
         animation->stop();

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -365,6 +365,12 @@ void TestCases::setTestCaseEditFont(const QFont &font)
         t->setTestCaseEditFont(font);
 }
 
+void TestCases::updateSizes()
+{
+    for (auto t : testcases)
+        t->updateSize();
+}
+
 int TestCases::id(TestCase *testcase) const
 {
     return testcases.indexOf(testcase);

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -365,10 +365,10 @@ void TestCases::setTestCaseEditFont(const QFont &font)
         t->setTestCaseEditFont(font);
 }
 
-void TestCases::updateSizes()
+void TestCases::updateHeights()
 {
     for (auto t : testcases)
-        t->updateSize();
+        t->updateHeight();
 }
 
 int TestCases::id(TestCase *testcase) const

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -371,6 +371,30 @@ void TestCases::updateHeights()
         t->updateHeight();
 }
 
+QVariantList TestCases::splitterStates() const
+{
+    QVariantList states;
+    for (auto t : testcases)
+    {
+        QVariantList tmp;
+        for (auto size : t->splitterSizes())
+            tmp.push_back(size);
+        states.push_back(tmp);
+    }
+    return states;
+}
+
+void TestCases::restoreSplitterStates(const QVariantList &states)
+{
+    for (int i = 0; i < count() && i < states.count(); ++i)
+    {
+        QList<int> sizes;
+        for (auto var : states[i].toList())
+            sizes.push_back(var.toInt());
+        testcases[i]->restoreSplitterSizes(sizes);
+    }
+}
+
 int TestCases::id(TestCase *testcase) const
 {
     return testcases.indexOf(testcase);

--- a/src/Widgets/TestCases.hpp
+++ b/src/Widgets/TestCases.hpp
@@ -79,6 +79,8 @@ class TestCases : public QWidget
 
     void setTestCaseEditFont(const QFont &font);
 
+    void updateSizes();
+
   public slots:
     void setVerdict(int index, Core::Checker::Verdict verdict);
 

--- a/src/Widgets/TestCases.hpp
+++ b/src/Widgets/TestCases.hpp
@@ -79,7 +79,7 @@ class TestCases : public QWidget
 
     void setTestCaseEditFont(const QFont &font);
 
-    void updateSizes();
+    void updateHeights();
 
   public slots:
     void setVerdict(int index, Core::Checker::Verdict verdict);

--- a/src/Widgets/TestCases.hpp
+++ b/src/Widgets/TestCases.hpp
@@ -81,6 +81,9 @@ class TestCases : public QWidget
 
     void updateHeights();
 
+    QVariantList splitterStates() const;
+    void restoreSplitterStates(const QVariantList &states);
+
   public slots:
     void setVerdict(int index, Core::Checker::Verdict verdict);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -529,7 +529,7 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
     {
         ui->compiler_edit->setFont(SettingsHelper::getMessageLoggerFont());
         testcases->setTestCaseEditFont(SettingsHelper::getTestCasesFont());
-        testcases->updateSizes();
+        testcases->updateHeights();
         if (SettingsHelper::isShowCompileAndRunOnly())
         {
             ui->compile->hide();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -529,6 +529,7 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
     {
         ui->compiler_edit->setFont(SettingsHelper::getMessageLoggerFont());
         testcases->setTestCaseEditFont(SettingsHelper::getTestCasesFont());
+        testcases->updateSizes();
         if (SettingsHelper::isShowCompileAndRunOnly())
         {
             ui->compile->hide();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -382,6 +382,7 @@ MainWindow::EditorStatus::EditorStatus(const QMap<QString, QVariant> &status)
     FROMSTATUS(expected).toStringList();
     FROMSTATUS(customCheckers).toStringList();
     FROMSTATUS(testcasesIsShow).toList();
+    FROMSTATUS(testCaseSplitterStates).toList();
 }
 #undef FROMSTATUS
 
@@ -406,6 +407,7 @@ QMap<QString, QVariant> MainWindow::EditorStatus::toMap() const
     TOSTATUS(expected);
     TOSTATUS(customCheckers);
     TOSTATUS(testcasesIsShow);
+    TOSTATUS(testCaseSplitterStates);
     return status;
 }
 #undef TOSTATUS
@@ -430,6 +432,7 @@ MainWindow::EditorStatus MainWindow::toStatus() const
     status.expected = testcases->expecteds();
     for (int i = 0; i < testcases->count(); ++i)
         status.testcasesIsShow.push_back(testcases->isShow(i));
+    status.testCaseSplitterStates = testcases->splitterStates();
 
     return status;
 }
@@ -455,6 +458,7 @@ void MainWindow::loadStatus(const EditorStatus &status)
     testcases->loadStatus(status.input, status.expected);
     for (int i = 0; i < status.testcasesIsShow.count() && i < testcases->count(); ++i)
         testcases->setShow(i, status.testcasesIsShow[i].toBool());
+    testcases->restoreSplitterStates(status.testCaseSplitterStates);
 }
 
 void MainWindow::applyCompanion(const Extensions::CompanionData &data)

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -64,6 +64,7 @@ class MainWindow : public QMainWindow
         int editorCursor, editorAnchor, horizontalScrollBarValue, verticalScrollbarValue, untitledIndex, checkerIndex;
         QStringList input, expected, customCheckers;
         QVariantList testcasesIsShow;
+        QVariantList testCaseSplitterStates;
 
         EditorStatus(){};
 

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2202,7 +2202,7 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The maximum height of a test case without a scrollbar.</source>
+        <source>The maximum height of a test case without a scrollbar in pixel.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2202,7 +2202,7 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The maximum height of a test case without a scrollbar in pixel.</source>
+        <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2197,6 +2197,14 @@ kill the application with SIGKILL which could not be handled by the application.
         <source>The time interval between two auto-saves of the current session.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Test Case Maximum Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum height of a test case without a scrollbar.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Settings::PathItem</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2261,6 +2261,14 @@ kill the application with SIGKILL which could not be handled by the application.
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>两次自动保存会话之间的时间间隔。</translation>
     </message>
+    <message>
+        <source>Test Case Maximum Height</source>
+        <translation>测试用例最大高度</translation>
+    </message>
+    <message>
+        <source>The maximum height of a test case without a scrollbar.</source>
+        <translation>无需滚动条时一个测试用例的最大高度。</translation>
+    </message>
 </context>
 <context>
     <name>Settings::PathItem</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2266,8 +2266,8 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation>测试用例最大高度</translation>
     </message>
     <message>
-        <source>The maximum height of a test case without a scrollbar.</source>
-        <translation>无需滚动条时一个测试用例的最大高度。</translation>
+        <source>The maximum height of a test case without a scrollbar in pixel.</source>
+        <translation>无需滚动条时一个测试用例的最大高度，以像素为单位。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2266,7 +2266,7 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation>测试用例最大高度</translation>
     </message>
     <message>
-        <source>The maximum height of a test case without a scrollbar in pixel.</source>
+        <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>无需滚动条时一个测试用例的最大高度，以像素为单位。</translation>
     </message>
 </context>


### PR DESCRIPTION
## Description

Now the width of the input/output/expected of each test case is adjustable, and the maximum height of a test case can be set in the preferences.

## Related Issue

This closes #414.

## How Has This Been Tested?

On Arch Linux with KDE.

## Screenshots (if appropriate)

![图片](https://user-images.githubusercontent.com/30581822/85421890-8a23f680-b5a7-11ea-9b08-222e8dc569ba.png)

## Type of changes

- [x] New feature (changes which add functionality)