### PR TITLE
feat(menu): add a link to issues in the main menu

### DIFF
--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -543,7 +543,7 @@ void AppWindow::on_actionManual_triggered()
         QUrl(tr("https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL.md").arg(APP_VERSION), QUrl::TolerantMode));
 }
 
-void AppWindow::on_action_troubleshooting_triggered()
+void AppWindow::on_action_report_issues_triggered()
 {
     QDesktopServices::openUrl(QUrl("https://github.com/cpeditor/cpeditor/issues", QUrl::TolerantMode));
 }

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -543,6 +543,11 @@ void AppWindow::on_actionManual_triggered()
         QUrl(tr("https://github.com/cpeditor/cpeditor/blob/%1/doc/MANUAL.md").arg(APP_VERSION), QUrl::TolerantMode));
 }
 
+void AppWindow::on_action_troubleshooting_triggered()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/cpeditor/cpeditor/issues", QUrl::TolerantMode));
+}
+
 void AppWindow::on_actionAbout_triggered()
 {
     QMessageBox::about(

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -80,7 +80,7 @@ class AppWindow : public QMainWindow
 
     void on_actionManual_triggered();
 
-    void on_action_troubleshooting_triggered();
+    void on_action_report_issues_triggered();
 
     void on_actionAbout_triggered();
 

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -80,6 +80,8 @@ class AppWindow : public QMainWindow
 
     void on_actionManual_triggered();
 
+    void on_action_troubleshooting_triggered();
+
     void on_actionAbout_triggered();
 
     void on_actionAboutQt_triggered();

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -543,6 +543,10 @@
         <source>CP Editor Session File</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Troubleshooting</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AppearancePage</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -544,7 +544,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Troubleshooting</source>
+        <source>Report issues</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -544,7 +544,7 @@
         <translation>CP Editor 会话文件</translation>
     </message>
     <message>
-        <source>Troubleshooting</source>
+        <source>Report issues</source>
         <translation>报告问题</translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -543,6 +543,10 @@
         <source>CP Editor Session File</source>
         <translation>CP Editor 会话文件</translation>
     </message>
+    <message>
+        <source>Troubleshooting</source>
+        <translation>报告问题</translation>
+    </message>
 </context>
 <context>
     <name>AppearancePage</name>

--- a/ui/appwindow.ui
+++ b/ui/appwindow.ui
@@ -125,7 +125,7 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="actionManual"/>
-    <addaction name="action_troubleshooting"/>
+    <addaction name="action_report_issues"/>
     <addaction name="actionAbout"/>
     <addaction name="actionAboutQt"/>
     <addaction name="actionBuildInfo"/>
@@ -415,9 +415,9 @@
     <string>Manual</string>
    </property>
   </action>
-  <action name="action_troubleshooting">
+  <action name="action_report_issues">
    <property name="text">
-    <string>Troubleshooting</string>
+    <string>Report issues</string>
    </property>
   </action>
   <action name="actionAbout">

--- a/ui/appwindow.ui
+++ b/ui/appwindow.ui
@@ -125,6 +125,7 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="actionManual"/>
+    <addaction name="action_troubleshooting"/>
     <addaction name="actionAbout"/>
     <addaction name="actionAboutQt"/>
     <addaction name="actionBuildInfo"/>
@@ -412,6 +413,11 @@
   <action name="actionManual">
    <property name="text">
     <string>Manual</string>
+   </property>
+  </action>
+  <action name="action_troubleshooting">
+   <property name="text">
+    <string>Troubleshooting</string>
    </property>
   </action>
   <action name="actionAbout">


### PR DESCRIPTION
## Description

Add a link to issues in the main menu for troubleshooting.

## Motivation and Context

Now many users are still writing comments in the CF blog instead of opening issues, hopefully this link in the menu can make more users open issues instead of asking elsewhere.

The user can also be redirected to FAQ/Manual/Telegram/Slack because of the new issue page:

![image](https://user-images.githubusercontent.com/30581822/85935674-20e51000-b926-11ea-81e0-d8f6e8f5123f.png)
