### PR TITLE
feat: use mouse wheel to change the font

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -20,6 +20,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now you can set a custom font for the whole application. (#169 and #453)
 - Now Java programmers can use a public class as your main class. (#459 and #461)
 - A warning when it failed to start compilation. (#463)
+- Now you can use the mouse wheel to change the font of the code editor. (#475)
 
 ### Fixed
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -370,6 +370,7 @@ void AppWindow::openTab(const QString &path)
             SLOT(onEditorTmpPathChanged(MainWindow *, const QString &)));
     connect(fsp, SIGNAL(editorLanguageChanged(MainWindow *)), this, SLOT(onEditorLanguageChanged(MainWindow *)));
     connect(fsp, SIGNAL(editorTextChanged(MainWindow *)), this, SLOT(onEditorTextChanged(MainWindow *)));
+    connect(fsp, &MainWindow::editorFontChanged, this, [this] { onSettingsApplied("Appearance"); });
     connect(fsp, SIGNAL(requestToastMessage(const QString &, const QString &)), trayIcon,
             SLOT(showMessage(const QString &, const QString &)));
     connect(fsp, SIGNAL(compileOrRunTriggered()), this, SLOT(onCompileOrRunTriggered()));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -109,6 +109,7 @@ void MainWindow::setEditor()
     ui->editorArea->addWidget(editor);
 
     connect(editor, SIGNAL(textChanged()), this, SLOT(onTextChanged()));
+    connect(editor, SIGNAL(fontChanged(const QFont &)), this, SLOT(onEditorFontChanged(const QFont &)));
 
     // cursorPositionChanged() does not imply selectionChanged() if you press Left with
     // a selection (and the cursor is at the begin of the selection)
@@ -1087,6 +1088,12 @@ void MainWindow::onTextChanged()
         autoSaveTimer->start();
     }
     emit editorTextChanged(this);
+}
+
+void MainWindow::onEditorFontChanged(const QFont &newFont)
+{
+    SettingsHelper::setEditorFont(newFont);
+    emit editorFontChanged();
 }
 
 void MainWindow::updateCursorInfo()

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -133,6 +133,7 @@ class MainWindow : public QMainWindow
     void onRunKilled(int index);
 
     void onFileWatcherChanged(const QString &);
+    void onEditorFontChanged(const QFont &newFont);
     void onTextChanged();
     void updateCursorInfo();
     void updateChecker();
@@ -154,6 +155,7 @@ class MainWindow : public QMainWindow
     void editorFileChanged();
     void editorTmpPathChanged(MainWindow *window, const QString &path);
     void editorTextChanged(MainWindow *window);
+    void editorFontChanged();
     void confirmTriggered(MainWindow *widget);
     void requestToastMessage(const QString &head, const QString &body);
     void editorLanguageChanged(MainWindow *window);


### PR DESCRIPTION
## Description

Use the mouse wheel to change the font of code editors. The change is saved in the settings if the changed editor is in a MainWindow (not in a CodeSnippetsPage).

## Motivation and Context

Easier to change the font, and many IDEs support this feature.

## How Has This Been Tested?

On Arch Linux.