### PR TITLE
refactor(QCodeEditorUtil): fix compiler warning

### DIFF
--- a/src/Util/QCodeEditorUtil.cpp
+++ b/src/Util/QCodeEditorUtil.cpp
@@ -88,26 +88,23 @@ void applySettingsToEditor(QCodeEditor *editor, const QString &language)
         auto left = li[0].toChar();
         auto right = li[1].toChar();
 
-        auto getFlag = [](bool &flag, Qt::CheckState state, bool def) {
+        auto getFlag = [](Qt::CheckState state, bool def) {
             switch (state)
             {
             case Qt::Checked:
-                flag = true;
-                break;
+                return true;
             case Qt::PartiallyChecked:
-                flag = def;
-                break;
+                return def;
             case Qt::Unchecked:
-                flag = false;
-                break;
+                return false;
+            default:
+                Q_UNREACHABLE();
             }
         };
 
-        bool autoComplete, autoRemove, tabJumpOut;
-
-        getFlag(autoComplete, Qt::CheckState(li[2].toInt()), SettingsHelper::isAutoCompleteParentheses());
-        getFlag(autoRemove, Qt::CheckState(li[3].toInt()), SettingsHelper::isAutoRemoveParentheses());
-        getFlag(tabJumpOut, Qt::CheckState(li[4].toInt()), SettingsHelper::isTabJumpOutParentheses());
+        bool autoComplete = getFlag(Qt::CheckState(li[2].toInt()), SettingsHelper::isAutoCompleteParentheses());
+        bool autoRemove = getFlag(Qt::CheckState(li[3].toInt()), SettingsHelper::isAutoRemoveParentheses());
+        bool tabJumpOut = getFlag(Qt::CheckState(li[4].toInt()), SettingsHelper::isTabJumpOutParentheses());
 
         parentheses.push_back({left, right, autoComplete, autoRemove, tabJumpOut});
     }


### PR DESCRIPTION
The following warnings are false positive, but it's better to return the value instead of changing a reference.

```
../src/Util/QCodeEditorUtil.cpp: In function ‘void Util::applySettingsToEditor(QCodeEditor*, const QString&)’:
../src/Util/QCodeEditorUtil.cpp:106:40: warning: ‘tabJumpOut’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         bool autoComplete, autoRemove, tabJumpOut;
                                        ^~~~~~~~~~
In file included from ../third_party/QCodeEditor/include/QCodeEditor:3:0,
                 from ../src/Util/QCodeEditorUtil.cpp:24:
../third_party/QCodeEditor/include/internal/QCodeEditor.hpp:39:96: warning: ‘autoRemove’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             : left(l), right(r), autoComplete(complete), autoRemove(remove), tabJumpOut(jumpout)
                                                                                                ^
../src/Util/QCodeEditorUtil.cpp:106:28: note: ‘autoRemove’ was declared here
         bool autoComplete, autoRemove, tabJumpOut;
                            ^~~~~~~~~~
In file included from ../third_party/QCodeEditor/include/QCodeEditor:3:0,
                 from ../src/Util/QCodeEditorUtil.cpp:24:
../third_party/QCodeEditor/include/internal/QCodeEditor.hpp:39:96: warning: ‘autoComplete’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             : left(l), right(r), autoComplete(complete), autoRemove(remove), tabJumpOut(jumpout)
                                                                                                ^
../src/Util/QCodeEditorUtil.cpp:106:14: note: ‘autoComplete’ was declared here
         bool autoComplete, autoRemove, tabJumpOut;
              ^~~~~~~~~~~~
```