### PR TITLE
feat(UpdateChecker): add a guide to install OpenSSL

### DIFF
--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -103,7 +103,16 @@ void UpdateChecker::managerFinished(QNetworkReply *reply)
     if (reply->error())
     {
         LOG_ERR(INFO_OF(reply->errorString()));
-        progress->onUpdateFailed(reply->errorString());
+        auto error = reply->errorString();
+        if (error.contains("TLS initialization failed"))
+        {
+            error += "<br /><br />" +
+                     tr("This error is probably caused by the lack of the OpenSSL library. You can visit "
+                        "<a href=\"https://wiki.openssl.org/index.php/Binaries\">the OpenSSLWiki</a> to find a binary "
+                        "to install, or install it via your favourite package manager. Try using different versions "
+                        "of OpenSSL if this still happens after the installation.");
+        }
+        progress->onUpdateFailed(error);
         return;
     }
 

--- a/src/Widgets/UpdateProgressDialog.cpp
+++ b/src/Widgets/UpdateProgressDialog.cpp
@@ -32,6 +32,7 @@ UpdateProgressDialog::UpdateProgressDialog()
     progressBar->setMinimumWidth(width());
 
     information = new QLabel(this);
+    information->setWordWrap(true);
 
     cancelUpdate = new QPushButton(tr("Cancel"), this);
     cancelUpdate->setToolTip(tr("Close this dialog and abort the update check"));

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2281,6 +2281,10 @@ kill the application with SIGKILL which could not be handled by the application.
         <source>No download URL of the version [%1] is found.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. Try using different versions of OpenSSL if this still happens after the installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Util::FileUtil</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2345,6 +2345,10 @@ kill the application with SIGKILL which could not be handled by the application.
         <source>No download URL of the version [%1] is found.</source>
         <translation>没有发现版本 [%1] 可用的下载链接。</translation>
     </message>
+    <message>
+        <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. Try using different versions of OpenSSL if this still happens after the installation.</source>
+        <translation>这个错误很可能是缺失 OpenSSL 库导致的。你可以访问 &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; 来获取 OpenSSL 的下载地址，或使用你喜欢的包管理器来安装。若安装后问题依然存在，请尝试使用不同版本的 OpenSSL。</translation>
+    </message>
 </context>
 <context>
     <name>Util::FileUtil</name>


### PR DESCRIPTION
## Description

Add a guide to install OpenSSL when the "TLS initialization failed" error happens in the update checker.

## Related Issue

This fixes #449.

## Motivation and Context

1. The user will be unable to check for updates in the application without OpenSSL.
2. It's hard and insecure to bundle the OpenSSL in the binary release, because OpenSSL is security-related, if we bundle it, it's hard to fix security problems. This is also why linuxdeployqt doesn't bundle OpenSSL in the AppImage (linuxdeploy/linuxdeploy-plugin-qt#57).
