### PR TITLE
feat(Settings): add settings for custom application font

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now you can auto-save the current session, besides saving it when the application exists. (#437 and #442)
 - Now the width of the input/output/expected of each test case is adjustable, and the maximum height of a test case can be set in the preferences. (#414 and #444)
 - Now you can use proxy to check for updates. (#448)
+- Now you can set a custom font for the whole application. (#169 and #453)
 
 ### Fixed
 

--- a/src/Settings/AppearancePage.cpp
+++ b/src/Settings/AppearancePage.cpp
@@ -25,7 +25,8 @@
 AppearancePage::AppearancePage(QWidget *parent)
     : PreferencesPageTemplate({"Locale", "UI Style", "Editor Theme", "Editor Font", "Test Cases Font",
                                "Message Logger Font", "Opacity", "Test Case Maximum Height",
-                               "Show Compile And Run Only", "Display EOLN In Diff", "Extra Bottom Margin"},
+                               "Show Compile And Run Only", "Display EOLN In Diff", "Extra Bottom Margin",
+                               "Use Custom Application Font", "Custom Application Font"},
                               true, parent)
 {
 }

--- a/src/Settings/FontItem.cpp
+++ b/src/Settings/FontItem.cpp
@@ -17,20 +17,13 @@
 
 #include "Settings/FontItem.hpp"
 #include <QFontDialog>
+#include <QVariant>
 
-FontItem::FontItem(QWidget *parent) : QPushButton(parent)
+FontItem::FontItem(QWidget *parent, const QVariant &param) : QPushButton(parent)
 {
     Q_ASSERT(parent != nullptr);
+    monospace = param.toBool();
     connect(this, SIGNAL(clicked(bool)), this, SLOT(onButtonClicked()));
-}
-
-void FontItem::setFont(const QString &desc)
-{
-    QFont newFont;
-    if (newFont.fromString(desc))
-    {
-        setFont(newFont);
-    }
 }
 
 void FontItem::setFont(QFont newFont)
@@ -38,9 +31,12 @@ void FontItem::setFont(QFont newFont)
     if (newFont != font)
     {
         font = newFont;
-        setText(QString("%1 %2").arg(font.family()).arg(font.pointSize()));
         emit fontChanged(font);
     }
+
+    // out of the if statement, because it's useful if this function is called for the first time and the newFont is the
+    // default font
+    setText(QString("%1 %2").arg(font.family()).arg(font.pointSize()));
 }
 
 QFont FontItem::getFont()
@@ -51,7 +47,8 @@ QFont FontItem::getFont()
 void FontItem::onButtonClicked()
 {
     bool ok;
-    QFont newFont = QFontDialog::getFont(&ok, font, this, QString(), QFontDialog::MonospacedFonts);
+    QFont newFont = QFontDialog::getFont(&ok, font, this, QString(),
+                                         monospace ? QFontDialog::MonospacedFonts : QFontDialog::FontDialogOption());
     if (ok)
         setFont(newFont);
     parentWidget()->raise();

--- a/src/Settings/FontItem.hpp
+++ b/src/Settings/FontItem.hpp
@@ -28,9 +28,8 @@ class FontItem : public QPushButton
 {
     Q_OBJECT
   public:
-    explicit FontItem(QWidget *parent);
+    explicit FontItem(QWidget *parent, const QVariant &param);
 
-    void setFont(const QString &desc);
     void setFont(QFont newFont);
     QFont getFont();
 
@@ -41,6 +40,7 @@ class FontItem : public QPushButton
     void onButtonClicked();
 
   private:
+    bool monospace;
     QFont font;
 };
 

--- a/src/Settings/ValueWrapper.cpp
+++ b/src/Settings/ValueWrapper.cpp
@@ -223,9 +223,9 @@ void SliderWrapper::set(int i)
     qobject_cast<QSlider *>(widget)->setValue(i);
 }
 
-void FontItemWrapper::init(QWidget *parent, QVariant)
+void FontItemWrapper::init(QWidget *parent, QVariant param)
 {
-    FontItem *item = new FontItem(parent);
+    FontItem *item = new FontItem(parent, param);
     connect(item, &FontItem::fontChanged, this, &ValueWidget::emitSignal);
     widget = item;
 }

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -14,7 +14,25 @@
         "name": "Editor Font",
         "type": "QFont",
         "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
+        "param": "true",
         "tip": "The font of the code editor"
+    },
+    {
+        "name": "Use Custom Application Font",
+        "type": "bool",
+        "tip": "Use a custom font for the whole application instead of the default system font."
+    },
+    {
+        "name": "Custom Application Font",
+        "type": "QFont",
+        "default": "QFontDatabase::systemFont(QFontDatabase::GeneralFont)",
+        "param": "false",
+        "depends": [
+            {
+                "name": "Use Custom Application Font"
+            }
+        ],
+        "tip": "The custom font for the whole application"
     },
     {
         "name": "Default Language",
@@ -692,6 +710,7 @@
         "name": "Test Cases Font",
         "type": "QFont",
         "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
+        "param": "true",
         "tip": "The font of test cases"
     },
     {
@@ -704,6 +723,7 @@
         "name": "Message Logger Font",
         "type": "QFont",
         "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
+        "param": "true",
         "tip": "The font of the message logger"
     },
     {

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -37,6 +37,7 @@
 #include <QDesktopServices>
 #include <QDragEnterEvent>
 #include <QFileDialog>
+#include <QFontDatabase>
 #include <QInputDialog>
 #include <QJsonDocument>
 #include <QMessageBox>
@@ -989,6 +990,10 @@ void AppWindow::onSettingsApplied(const QString &pagePath)
     {
         setWindowOpacity(SettingsHelper::getOpacity() / 100.0);
         Core::StyleManager::setStyle(SettingsHelper::getUIStyle());
+        if (SettingsHelper::isUseCustomApplicationFont())
+            qApp->setFont(SettingsHelper::getCustomApplicationFont());
+        else
+            qApp->setFont(QFontDatabase::systemFont(QFontDatabase::GeneralFont));
     }
 
     if (pagePath.isEmpty() || pagePath == "Extensions/Language Server/C++ Server")

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2272,6 +2272,22 @@ kill the application with SIGKILL which could not be handled by the application.
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use Custom Application Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use a custom font for the whole application instead of the default system font.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Application Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The custom font for the whole application</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2336,6 +2336,22 @@ kill the application with SIGKILL which could not be handled by the application.
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>代理的类型。类型 &quot;System&quot; 会使用系统代理设置。</translation>
     </message>
+    <message>
+        <source>Use Custom Application Font</source>
+        <translation>使用自定义的全局字体</translation>
+    </message>
+    <message>
+        <source>Use a custom font for the whole application instead of the default system font.</source>
+        <translation>使用一个自定义的字体作为整个 CP Editor 的字体，而非使用默认的系统字体。</translation>
+    </message>
+    <message>
+        <source>Custom Application Font</source>
+        <translation>自定义全局字体</translation>
+    </message>
+    <message>
+        <source>The custom font for the whole application</source>
+        <translation>整个 CP Editor 使用的自定义字体</translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>


### PR DESCRIPTION
## Description

Now you can set a custom font for the whole application.

## Related Issue

This closes #169.

## Motivation and Context

On (my) Windows (with Chinese locale), the default font (SimSun) is not good-looking, and other applications are not using that font. I guess Qt gets the default font from a wrong place. I'm not sure what the reason actually is, but we can solve it by providing the custom application font option.

## How Has This Been Tested?

Tested on Arch Linux with KDE and Windows 10.