### PR TITLE
refactor(translation): make codes easier to maintain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ ENDIF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 configure_file(cmake/version.hpp.in ${CMAKE_BINARY_DIR}/generated/version.hpp)
 configure_file(cmake/portable.hpp.in ${CMAKE_BINARY_DIR}/generated/portable.hpp)
 
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp
+add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp
                    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/genSettings.py ${PROJECT_SOURCE_DIR}/src/Settings/settings.json
                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                    DEPENDS ${PROJECT_SOURCE_DIR}/src/Settings/settings.json ${PROJECT_SOURCE_DIR}/tools/genSettings.py)
@@ -71,7 +71,7 @@ qt5_add_translation(QMFILES ${TSS})
 
 file(COPY ${CMAKE_SOURCE_DIR}/translations/translations.qrc DESTINATION ${CMAKE_BINARY_DIR}/translations)
 
-set_property(SOURCE ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp PROPERTY SKIP_AUTOGEN ON)
+set_property(SOURCE ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp PROPERTY SKIP_AUTOGEN ON)
 
 add_executable(cpeditor
     ${GUI_TYPE}
@@ -178,7 +178,7 @@ add_executable(cpeditor
 
     ${CMAKE_BINARY_DIR}/generated/version.hpp
     ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp
-    ${CMAKE_BINARY_DIR}/generated/SettingsInfo.hpp
+    src/Settings/SettingsInfo.hpp
     ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp
 
     ${CMAKE_BINARY_DIR}/translations/translations.qrc

--- a/src/Core/EventLogger.cpp
+++ b/src/Core/EventLogger.cpp
@@ -196,7 +196,6 @@ void Log::revealInFileManager()
     }
 #else
     QDesktopServices::openUrl(QUrl::fromLocalFile(QFileInfo(filePath).path()));
-}
 #endif
 } // namespace Core
 

--- a/src/Core/Translator.cpp
+++ b/src/Core/Translator.cpp
@@ -17,7 +17,7 @@
 
 #include "Core/Translator.hpp"
 #include "Core/EventLogger.hpp"
-#include "generated/SettingsInfo.hpp"
+#include "Settings/SettingsInfo.hpp"
 #include <QMap>
 #include <QTranslator>
 
@@ -55,7 +55,7 @@ void Translator::setLocale(const QString &language)
         translator = new QTranslator(qApp);
         translator->load(QString(":/translations/%1.qm").arg(locale));
         LOG_ERR_IF(!qApp->installTranslator(translator), "Failed to load the translator " << translator);
-        updateSettingInfo();
+        SettingsInfo::updateSettingInfo();
     }
 }
 } // namespace Core

--- a/src/Settings/AppearancePage.cpp
+++ b/src/Settings/AppearancePage.cpp
@@ -17,10 +17,10 @@
 
 #include "Settings/AppearancePage.hpp"
 #include "Core/Translator.hpp"
+#include "Settings/SettingsInfo.hpp"
 #include "Settings/SettingsManager.hpp"
 #include "Settings/ValueWrapper.hpp"
 #include <QMessageBox>
-#include <generated/SettingsInfo.hpp>
 
 AppearancePage::AppearancePage(QWidget *parent)
     : PreferencesPageTemplate({"Locale", "UI Style", "Editor Theme", "Editor Font", "Test Cases Font",
@@ -35,7 +35,7 @@ void AppearancePage::makeSettingsTheSameAsUI()
     for (int i = 0; i < options.size(); ++i)
     {
         ValueWidget *widget = widgets[i];
-        SettingInfo si = findSetting(options[i]);
+        auto si = SettingsInfo::findSetting(options[i]);
         if (si.name == "Locale" && SettingsManager::get(si.name) != widget->getVariant())
         {
             Core::Translator::setLocale(widget->getVariant().toString());

--- a/src/Settings/PathItem.cpp
+++ b/src/Settings/PathItem.cpp
@@ -26,12 +26,12 @@
 #include <QStyle>
 #include <QToolButton>
 
-inline QString getFilters(int index)
+QString PathItem::getFilters(int index)
 {
     switch (index)
     {
     case 0:
-        return QCoreApplication::translate("Settings::PathItem", "Excutable") + " (*" + Util::exeSuffix + ")";
+        return tr("Excutable") + " (*" + Util::exeSuffix + ")";
     case 1:
     case 2:
     case 3:
@@ -42,17 +42,16 @@ inline QString getFilters(int index)
     }
 }
 
-inline QString getTitles(int index)
+QString PathItem::getTitles(int index)
 {
     switch (index)
     {
     case 0:
-        return QCoreApplication::translate("Settings::PathItem", "Choose Excutable");
+        return tr("Choose Excutable");
     case 1:
     case 2:
     case 3:
-        return QCoreApplication::translate("Settings::PathItem", "Choose %1 Sources")
-            .arg(QStringList{"C++", "Java", "Python"}[index - 1]);
+        return tr("Choose %1 Sources").arg(QStringList{"C++", "Java", "Python"}[index - 1]);
     default:
         LOG_ERR("Unknown index: " INFO_OF(index));
         return QString();

--- a/src/Settings/PathItem.hpp
+++ b/src/Settings/PathItem.hpp
@@ -55,6 +55,11 @@ class PathItem : public QWidget
     void onButtonClicked();
 
   private:
+    QString getFilters(int index);
+
+    QString getTitles(int index);
+
+  private:
     QString filter, title;
     QHBoxLayout *layout = nullptr;
     QLineEdit *lineEdit = nullptr;

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -16,9 +16,9 @@
  */
 
 #include "Settings/PreferencesPageTemplate.hpp"
+#include "Settings/SettingsInfo.hpp"
 #include "Settings/SettingsManager.hpp"
 #include "Settings/ValueWrapper.hpp"
-#include "generated/SettingsInfo.hpp"
 #include <QCheckBox>
 #include <QDebug>
 
@@ -27,7 +27,7 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
 {
     for (const QString &name : options)
     {
-        SettingInfo si = findSetting(name);
+        auto si = SettingsInfo::findSetting(name);
 #ifdef QT_DEBUG
         if (name != si.name)
             qDebug() << "Unknown option" << name;
@@ -71,7 +71,7 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
 
     for (const QString &name : options)
     {
-        SettingInfo si = findSetting(name);
+        auto si = SettingsInfo::findSetting(name);
         if (si.depends.isEmpty())
             continue;
         auto currentWidget = widgets[options.indexOf(name)]->coreWidget();
@@ -82,7 +82,7 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
                 qDebug() << name << " depends on unknown option " << depend;
                 continue;
             }
-            SettingInfo dependInfo = findSetting(depend);
+            auto dependInfo = SettingsInfo::findSetting(depend);
             if (dependInfo.type != "bool")
             {
                 qDebug() << name << " depends on " << depend << " which is not a bool option";
@@ -102,7 +102,7 @@ QStringList PreferencesPageTemplate::content()
     QStringList ret = options;
     for (auto opt : options)
     {
-        SettingInfo si = findSetting(opt);
+        auto si = SettingsInfo::findSetting(opt);
         if (!si.desc.isEmpty())
             ret += si.desc;
         if (!si.tip.isEmpty())
@@ -118,7 +118,7 @@ bool PreferencesPageTemplate::areSettingsChanged()
     for (int i = 0; i < options.size(); ++i)
     {
         ValueWidget *widget = widgets[i];
-        SettingInfo si = findSetting(options[i]);
+        auto si = SettingsInfo::findSetting(options[i]);
         if (widget->getVariant() != SettingsManager::get(si.name))
             return true;
     }
@@ -130,7 +130,7 @@ void PreferencesPageTemplate::makeUITheSameAsDefault()
     for (int i = 0; i < options.size(); ++i)
     {
         ValueWidget *widget = widgets[i];
-        SettingInfo si = findSetting(options[i]);
+        auto si = SettingsInfo::findSetting(options[i]);
         widget->setVariant(SettingsManager::get(si.name, true));
     }
 }
@@ -140,7 +140,7 @@ void PreferencesPageTemplate::makeUITheSameAsSettings()
     for (int i = 0; i < options.size(); ++i)
     {
         ValueWidget *widget = widgets[i];
-        SettingInfo si = findSetting(options[i]);
+        auto si = SettingsInfo::findSetting(options[i]);
         widget->setVariant(SettingsManager::get(si.name));
     }
 }
@@ -150,7 +150,7 @@ void PreferencesPageTemplate::makeSettingsTheSameAsUI()
     for (int i = 0; i < options.size(); ++i)
     {
         ValueWidget *widget = widgets[i];
-        SettingInfo si = findSetting(options[i]);
+        auto si = SettingsInfo::findSetting(options[i]);
         SettingsManager::set(si.name, widget->getVariant());
     }
 }

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -163,13 +163,16 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
     });
 
     // clang-format off
+
+#define TRKEY(x) x, tr(x)
+
     AddPageHelper(this)
-        .page("Code Edit", tr("Code Edit"),
+        .page(TRKEY("Code Edit"),
               {"Tab Width", "Auto Indent", "Wrap Text", "Auto Complete Parentheses", "Auto Remove Parentheses",
                "Tab Jump Out Parentheses", "Replace Tabs"})
-        .dir("Language", tr("Language"))
-            .page("General", tr("General"), {"Default Language"})
-            .dir("C++", tr("C++"))
+        .dir(TRKEY("Language"))
+            .page(TRKEY("General"), {"Default Language"})
+            .dir(TRKEY("C++"))
                 .page("C++ Commands", tr("%1 Commands").arg(tr("C++")),
                       {"C++/Compile Command", "C++/Output Path", "C++/Run Arguments"})
                 .page("C++ Template", tr("%1 Template").arg(tr("C++")),
@@ -181,7 +184,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                       {"C++ Parentheses", "C++ Brackets", "C++ Braces", "C++ Auto Complete", "C++ Auto Remove",
                        "C++ Tab Jump Out"})
             .end()
-            .dir("Java", tr("Java"))
+            .dir(TRKEY("Java"))
                 .page("Java Commands", tr("%1 Commands").arg(tr("Java")),
                       {"Java/Compile Command", "Java/Output Path", "Java/Class Name", "Java/Run Command", "Java/Run Arguments"})
                 .page("Java Template", tr("%1 Template").arg(tr("Java")),
@@ -193,7 +196,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                       {"Java Parentheses", "Java Brackets", "Java Braces", "Java Auto Complete", "Java Auto Remove",
                        "Java Tab Jump Out"})
             .end()
-            .dir("Python", tr("Python"))
+            .dir(TRKEY("Python"))
                 .page("Python Commands", tr("%1 Commands").arg(tr("Python")),
                       {"Python/Run Command", "Python/Run Arguments"})
                 .page("Python Template", tr("%1 Template").arg(tr("Python")),
@@ -206,37 +209,40 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                        "Python Tab Jump Out"})
             .end()
         .end()
-        .page("Appearance", tr("Appearance"), new AppearancePage())
-        .dir("Actions", tr("Actions"))
-            .page("Save", tr("Save"), {"Save Faster", "Auto Format", "Save File On Compilation",
+        .page(TRKEY("Appearance"), new AppearancePage())
+        .dir(TRKEY("Actions"))
+            .page(TRKEY("Save"), {"Save Faster", "Auto Format", "Save File On Compilation",
                                "Save File On Execution", "Save Tests"})
-            .page("Auto Save", tr("Auto Save"), {"Auto Save", "Auto Save Interval", "Auto Save Interval Type"})
-            .page("Save Session", tr("Save Session"), {"Hot Exit/Enable", "Hot Exit/Auto Save", "Hot Exit/Auto Save Interval"})
-            .page("Bind file and problem", tr("Bind file and problem"), {"Restore Old Problem Url", "Open Old File For Old Problem Url"})
-            .page("Empty Test Cases", tr("Empty Test Cases"), {"Run On Empty Testcase", "Check On Testcases With Empty Output"})
+            .page(TRKEY("Auto Save"), {"Auto Save", "Auto Save Interval", "Auto Save Interval Type"})
+            .page(TRKEY("Save Session"), {"Hot Exit/Enable", "Hot Exit/Auto Save", "Hot Exit/Auto Save Interval"})
+            .page(TRKEY("Bind file and problem"), {"Restore Old Problem Url", "Open Old File For Old Problem Url"})
+            .page(TRKEY("Empty Test Cases"), {"Run On Empty Testcase", "Check On Testcases With Empty Output"})
         .end()
-        .dir("Extensions", tr("Extensions"))
-            .page("Clang Format", tr("Clang Format"), new PreferencesPageTemplate({"Clang Format/Path", "Clang Format/Style"}, false))
-            .dir("Language Server", tr("Language Server"))
+        .dir(TRKEY("Extensions"))
+            .page(TRKEY("Clang Format"), new PreferencesPageTemplate({"Clang Format/Path", "Clang Format/Style"}, false))
+            .dir(TRKEY("Language Server"))
                 .page("C++ Server", tr("%1 Server").arg(tr("C++")), {"LSP/Use Linting C++", "LSP/Delay C++", "LSP/Path C++", "LSP/Args C++"})
                 .page("Java Server", tr("%1 Server").arg(tr("Java")), {"LSP/Use Linting Java", "LSP/Delay Java", "LSP/Path Java", "LSP/Args Java"})
                 .page("Python Server", tr("%1 Server").arg(tr("Python")), {"LSP/Use Linting Python", "LSP/Delay Python", "LSP/Path Python", "LSP/Args Python"})
             .end()
-            .page("Competitive Companion", tr("Competitive Companion"), {"Competitive Companion/Enable", "Competitive Companion/Open New Tab",
+            .page(TRKEY("Competitive Companion"), {"Competitive Companion/Enable", "Competitive Companion/Open New Tab",
                                                 "Competitive Companion/Connection Port"})
-            .page("CF Tool", tr("CF Tool"), {"CF/Path"})
+            .page(TRKEY("CF Tool"), {"CF/Path"})
         .end()
-        .dir("File Path", tr("File Path"))
-            .page("Testcases", tr("Testcases"), {"Input File Save Path", "Answer File Save Path", "Testcases Matching Rules"})
-            .page("Problem URL", tr("Problem URL"), {"Default File Paths For Problem URLs"})
+        .dir(TRKEY("File Path"))
+            .page(TRKEY("Testcases"), {"Input File Save Path", "Answer File Save Path", "Testcases Matching Rules"})
+            .page(TRKEY("Problem URL"), {"Default File Paths For Problem URLs"})
         .end()
-        .page("Key Bindings", tr("Key Bindings"), {"Hotkey/Compile", "Hotkey/Run", "Hotkey/Compile Run", "Hotkey/Format", "Hotkey/Kill",
+        .page(TRKEY("Key Bindings"), {"Hotkey/Compile", "Hotkey/Run", "Hotkey/Compile Run", "Hotkey/Format", "Hotkey/Kill",
                                    "Hotkey/Change View Mode", "Hotkey/Snippets"})
-        .dir("Advanced", tr("Advanced"))
-            .page("Update", tr("Update"), {"Check Update", "Beta"})
-            .page("Limits", tr("Limits"), {"Time Limit", "Output Length Limit", "Message Length Limit", "HTML Diff Viewer Length Limit",
+        .dir(TRKEY("Advanced"))
+            .page(TRKEY("Update"), {"Check Update", "Beta"})
+            .page(TRKEY("Limits"), {"Time Limit", "Output Length Limit", "Message Length Limit", "HTML Diff Viewer Length Limit",
                                  "Open File Length Limit", "Load Test Case File Length Limit"})
         .end();
+
+#undef TRKEY
+
     // clang-format on
 }
 

--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#ifndef SETTINGSINFO_HPP
+#define SETTINGSINFO_HPP
+
+#include <QCoreApplication>
+#include <QVariant>
+
+class SettingsInfo
+{
+    Q_DECLARE_TR_FUNCTIONS(SettingsInfo)
+
+  public:
+    struct SettingInfo
+    {
+        QString name, desc, type, ui, tip, help;
+        bool requireAllDepends; // false for one of the depends, true for all depends
+        QStringList depends;
+        QVariant def;
+        QVariant param;
+        QList<SettingInfo> child;
+
+        QString key() const
+        {
+            return name.toLower().replace('+', 'p').replace(' ', '_');
+        }
+    };
+
+    static void updateSettingInfo();
+
+    static SettingInfo findSetting(const QString &name, const QList<SettingInfo> &infos = settings)
+    {
+        for (const SettingInfo &si : infos)
+            if (si.name == name)
+                return si;
+        return SettingInfo();
+    }
+
+  private:
+    static QList<SettingInfo> settings;
+
+    friend class SettingsManager;
+};
+
+#endif // SETTINGSINFO_HPP

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -20,7 +20,6 @@
 #include "Settings/FileProblemBinder.hpp"
 #include "Settings/SettingsUpdater.hpp"
 #include "Util/FileUtil.hpp"
-#include "generated/SettingsInfo.hpp"
 #include "generated/portable.hpp"
 #include <QDebug>
 #include <QFile>
@@ -55,9 +54,9 @@ void SettingsManager::deinit()
     cur = def = nullptr;
 }
 
-void SettingsManager::load(QSettings &setting, const QString &prefix, const QList<SettingInfo> &infos)
+void SettingsManager::load(QSettings &setting, const QString &prefix, const QList<SettingsInfo::SettingInfo> &infos)
 {
-    for (const SettingInfo &si : infos)
+    for (const auto &si : infos)
     {
         if (si.type == "Object")
         {
@@ -85,9 +84,9 @@ void SettingsManager::load(QSettings &setting, const QString &prefix, const QLis
     }
 }
 
-void SettingsManager::save(QSettings &setting, const QString &prefix, const QList<SettingInfo> &infos)
+void SettingsManager::save(QSettings &setting, const QString &prefix, const QList<SettingsInfo::SettingInfo> &infos)
 {
-    for (const SettingInfo &si : infos)
+    for (const auto &si : infos)
         if (si.type == "Object")
         {
             QString head = QString("%1%2/").arg(prefix, si.name);
@@ -118,13 +117,13 @@ void SettingsManager::loadSettings(const QString &path)
     def = new QVariantMap();
 
     // default settings
-    for (const SettingInfo &si : settingInfo)
+    for (const auto &si : SettingsInfo::settings)
         def->insert(si.name, si.def);
 
     if (!path.isEmpty())
     {
         QSettings setting(path, QSettings::IniFormat);
-        load(setting, "", settingInfo);
+        load(setting, "", SettingsInfo::settings);
         SettingsUpdater::updateSetting(setting);
 
         // load file problem binding
@@ -148,7 +147,7 @@ void SettingsManager::saveSettings(const QString &path)
 
     QSettings setting(path, QSettings::IniFormat);
     setting.clear(); // Otherwise SettingsManager::remove won't work
-    save(setting, "", settingInfo);
+    save(setting, "", SettingsInfo::settings);
 
     // save file problem binding
     setting.setValue("file_problem_binding", FileProblemBinder::toVariant());

--- a/src/Settings/SettingsManager.hpp
+++ b/src/Settings/SettingsManager.hpp
@@ -18,16 +18,15 @@
 #ifndef SETTINGSMANAGER_HPP
 #define SETTINGSMANAGER_HPP
 
-#include <QMetaType>
+#include "Settings/SettingsInfo.hpp"
 
 class QSettings;
-struct SettingInfo;
 
 class SettingsManager
 {
   private:
-    static void load(QSettings &setting, const QString &prefix, const QList<SettingInfo> &infos);
-    static void save(QSettings &setting, const QString &prefix, const QList<SettingInfo> &infos);
+    static void load(QSettings &setting, const QString &prefix, const QList<SettingsInfo::SettingInfo> &infos);
+    static void save(QSettings &setting, const QString &prefix, const QList<SettingsInfo::SettingInfo> &infos);
 
   public:
     static void init();

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -634,7 +634,7 @@
         "name": "Testcases Matching Rules",
         "type": "QVariantList",
         "default": "QVariantList { QStringList {\"(.*)\\\\.in\", \"\\\\1.ans\"}, QStringList {\"(.*)\\\\.in\", \"\\\\1.out\"}}",
-        "param": "QVariantList { QStringList {QCoreApplication::translate(\"Setting\", \"Input Regex\"), QCoreApplication::translate(\"Setting\", \"The regular expression which matches the whole input file name\")}, QStringList {QCoreApplication::translate(\"Setting\", \"Answer Replace\"), QCoreApplication::translate(\"Setting\", \"The replace expression for the answer file name.\\nYou can use \\\"\\\\1\\\" for the first captured group.\")}}",
+        "param": "QVariantList { QStringList {tr(\"Input Regex\"), tr(\"The regular expression which matches the whole input file name\")}, QStringList {tr(\"Answer Replace\"), tr(\"The replace expression for the answer file name.\\nYou can use \\\"\\\\1\\\" for the first captured group.\")}}",
         "tip": "Pairs of regular expressions used when adding pairs of test cases from files.\nEach pair of regular expressions represents a test case."
     },
     {
@@ -653,7 +653,7 @@
         "name": "Default File Paths For Problem URLs",
         "type": "QVariantList",
         "default": "QVariantList {}",
-        "param": "QVariantList { QStringList { QCoreApplication::translate(\"Setting\", \"Problem URL\"), QCoreApplication::translate(\"Setting\", \"The regular expression which matches a part of the problem URL\")}, QStringList {QCoreApplication::translate(\"Setting\", \"File Path\"), QCoreApplication::translate(\"Setting\", \"The replace expression for the file path, without file name suffix.\\nYou can use \\\"\\\\1\\\" for the first captured group.\")}}",
+        "param": "QVariantList { QStringList { tr(\"Problem URL\"), tr(\"The regular expression which matches a part of the problem URL\")}, QStringList {tr(\"File Path\"), tr(\"The replace expression for the file path, without file name suffix.\\nYou can use \\\"\\\\1\\\" for the first captured group.\")}}",
         "tip": "The default file path used when saving a new file while the problem URL is set"
     },
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,11 +17,11 @@
 
 #include "Core/EventLogger.hpp"
 #include "Core/Translator.hpp"
+#include "Settings/SettingsInfo.hpp"
 #include "SignalHandler.hpp"
 #include "Util/Util.hpp"
 #include "appwindow.hpp"
 #include "generated/SettingsHelper.hpp"
-#include "generated/SettingsInfo.hpp"
 #include "mainwindow.hpp"
 #include <QApplication>
 #include <QCommandLineParser>
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
     Core::Log::init(instance, shouldDumpTostderr);
     LOG_INFO(INFO_OF(instance));
 
-    updateSettingInfo(); // generate an English version, so that we can use SettingsHelper
+    SettingsInfo::updateSettingInfo(); // generate an English version, so that we can use SettingsHelper
     SettingsManager::init();
     Core::Translator::setLocale(SettingsHelper::getLocale());
 

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -52,17 +52,17 @@ def writeInfo(f, obj, lst):
             f.write(f"    QList<SettingInfo> LIST{key};\n")
             writeInfo(f, t["sub"], f"LIST{key}")
         f.write(f"    {lst}.append(SettingInfo {{{json.dumps(name)}, ")
-        desccode = f"QCoreApplication::translate(\"Setting\", {json.dumps(desc)})"
+        desccode = f"tr({json.dumps(desc)})"
         for lang in [ "C++", "Java", "Python" ]:
             if lang in desc:
-                desccode = f"QCoreApplication::translate(\"Setting\", {json.dumps(desc.replace(lang, '%1'))}).arg(\"{lang}\")"
+                desccode = f"tr({json.dumps(desc.replace(lang, '%1'))}).arg(\"{lang}\")"
                 break
         f.write(desccode)
         tempname = typename
         if typename == "QMap":
             final = t["final"]
             tempname = f"QMap:{final}"
-        f.write(f", \"{tempname}\", \"{ui}\", QCoreApplication::translate(\"Setting\", {json.dumps(tip)}), QCoreApplication::translate(\"Setting\", {json.dumps(hlp)}), {json.dumps(requireAllDepends)}, {{{json.dumps(depends)[1:-1]}}}, ")
+        f.write(f", \"{tempname}\", \"{ui}\", tr({json.dumps(tip)}), tr({json.dumps(hlp)}), {json.dumps(requireAllDepends)}, {{{json.dumps(depends)[1:-1]}}}, ")
         if typename != "Object":
             if "default" in t:
                 if typename == "QString":
@@ -132,57 +132,20 @@ namespace SettingsHelper
 
 #endif // SETTINGSHELPER_HPP""")
     setting_helper.close()
-    setting_info = open("generated/SettingsInfo.hpp", mode="w", encoding="utf-8")
-    setting_info.write(head)
-    setting_info.write("""#ifndef SETTINGSINFO_HPP
-#define SETTINGSINFO_HPP
-
-#include <QCoreApplication>
-#include <QFontDatabase>
-#include <QRect>
-#include <QVariant>
-#include "Core/StyleManager.hpp"
-
-struct SettingInfo
-{
-    QString name, desc, type, ui, tip, help;
-    bool requireAllDepends; // false for one of the depends, true for all depends
-    QStringList depends;
-    QVariant def;
-    QVariant param;
-    QList<SettingInfo> child;
-
-    QString key() const
-    {
-        return name.toLower().replace('+', 'p').replace(' ', '_');
-    }
-};
-
-extern QList<SettingInfo> settingInfo;
-
-void updateSettingInfo();
-
-inline SettingInfo findSetting(const QString &name, const QList<SettingInfo> &infos = settingInfo)
-{
-    for (const SettingInfo &si: infos)
-        if (si.name == name)
-            return si;
-    return SettingInfo();
-}
-
-#endif // SETTINGSINFO_HPP""")
-    setting_info.close()
 
     setting_info = open("generated/SettingsInfo.cpp", mode="w", encoding="utf-8")
     setting_info.write(head)
-    setting_info.write("""#include "SettingsInfo.hpp"
+    setting_info.write("""#include "Settings/SettingsInfo.hpp"
+#include <QFontDatabase>
+#include <QRect>
+#include "Core/StyleManager.hpp"
 
-QList<SettingInfo> settingInfo;
+QList<SettingsInfo::SettingInfo> SettingsInfo::settings;
 
-void updateSettingInfo()
+void SettingsInfo::updateSettingInfo()
 {
-    settingInfo.clear();
+    settings.clear();
 """)
-    writeInfo(setting_info, obj, "settingInfo")
+    writeInfo(setting_info, obj, "settings")
     setting_info.write("};\n")
     setting_info.close()

--- a/tools/updateTranslation.sh
+++ b/tools/updateTranslation.sh
@@ -21,5 +21,5 @@ for i in "${DIRS[@]}"; do
 done
 
 for i in zh_CN ru_RU; do
-	lupdate -no-obsolete "${SOURCES[@]}" -locations "$LOCATIONS" -ts translations/$i.ts -I src "${INCS[@]}"
+	lupdate -no-obsolete "${SOURCES[@]}" -locations "$LOCATIONS" -tr-function-alias tr+=TRKEY -ts translations/$i.ts -I src "${INCS[@]}"
 done

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1500,7 +1500,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
 </context>
 <context>
-    <name>Setting</name>
+    <name>SettingsInfo</name>
     <message>
         <source>Tab Width</source>
         <translation type="unfinished"></translation>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1280,6 +1280,21 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
 </context>
 <context>
+    <name>PathItem</name>
+    <message>
+        <source>Excutable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose Excutable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose %1 Sources</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PreferencesHomePage</name>
     <message>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
@@ -2195,21 +2210,6 @@ kill the application with SIGKILL which could not be handled by the application.
     </message>
     <message>
         <source>The time interval between two auto-saves of the current session.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>Settings::PathItem</name>
-    <message>
-        <source>Excutable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Choose Excutable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Choose %1 Sources</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1299,6 +1299,21 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
 </context>
 <context>
+    <name>PathItem</name>
+    <message>
+        <source>Excutable</source>
+        <translation>可执行文件</translation>
+    </message>
+    <message>
+        <source>Choose Excutable</source>
+        <translation>选择可执行文件</translation>
+    </message>
+    <message>
+        <source>Choose %1 Sources</source>
+        <translation>选择 %1 源代码</translation>
+    </message>
+</context>
+<context>
     <name>PreferencesHomePage</name>
     <message>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
@@ -2260,21 +2275,6 @@ kill the application with SIGKILL which could not be handled by the application.
     <message>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>两次自动保存会话之间的时间间隔。</translation>
-    </message>
-</context>
-<context>
-    <name>Settings::PathItem</name>
-    <message>
-        <source>Excutable</source>
-        <translation>可执行文件</translation>
-    </message>
-    <message>
-        <source>Choose Excutable</source>
-        <translation>选择可执行文件</translation>
-    </message>
-    <message>
-        <source>Choose %1 Sources</source>
-        <translation>选择 %1 源代码</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1519,7 +1519,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
 </context>
 <context>
-    <name>Setting</name>
+    <name>SettingsInfo</name>
     <message>
         <source>Tab Width</source>
         <translation>缩进宽度</translation>


### PR DESCRIPTION
##  Description

1. Use `TRKEY` in `PreferencesWindow` to avoid duplicate keys.
2. Convert inline functions in `PathItem` to member functions and use `tr` instead of `QCoreApplication::translate`.
3. Make `SettingsInfo` a class and use `Q_DECLARE_TR_FUNCTIONS` to use `tr` instead of `QCoreApplication::translate`.
4. Move `SettingsInfo.hpp` out of `generated` because it has nothing generated.
5. Remove an extra bracket in `EventLogger` which causes compilation error in platforms other than Linux, Windows and macOS, and causes a warning when updating the translations.

## Motivation and Context

1. Remove duplicates.
2. Use the shorter `tr` instead of the longer `QCoreApplication::translate`.
3. Make `SettingsInfo` more OOP.
4. Fix warnings.

## How Has This Been Tested?

On Arch Linux.

## Type of changes

- [x] Refactor (changes which affect the meaning of the code but neither fix a bug nor add a feature)
