### PR TITLE
refactor(SettingsUpdater): rename editor theme in SettingsUpdater

### DIFF
--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -128,14 +128,6 @@ void SettingsManager::loadSettings(const QString &path)
 
         // load file problem binding
         FileProblemBinder::fromVariant(setting.value("file_problem_binding"));
-
-        // rename themes
-        QString theme = get("Editor Theme")
-                            .toString()
-                            .replace("Monkai", "Monokai")
-                            .replace("Drakula", "Dracula")
-                            .replace("Solarised", "Solarized");
-        set("Editor Theme", theme);
     }
 
     LOG_INFO("Settings have been loaded from " + path);

--- a/src/Settings/SettingsUpdater.cpp
+++ b/src/Settings/SettingsUpdater.cpp
@@ -114,4 +114,11 @@ void SettingsUpdater::updateSetting(QSettings &setting)
 
         Core::SessionManager::saveSession(QJsonDocument(json).toJson());
     }
+
+    QString theme = SettingsManager::get("Editor Theme")
+                        .toString()
+                        .replace("Monkai", "Monokai")
+                        .replace("Drakula", "Dracula")
+                        .replace("Solarised", "Solarized");
+    SettingsManager::set("Editor Theme", theme);
 }


### PR DESCRIPTION
## Description

Move renaming editor theme from `SettingsManager` to `SettingsUpdater`.