### PR TITLE
build(aur): use Ninja to build

### DIFF
--- a/.ci/aur/git/.SRCINFO
+++ b/.ci/aur/git/.SRCINFO
@@ -7,6 +7,7 @@ pkgbase = cpeditor-git
 	license = GPL3
 	makedepends = cmake
 	makedepends = git
+	makedepends = ninja
 	makedepends = python3
 	makedepends = qt5-tools
 	depends = qt5-base>=5.15.0

--- a/.ci/aur/git/PKGBUILD
+++ b/.ci/aur/git/PKGBUILD
@@ -12,6 +12,7 @@ depends=('qt5-base>=5.15.0')
 makedepends=(
 	"cmake"
 	"git"
+	"ninja"
 	"python3"
 	"qt5-tools"
 )
@@ -54,11 +55,11 @@ prepare() {
 
 build() {
 	cd "$_pkgname"
-	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr
+	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DPORTABLE_VERSION=Off -DCMAKE_BUILD_TYPE=Release -GNinja
 	cmake --build build -j$(nproc)
 }
 
 package() {
 	cd "$_pkgname/build"
-	make DESTDIR="$pkgdir" install
+	DESTDIR="$pkgdir/" ninja install
 }

--- a/.ci/aur/stable/.SRCINFO
+++ b/.ci/aur/stable/.SRCINFO
@@ -7,6 +7,7 @@ pkgbase = cpeditor
 	license = GPL3
 	makedepends = cmake
 	makedepends = git
+	makedepends = ninja
 	makedepends = python3
 	makedepends = qt5-tools
 	depends = qt5-base>=5.15.0

--- a/.ci/aur/stable/PKGBUILD
+++ b/.ci/aur/stable/PKGBUILD
@@ -12,6 +12,7 @@ depends=('qt5-base>=5.15.0')
 makedepends=(
 	"cmake"
 	"git"
+	"ninja"
 	"python3"
 	"qt5-tools"
 )

--- a/.ci/aur/stable/PKGBUILD
+++ b/.ci/aur/stable/PKGBUILD
@@ -29,11 +29,11 @@ sha256sums=('SKIP')
 
 build() {
 	cd "$_pkgdir"
-	cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=/usr
+	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=/usr -DPORTABLE_VERSION=Off -DCMAKE_BUILD_TYPE=Release -GNinja
 	cmake --build build -j$(nproc)
 }
 
 package() {
 	cd "$_pkgdir/build"
-	make DESTDIR="$pkgdir" install
+	DESTDIR="$pkgdir/" ninja install
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,16 @@ else()
   message(STATUS "Will build the setup version")
 endif()
 
+# https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949
+option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." On)
+if(${FORCE_COLORED_OUTPUT})
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options(-fdiagnostics-color=always)
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    add_compile_options(-fcolor-diagnostics)
+  endif()
+endif()
+
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git)
   if(GIT_FOUND)


### PR DESCRIPTION
## Description

Use Ninja to build in the PKBUILD for AUR.

## Motivation and Context

1. Ninja doesn't spam in the terminal like `make`.
2. It is a little bit faster.

## How Has This Been Tested?

Used `makepkg -si` to install the PKGBUILD.