### PR TITLE
feat(Compiler): add a warning when failed to start compilation

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -19,6 +19,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now you can use proxy to check for updates. (#448)
 - Now you can set a custom font for the whole application. (#169 and #453)
 - Now Java programmers can use a public class as your main class. (#459 and #461)
+- A warning when it failed to start compilation. (#463)
 
 ### Fixed
 

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -28,8 +28,7 @@
 #define COMPILER_HPP
 
 #include <QObject>
-
-class QProcess;
+#include <QProcess>
 
 namespace Core
 {
@@ -108,6 +107,8 @@ class Compiler : public QObject
      * @param the exit code of the compilation process
      */
     void onProcessFinished(int exitCode);
+
+    void onProcessErrorOccurred(QProcess::ProcessError error);
 
   private:
     QProcess *compileProcess = nullptr; // the compilation process

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -722,6 +722,10 @@
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Failed to start compilation. Please check the compile command in the settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Core::Runner</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -725,6 +725,10 @@
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>编程语言“%1”不受支持</translation>
     </message>
+    <message>
+        <source>Failed to start compilation. Please check the compile command in the settings.</source>
+        <translation>未能成功启动编译。请在设置中检查编译命令。</translation>
+    </message>
 </context>
 <context>
     <name>Core::Runner</name>


### PR DESCRIPTION
## Description

Add a warning when failed to start compilation.

There was no message when it failed to start the compilation process.

## How has this been tested?

On Arch Linux.