### PR TITLE
feat(UpdateChecker): add proxy support

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -16,6 +16,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Auto-save time interval.
 - Now you can auto-save the current session, besides saving it when the application exists. (#437 and #442)
 - Now the width of the input/output/expected of each test case is adjustable, and the maximum height of a test case can be set in the preferences. (#414 and #444)
+- Now you can use proxy to check for updates. (#448)
 
 ### Fixed
 

--- a/src/Settings/PreferencesPageTemplate.hpp
+++ b/src/Settings/PreferencesPageTemplate.hpp
@@ -19,9 +19,6 @@
 #define PREFERENCESPAGETEMPLATE_HPP
 
 #include "Settings/PreferencesGridPage.hpp"
-#include <QMap>
-
-class QCheckBox;
 
 class PreferencesPageTemplate : public PreferencesGridPage
 {
@@ -38,12 +35,11 @@ class PreferencesPageTemplate : public PreferencesGridPage
     void makeUITheSameAsSettings() override;
     void makeSettingsTheSameAsUI() override;
 
-    void onDependencyUpdated(QWidget *widget, bool requireAllDepends);
+    void onDependencyUpdated(const QString &settingName);
 
   protected:
     QStringList options;
     QVector<ValueWidget *> widgets;
-    QMap<QWidget *, QVector<QCheckBox *>> depends;
 };
 
 #endif // PREFERENCESPAGETEMPLATE_HPP

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -237,6 +237,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
             .page(TRKEY("Update"), {"Check Update", "Beta"})
             .page(TRKEY("Limits"), {"Time Limit", "Output Length Limit", "Message Length Limit", "HTML Diff Viewer Length Limit",
                                  "Open File Length Limit", "Load Test Case File Length Limit"})
+            .page(TRKEY("Network Proxy"), {"Proxy/Enabled", "Proxy/Type", "Proxy/Host Name", "Proxy/Port", "Proxy/User", "Proxy/Password"})
         .end();
 
 #undef TRKEY

--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -20,6 +20,7 @@
 
 #include <QCoreApplication>
 #include <QVariant>
+#include <functional>
 
 class SettingsInfo
 {
@@ -30,7 +31,7 @@ class SettingsInfo
     {
         QString name, desc, type, ui, tip, help;
         bool requireAllDepends; // false for one of the depends, true for all depends
-        QStringList depends;
+        QList<QPair<QString, std::function<bool(const QVariant &)>>> depends;
         QVariant def;
         QVariant param;
         QList<SettingInfo> child;

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -744,5 +744,62 @@
         "default": 300,
         "param": "QVariantList {30, 2000}",
         "tip": "The maximum height of a test case without a scrollbar in pixels."
+    },
+    {
+        "name": "Proxy/Enabled",
+        "desc": "Enable Proxy",
+        "type": "bool",
+        "tip": "Enable proxy for checking updates"
+    },
+    {
+        "name": "Proxy/Type",
+        "desc": "Type",
+        "type": "QString",
+        "default": "Http",
+        "ui": "QComboBox",
+        "param": "QStringList { \"Http\", \"Socks5\" }",
+        "depends": [
+            "Proxy/Enabled"
+        ],
+        "tip": "The type of the proxy"
+    },
+    {
+        "name": "Proxy/Host Name",
+        "desc": "Host Name",
+        "type": "QString",
+        "default": "127.0.0.1",
+        "depends": [
+            "Proxy/Enabled"
+        ],
+        "tip": "The host name of the proxy, e.g. 127.0.0.1"
+    },
+    {
+        "name": "Proxy/Port",
+        "desc": "Port",
+        "type": "int",
+        "default": 1080,
+        "param": "QVariantList {1024,49151}",
+        "depends": [
+            "Proxy/Enabled"
+        ],
+        "tip": "The port of the proxy, e.g. 1080"
+    },
+    {
+        "name": "Proxy/User",
+        "desc": "User",
+        "type": "QString",
+        "depends": [
+            "Proxy/Enabled"
+        ],
+        "tip": "The user of the proxy server. It can be empty if the proxy server doesn't require authentication."
+    },
+    {
+        "name": "Proxy/Password",
+        "desc": "Password",
+        "type": "QString",
+        "depends": [
+            "Proxy/Enabled"
+        ],
+        "tip": "The password of the proxy server. It can be empty if the proxy server doesn't require authentication."
     }
 ]

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -242,7 +242,9 @@
         "default": 1000,
         "param": "QVariantList {100, 36000000}",
         "depends": [
-            "Auto Save"
+            {
+                "name": "Auto Save"
+            }
         ],
         "tip": "The time interval between a modification and an auto-save, or between two auto-saves."
     },
@@ -253,7 +255,9 @@
         "param": "QStringList { \"After the last modification\", \"After the first modification\", \"Without modification\" }",
         "default": "After the last modification",
         "depends": [
-            "Auto Save"
+            {
+                "name": "Auto Save"
+            }
         ],
         "tip": "After the last modification: the timer will be reset after a modification to the code.\nAfter the first modification: the timer will start after a modification, if at that time the timer is not running.\nWithout modification: auto-save happens with an constant inverval no matter there are modifications or not."
     },
@@ -332,7 +336,9 @@
         "default": 10045,
         "param": "QVariantList {1024,49151}",
         "depends": [
-            "Competitive Companion/Enable"
+            {
+                "name": "Competitive Companion/Enable"
+            }
         ],
         "tip": "The port used to receive data from Competitive Companion"
     },
@@ -342,7 +348,9 @@
         "type": "bool",
         "default": true,
         "depends": [
-            "Competitive Companion/Enable"
+            {
+                "name": "Competitive Companion/Enable"
+            }
         ],
         "tip": "Open a new tab for each problem parsed by Competitive Companion."
     },
@@ -400,7 +408,9 @@
         "desc": "Auto-save the current session periodically",
         "type": "bool",
         "depends": [
-            "Hot Exit/Enable"
+            {
+                "name": "Hot Exit/Enable"
+            }
         ],
         "tip": "Auto-save the current session periodically instead of only save when the application exists.\nThis is useful if your computer is frozen and you have to cut off the power or\nkill the application with SIGKILL which could not be handled by the application."
     },
@@ -411,8 +421,12 @@
         "default": 20000,
         "param": "QVariantList {1000, 36000000}",
         "depends": [
-            "Hot Exit/Enable",
-            "Hot Exit/Auto Save"
+            {
+                "name": "Hot Exit/Enable"
+            },
+            {
+                "name": "Hot Exit/Auto Save"
+            }
         ],
         "tip": "The time interval between two auto-saves of the current session."
     },
@@ -501,7 +515,9 @@
         "param": "0",
         "requireAllDepends": false,
         "depends": [
-            "LSP/Use Linting C++"
+            {
+                "name": "LSP/Use Linting C++"
+            }
         ],
         "tip": "The path to the C++ Language Server executable"
     },
@@ -513,7 +529,9 @@
         "param": "0",
         "requireAllDepends": false,
         "depends": [
-            "LSP/Use Linting Java"
+            {
+                "name": "LSP/Use Linting Java"
+            }
         ],
         "tip": "The path to the Java Language Server executable"
     },
@@ -526,7 +544,9 @@
         "param": "0",
         "requireAllDepends": false,
         "depends": [
-            "LSP/Use Linting Python"
+            {
+                "name": "LSP/Use Linting Python"
+            }
         ],
         "tip": "The path to the Python Language Server executable"
     },
@@ -573,7 +593,9 @@
         "default": 2000,
         "param": "QVariantList {10, 3600000}",
         "depends": [
-            "LSP/Use Linting C++"
+            {
+                "name": "LSP/Use Linting C++"
+            }
         ],
         "tip": "Delay in linting in miliseconds after last modification to code"
     },
@@ -584,7 +606,9 @@
         "default": 2000,
         "param": "QVariantList {10, 3600000}",
         "depends": [
-            "LSP/Use Linting Java"
+            {
+                "name": "LSP/Use Linting Java"
+            }
         ],
         "tip": "Delay in linting in miliseconds after last modification to code"
     },
@@ -595,7 +619,9 @@
         "default": 2000,
         "param": "QVariantList {10, 3600000}",
         "depends": [
-            "LSP/Use Linting Python"
+            {
+                "name": "LSP/Use Linting Python"
+            }
         ],
         "tip": "Delay in linting in miliseconds after last modification to code"
     },
@@ -605,7 +631,9 @@
         "type": "QString",
         "requireAllDepends": false,
         "depends": [
-            "LSP/Use Linting C++"
+            {
+                "name": "LSP/Use Linting C++"
+            }
         ],
         "tip": "Arguments to pass to Language server executable"
     },
@@ -615,7 +643,9 @@
         "type": "QString",
         "requireAllDepends": false,
         "depends": [
-            "LSP/Use Linting Java"
+            {
+                "name": "LSP/Use Linting Java"
+            }
         ],
         "tip": "Arguments to pass to Language server executable"
     },
@@ -626,7 +656,9 @@
         "type": "QString",
         "requireAllDepends": false,
         "depends": [
-            "LSP/Use Linting Python"
+            {
+                "name": "LSP/Use Linting Python"
+            }
         ],
         "tip": "Arguments to pass to Language server executable"
     },
@@ -759,7 +791,9 @@
         "ui": "QComboBox",
         "param": "QStringList { \"Http\", \"Socks5\" }",
         "depends": [
-            "Proxy/Enabled"
+            {
+                "name": "Proxy/Enabled"
+            }
         ],
         "tip": "The type of the proxy"
     },
@@ -769,7 +803,9 @@
         "type": "QString",
         "default": "127.0.0.1",
         "depends": [
-            "Proxy/Enabled"
+            {
+                "name": "Proxy/Enabled"
+            }
         ],
         "tip": "The host name of the proxy, e.g. 127.0.0.1"
     },
@@ -780,7 +816,9 @@
         "default": 1080,
         "param": "QVariantList {1024,49151}",
         "depends": [
-            "Proxy/Enabled"
+            {
+                "name": "Proxy/Enabled"
+            }
         ],
         "tip": "The port of the proxy, e.g. 1080"
     },
@@ -789,7 +827,9 @@
         "desc": "User",
         "type": "QString",
         "depends": [
-            "Proxy/Enabled"
+            {
+                "name": "Proxy/Enabled"
+            }
         ],
         "tip": "The user of the proxy server. It can be empty if the proxy server doesn't require authentication."
     },
@@ -798,7 +838,9 @@
         "desc": "Password",
         "type": "QString",
         "depends": [
-            "Proxy/Enabled"
+            {
+                "name": "Proxy/Enabled"
+            }
         ],
         "tip": "The password of the proxy server. It can be empty if the proxy server doesn't require authentication."
     }

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -781,21 +781,22 @@
         "name": "Proxy/Enabled",
         "desc": "Enable Proxy",
         "type": "bool",
+        "default": "true",
         "tip": "Enable proxy for checking updates"
     },
     {
         "name": "Proxy/Type",
         "desc": "Type",
         "type": "QString",
-        "default": "Http",
+        "default": "System",
         "ui": "QComboBox",
-        "param": "QStringList { \"Http\", \"Socks5\" }",
+        "param": "QStringList { \"System\", \"Http\", \"Socks5\" }",
         "depends": [
             {
                 "name": "Proxy/Enabled"
             }
         ],
-        "tip": "The type of the proxy"
+        "tip": "The type of the proxy. \"System\" for using the system proxy."
     },
     {
         "name": "Proxy/Host Name",
@@ -805,6 +806,10 @@
         "depends": [
             {
                 "name": "Proxy/Enabled"
+            },
+            {
+                "name": "Proxy/Type",
+                "check": "return var.toString() != \"System\";"
             }
         ],
         "tip": "The host name of the proxy, e.g. 127.0.0.1"
@@ -818,6 +823,10 @@
         "depends": [
             {
                 "name": "Proxy/Enabled"
+            },
+            {
+                "name": "Proxy/Type",
+                "check": "return var.toString() != \"System\";"
             }
         ],
         "tip": "The port of the proxy, e.g. 1080"
@@ -829,6 +838,10 @@
         "depends": [
             {
                 "name": "Proxy/Enabled"
+            },
+            {
+                "name": "Proxy/Type",
+                "check": "return var.toString() != \"System\";"
             }
         ],
         "tip": "The user of the proxy server. It can be empty if the proxy server doesn't require authentication."
@@ -840,6 +853,10 @@
         "depends": [
             {
                 "name": "Proxy/Enabled"
+            },
+            {
+                "name": "Proxy/Type",
+                "check": "return var.toString() != \"System\";"
             }
         ],
         "tip": "The password of the proxy server. It can be empty if the proxy server doesn't require authentication."

--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -139,14 +139,16 @@ void UpdateChecker::managerFinished(QNetworkReply *reply)
     auto latestInfo = releases.last().second;
     Version currentVersion(APP_VERSION);
 
-    if (latestInfo.assetDownloadUrl.isEmpty())
-    {
-        LOG_INFO("No download URL");
-        progress->onUpdateFailed(tr("No download URL of the version [%1] is found.").arg(latestInfo.version));
-    }
-    else if (currentVersion < latestVersion)
+    if (currentVersion < latestVersion)
     {
         LOG_INFO("Update available");
+
+        if (latestInfo.assetDownloadUrl.isEmpty())
+        {
+            LOG_INFO("No download URL");
+            progress->onUpdateFailed(tr("No download URL of the version [%1] is found.").arg(latestInfo.version));
+        }
+
         auto last = currentVersion;
         QStringList changelog;
         for (auto release : releases)

--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -212,7 +212,7 @@ void UpdateChecker::updateProxy()
         manager->setProxy(proxy);
     }
     else
-        manager->setProxy({QNetworkProxy::NoProxy});
+        manager->setProxy({QNetworkProxy::DefaultProxy});
 }
 
 UpdateChecker::Version::Version(const QString &version)

--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -200,21 +200,28 @@ void UpdateChecker::closeAll()
 
 void UpdateChecker::updateProxy()
 {
-    if (SettingsHelper::isProxyEnabled())
+    if (!SettingsHelper::isProxyEnabled())
+        manager->setProxy({QNetworkProxy::NoProxy});
+    else if (SettingsHelper::getProxyType() == "System")
+        manager->setProxy({QNetworkProxy::DefaultProxy});
+    else
     {
         QNetworkProxy proxy;
         if (SettingsHelper::getProxyType() == "Http")
             proxy.setType(QNetworkProxy::HttpProxy);
         else if (SettingsHelper::getProxyType() == "Socks5")
             proxy.setType(QNetworkProxy::Socks5Proxy);
+        else
+        {
+            LOG_WTF("Unknown proxy type: " << SettingsHelper::getProxyType());
+            proxy.setType(QNetworkProxy::DefaultProxy);
+        }
         proxy.setHostName(SettingsHelper::getProxyHostName());
         proxy.setPort(SettingsHelper::getProxyPort());
         proxy.setUser(SettingsHelper::getProxyUser());
         proxy.setPassword(SettingsHelper::getProxyPassword());
         manager->setProxy(proxy);
     }
-    else
-        manager->setProxy({QNetworkProxy::DefaultProxy});
 }
 
 UpdateChecker::Version::Version(const QString &version)

--- a/src/Telemetry/UpdateChecker.hpp
+++ b/src/Telemetry/UpdateChecker.hpp
@@ -68,6 +68,7 @@ class UpdateChecker : public QObject
         bool operator<(const Version &rhs) const;
     };
 
+    void updateProxy();
     UpdateMetaInformation toMetaInformation(const QJsonDocument &release);
 
     Widgets::UpdateProgressDialog *progress = nullptr;

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -4,6 +4,7 @@
 import sys
 import json
 
+
 def writeHelper(f, obj, pre, indent):
     ids = "    " * indent
     for t in obj:
@@ -16,7 +17,8 @@ def writeHelper(f, obj, pre, indent):
             f.write(f"{ids}    {key}(QString p) : pre(p) {{}}\n")
             writeHelper(f, t["sub"], "pre, ", indent + 1)
             f.write(f"{ids}}};\n")
-            f.write(f"{ids}inline {key} get{key}(QString key) {{ return {key}(QStringList {{{pre} {json.dumps(name)}, key}}.join('/')); }}\n")
+            f.write(
+                f"{ids}inline {key} get{key}(QString key) {{ return {key}(QStringList {{{pre} {json.dumps(name)}, key}}.join('/')); }}\n")
             f.write(f"{ids}inline void remove{key}(QString key) {{ SettingsManager::remove(SettingsManager::keyStartsWith(QStringList {{{pre} {json.dumps(name)}, key}}.join('/'))); }}\n")
             f.write(f"{ids}inline QStringList query{key}() {{ return SettingsManager::itemUnder(QStringList {{{pre} {json.dumps(name)}}}.join('/') + '/'); }}\n")
         elif typename == "QMap":
@@ -37,6 +39,7 @@ def writeHelper(f, obj, pre, indent):
                 f.write(
                     f"{ids}inline {typename} get{key}() {{ return SettingsManager::get({json.dumps(name)}).value<{typename}>(); }}\n")
 
+
 def writeInfo(f, obj, lst):
     for t in obj:
         name = t["name"]
@@ -53,7 +56,7 @@ def writeInfo(f, obj, lst):
             writeInfo(f, t["sub"], f"LIST{key}")
         f.write(f"    {lst}.append(SettingInfo {{{json.dumps(name)}, ")
         desccode = f"tr({json.dumps(desc)})"
-        for lang in [ "C++", "Java", "Python" ]:
+        for lang in ["C++", "Java", "Python"]:
             if lang in desc:
                 desccode = f"tr({json.dumps(desc.replace(lang, '%1'))}).arg(\"{lang}\")"
                 break
@@ -62,7 +65,11 @@ def writeInfo(f, obj, lst):
         if typename == "QMap":
             final = t["final"]
             tempname = f"QMap:{final}"
-        f.write(f", \"{tempname}\", \"{ui}\", tr({json.dumps(tip)}), tr({json.dumps(hlp)}), {json.dumps(requireAllDepends)}, {{{json.dumps(depends)[1:-1]}}}, ")
+        dependsString = "{"
+        for depend in depends:
+            dependsString += f"{{{json.dumps(depend.get('name', ''))}, [](const QVariant &var) {{ {depend.get('check', 'return var.toBool();')} }}}}, "
+        dependsString += "}"
+        f.write(f", \"{tempname}\", \"{ui}\", tr({json.dumps(tip)}), tr({json.dumps(hlp)}), {json.dumps(requireAllDepends)}, {dependsString}, ")
         if typename != "Object":
             if "default" in t:
                 if typename == "QString":
@@ -90,6 +97,7 @@ def writeInfo(f, obj, lst):
             f.write(f", LIST{key}")
         f.write("});\n")
 
+
 if __name__ == "__main__":
     obj = json.load(open(sys.argv[1], mode="r", encoding="utf-8"))
     head = """/*
@@ -114,7 +122,8 @@ if __name__ == "__main__":
  */
 
 """
-    setting_helper = open("generated/SettingsHelper.hpp", mode="w", encoding="utf-8")
+    setting_helper = open("generated/SettingsHelper.hpp",
+                          mode="w", encoding="utf-8")
     setting_helper.write(head)
     setting_helper.write("""#ifndef SETTINGSHELPER_HPP
 #define SETTINGSHELPER_HPP
@@ -133,7 +142,8 @@ namespace SettingsHelper
 #endif // SETTINGSHELPER_HPP""")
     setting_helper.close()
 
-    setting_info = open("generated/SettingsInfo.cpp", mode="w", encoding="utf-8")
+    setting_info = open("generated/SettingsInfo.cpp",
+                        mode="w", encoding="utf-8")
     setting_info.write(head)
     setting_info.write("""#include "Settings/SettingsInfo.hpp"
 #include <QFontDatabase>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2233,10 +2233,6 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The type of the proxy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The host name of the proxy, e.g. 127.0.0.1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2270,6 +2266,10 @@ kill the application with SIGKILL which could not be handled by the application.
     </message>
     <message>
         <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1498,6 +1498,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Empty Test Cases</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Network Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -2218,6 +2222,54 @@ kill the application with SIGKILL which could not be handled by the application.
     </message>
     <message>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable proxy for checking updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The type of the proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The host name of the proxy, e.g. 127.0.0.1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The port of the proxy, e.g. 1080</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2297,10 +2297,6 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation>检查更新时启用代理</translation>
     </message>
     <message>
-        <source>The type of the proxy</source>
-        <translation>代理的类型</translation>
-    </message>
-    <message>
         <source>The host name of the proxy, e.g. 127.0.0.1</source>
         <translation>代理的主机名，例如：127.0.0.1</translation>
     </message>
@@ -2335,6 +2331,10 @@ kill the application with SIGKILL which could not be handled by the application.
     <message>
         <source>Password</source>
         <translation>密码</translation>
+    </message>
+    <message>
+        <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
+        <translation>代理的类型。类型 &quot;System&quot; 会使用系统代理设置。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1517,6 +1517,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Empty Test Cases</source>
         <translation>空测试点</translation>
     </message>
+    <message>
+        <source>Network Proxy</source>
+        <translation>网络代理</translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -2283,6 +2287,54 @@ kill the application with SIGKILL which could not be handled by the application.
     <message>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>无需滚动条时一个测试用例的最大高度，以像素为单位。</translation>
+    </message>
+    <message>
+        <source>Enable Proxy</source>
+        <translation>启用代理</translation>
+    </message>
+    <message>
+        <source>Enable proxy for checking updates</source>
+        <translation>检查更新时启用代理</translation>
+    </message>
+    <message>
+        <source>The type of the proxy</source>
+        <translation>代理的类型</translation>
+    </message>
+    <message>
+        <source>The host name of the proxy, e.g. 127.0.0.1</source>
+        <translation>代理的主机名，例如：127.0.0.1</translation>
+    </message>
+    <message>
+        <source>The port of the proxy, e.g. 1080</source>
+        <translation>代理的端口，例如：1080</translation>
+    </message>
+    <message>
+        <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
+        <translation>代理的用户名。若代理服务器不需要认证则可以留空。</translation>
+    </message>
+    <message>
+        <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
+        <translation>代理的密码。若代理服务器不需要认证则可以留空。</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>类型</translation>
+    </message>
+    <message>
+        <source>Host Name</source>
+        <translation>主机名</translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <source>User</source>
+        <translation>用户名</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>密码</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

Now you can use proxy to check for updates.

## Motivation and Context

In some countries, it's easier to check for updates via proxy.

## How Has This Been Tested?

On Arch Linux, with clash and both Http and Socks5 proxy.