### PR TITLE
feat(PreferencesWindow): Ctrl+Tab and Ctrl+Shift+Tab skip hidden pages

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -28,6 +28,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now the lengths of the files added by "Add Pairs of Testcases From Files" are limited by Preferences->Advanced->Limits->Load Test Case File Length Limit. (#405)
 - The default font is set to the system fixed-width font instead of the font named "Monospace". (#422)
 - Now the session is stored in a separate file, which was stored along with the settings. So now when exporting/importing settings, the session won't be included, but you can export/load the session separately. (#437 and #442)
+- Now the hidden (not in the search result) pages are skipped when navigating pages in the preferences window via Ctrl+Tab and Ctrl+Shift+Tab. (#447)
 
 ## v6.5
 

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -139,6 +139,15 @@ class PreferencesWindow : public QMainWindow
     QTreeWidgetItem *getChild(QTreeWidgetItem *item, const QString &text);
 
     /**
+     * @brief get the index of the next/previous non-hidden page (including the home page)
+     * @param index the index of the current page in the stackedWidget
+     * @param direction either 1 or -1, 1 for the next non-hidden page and -1 for the previous non-hidden-page
+     * @param includingSelf when it's true, the result can be the current page
+     * @returns the index of the (strictly) next/previous non-hidden page in the stackedWidget
+     */
+    int nextNonHiddenPage(int index, int direction = 1, bool includingSelf = false);
+
+    /**
      * The GUI:
      *
      * - splitter


### PR DESCRIPTION
## Description

Skip hidden pages when pressing <kbd>Ctrl+Tab</kbd> or <kbd>Ctrl+Shift+Tab</kbd> in the preferces window.

## Motivation and Context

This can make it easier to navigate the settings via keyboard.

## How Has This Been Tested?

On Arch Linux.