### PR TITLE
feat(Settings): add a flexible system to set and change default paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ add_executable(cpeditor
     src/Settings/AppearancePage.hpp
     src/Settings/CodeSnippetsPage.cpp
     src/Settings/CodeSnippetsPage.hpp
+    src/Settings/DefaultPathManager.cpp
+    src/Settings/DefaultPathManager.hpp
     src/Settings/FileProblemBinder.cpp
     src/Settings/FileProblemBinder.hpp
     src/Settings/FontItem.cpp

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -22,6 +22,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - A warning when it failed to start compilation. (#463)
 - Now you can change the text codec of the compiler output. (#469)
 - Now you can use the mouse wheel to change the font of the code editor. (#475)
+- A flexible system to set and change default paths for several path choosing actions. (#483)
 
 ### Fixed
 

--- a/src/Settings/CodeSnippetsPage.cpp
+++ b/src/Settings/CodeSnippetsPage.cpp
@@ -16,11 +16,11 @@
  */
 
 #include "Settings/CodeSnippetsPage.hpp"
+#include "Settings/DefaultPathManager.hpp"
 #include "Util/FileUtil.hpp"
 #include "Util/QCodeEditorUtil.hpp"
 #include "generated/SettingsHelper.hpp"
 #include <QCodeEditor>
-#include <QFileDialog>
 #include <QInputDialog>
 #include <QLabel>
 #include <QListWidget>
@@ -314,8 +314,9 @@ void CodeSnippetsPage::renameSnippet()
 
 void CodeSnippetsPage::loadSnippetsFromFiles()
 {
-    auto files = QFileDialog::getOpenFileNames(this, tr("Load Snippets"), QString(),
-                                               Util::fileNameFilter(lang == "C++", lang == "Java", lang == "Python"));
+    auto files =
+        DefaultPathManager::getOpenFileNames("Extract And Load Snippets", this, tr("Load Snippets"),
+                                             Util::fileNameFilter(lang == "C++", lang == "Java", lang == "Python"));
 
     for (auto file : files)
     {
@@ -338,9 +339,11 @@ void CodeSnippetsPage::loadSnippetsFromFiles()
 
 void CodeSnippetsPage::extractSnippetsToFiles()
 {
-    auto dirPath = QFileDialog::getExistingDirectory(this, tr("Extract Snippets"));
+    auto dirPath = DefaultPathManager::getExistingDirectory("Extract And Load Snippets", this, tr("Extract Snippets"));
+
     if (dirPath.isEmpty())
         return;
+
     auto dir = QDir(dirPath);
 
     auto names = SettingsHelper::getLanguageConfig(lang).getSnippets();

--- a/src/Settings/DefaultPathManager.cpp
+++ b/src/Settings/DefaultPathManager.cpp
@@ -41,7 +41,7 @@ void DefaultPathManager::changeDefaultPathForAction(const QString &action, const
 
     if (!SettingsManager::contains(settingsKey, true))
     {
-        qDebug() << "Unkown Action:" << action;
+        qDebug() << "Unknown Action:" << action;
         LOG_ERR("Unknown Action");
         return;
     }

--- a/src/Settings/DefaultPathManager.cpp
+++ b/src/Settings/DefaultPathManager.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#include "Settings/DefaultPathManager.hpp"
+#include "Core/EventLogger.hpp"
+#include "Settings/SettingsManager.hpp"
+#include "generated/SettingsHelper.hpp"
+#include <QDebug>
+#include <QFileInfo>
+#include <QRegularExpression>
+
+QMap<QString, QString> DefaultPathManager::defaultPath;
+
+QString DefaultPathManager::defaultPathForAction(const QString &action)
+{
+    const auto result =
+        convertPath(SettingsManager::get(QString("Default Path/Action/%1/Uses").arg(action)).toString());
+    LOG_INFO(INFO_OF(action) << INFO_OF(result));
+    return result;
+}
+
+void DefaultPathManager::changeDefaultPathForAction(const QString &action, const QString &path)
+{
+    LOG_INFO(INFO_OF(action) << INFO_OF(path));
+
+    const auto settingsKey = QString("Default Path/Action/%1/Changes").arg(action);
+
+    if (!SettingsManager::contains(settingsKey, true))
+    {
+        qDebug() << "Unkown Action:" << action;
+        LOG_ERR("Unknown Action");
+        return;
+    }
+
+    const QFileInfo info(path);
+    const auto dir = info.isFile() ? info.canonicalPath() : info.canonicalFilePath();
+
+    const auto list = SettingsManager::get(settingsKey).toString().split(",");
+
+    for (const auto &key : list)
+    {
+        const auto trimmedKey = key.trimmed();
+        if (trimmedKey.isEmpty())
+            continue;
+        defaultPath[trimmedKey] = dir;
+    }
+
+    SettingsHelper::setDefaultPathNamesAndPaths(toVariantList());
+}
+
+QString DefaultPathManager::getExistingDirectory(const QString &action, QWidget *parent, const QString &caption,
+                                                 QFileDialog::Options options)
+{
+    const auto result = QFileDialog::getExistingDirectory(parent, caption, defaultPathForAction(action), options);
+    if (!result.isEmpty())
+        changeDefaultPathForAction(action, result);
+    return result;
+}
+
+QString DefaultPathManager::getOpenFileName(const QString &action, QWidget *parent, const QString &caption,
+                                            const QString &filter, QString *selectedFilter,
+                                            QFileDialog::Options options)
+{
+    const auto result =
+        QFileDialog::getOpenFileName(parent, caption, defaultPathForAction(action), filter, selectedFilter, options);
+    if (!result.isEmpty())
+        changeDefaultPathForAction(action, result);
+    return result;
+}
+
+QStringList DefaultPathManager::getOpenFileNames(const QString &action, QWidget *parent, const QString &caption,
+                                                 const QString &filter, QString *selectedFilter,
+                                                 QFileDialog::Options options)
+{
+    const auto result =
+        QFileDialog::getOpenFileNames(parent, caption, defaultPathForAction(action), filter, selectedFilter, options);
+    if (!result.isEmpty())
+        changeDefaultPathForAction(action, result.front());
+    return result;
+}
+
+QString DefaultPathManager::getSaveFileName(const QString &action, QWidget *parent, const QString &caption,
+                                            const QString &filter, QString *selectedFilter,
+                                            QFileDialog::Options options)
+{
+    const auto result =
+        QFileDialog::getSaveFileName(parent, caption, defaultPathForAction(action), filter, selectedFilter, options);
+    if (!result.isEmpty())
+        changeDefaultPathForAction(action, result);
+    return result;
+}
+
+void DefaultPathManager::fromVariantList(const QVariantList &list)
+{
+    defaultPath.clear();
+    for (const auto &strListVar : list)
+    {
+        const auto strList = strListVar.toStringList();
+        if (strList.length() != 2)
+        {
+            LOG_ERR(INFO_OF(strList.length()));
+            continue;
+        }
+        defaultPath[strList[0]] = strList[1];
+    }
+}
+
+QStringList DefaultPathManager::actionSettingsList()
+{
+    QStringList list;
+    for (const auto &info : SettingsInfo::getSettings())
+    {
+        if (info.name.startsWith("Default Path/Action/"))
+        {
+            list.push_back(info.name);
+        }
+    }
+    return list;
+}
+
+QString DefaultPathManager::convertPath(const QString &str)
+{
+    QString result = str;
+    for (const auto &key : defaultPath.keys())
+        result.replace(QString("${%1}").arg(key), defaultPath[key]);
+    const QRegularExpression placeHolderRegex("\\$\\{.*?\\}");
+    if (result.contains(placeHolderRegex))
+    {
+        LOG_WARN("Unknown place holder: " << INFO_OF(str) << INFO_OF(result));
+        result.replace(placeHolderRegex, "");
+    }
+    return result;
+}
+
+QVariantList DefaultPathManager::toVariantList()
+{
+    QVariantList result;
+    for (const auto &key : defaultPath.keys())
+        result.push_back(QStringList{key, defaultPath[key]});
+    return result;
+}

--- a/src/Settings/DefaultPathManager.hpp
+++ b/src/Settings/DefaultPathManager.hpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#ifndef DEFAULTPATHMANAGER_HPP
+#define DEFAULTPATHMANAGER_HPP
+
+#include <QFileDialog>
+#include <QMap>
+#include <QVariant>
+
+class DefaultPathManager
+{
+  public:
+    /**
+     * @brief get the default path for *action*
+     */
+    static QString defaultPathForAction(const QString &action);
+
+    /**
+     * @brief change the default path after getting the default path for *action*
+     */
+    static void changeDefaultPathForAction(const QString &action, const QString &path);
+
+    /**
+     * @brief a wrapper for QFileDialog::getExistingDirectory
+     */
+    static QString getExistingDirectory(const QString &action, QWidget *parent = nullptr,
+                                        const QString &caption = QString(),
+                                        QFileDialog::Options options = QFileDialog::ShowDirsOnly);
+    /**
+     * @brief a wrapper for QFileDialog::getOpenFileName
+     */
+    static QString getOpenFileName(const QString &action, QWidget *parent = nullptr, const QString &caption = QString(),
+                                   const QString &filter = QString(), QString *selectedFilter = nullptr,
+                                   QFileDialog::Options options = QFileDialog::Options());
+
+    /**
+     * @brief a wrapper for QFileDialog::getOpenFileNames
+     */
+    static QStringList getOpenFileNames(const QString &action, QWidget *parent = nullptr,
+                                        const QString &caption = QString(), const QString &filter = QString(),
+                                        QString *selectedFilter = nullptr,
+                                        QFileDialog::Options options = QFileDialog::Options());
+
+    /**
+     * @brief a wrapper for QFileDialog::getSaveFileName
+     */
+    static QString getSaveFileName(const QString &action, QWidget *parent = nullptr, const QString &caption = QString(),
+                                   const QString &filter = QString(), QString *selectedFilter = nullptr,
+                                   QFileDialog::Options options = QFileDialog::Options());
+
+    /**
+     * @brief restore the default paths from a QVariant
+     */
+    static void fromVariantList(const QVariantList &list);
+
+    /**
+     * @brief get a list of all action settings, in a correct order instead of the lexicographical order
+     */
+    static QStringList actionSettingsList();
+
+  private:
+    /**
+     * @brief get the path from *str*, replace place holders with default paths
+     */
+    static QString convertPath(const QString &str);
+
+    /**
+     * @brief dump the default paths to a QVariant
+     */
+    static QVariantList toVariantList();
+
+  private:
+    static QMap<QString, QString> defaultPath;
+};
+
+#endif // DEFAULTPATHMANAGER_HPP

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -19,9 +19,11 @@
 #include "Core/EventLogger.hpp"
 #include "Settings/AppearancePage.hpp"
 #include "Settings/CodeSnippetsPage.hpp"
+#include "Settings/DefaultPathManager.hpp"
 #include "Settings/ParenthesesPage.hpp"
 #include "Settings/PreferencesHomePage.hpp"
 #include "Util/Util.hpp"
+#include "generated/SettingsHelper.hpp"
 #include <QApplication>
 #include <QCloseEvent>
 #include <QHBoxLayout>
@@ -33,7 +35,6 @@
 #include <QStackedWidget>
 #include <QTreeWidget>
 #include <QVBoxLayout>
-#include <generated/SettingsHelper.hpp>
 
 AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, const QStringList &content)
 {
@@ -230,6 +231,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .dir(TRKEY("File Path"))
             .page(TRKEY("Testcases"), {"Input File Save Path", "Answer File Save Path", "Testcases Matching Rules"})
             .page(TRKEY("Problem URL"), {"Default File Paths For Problem URLs"})
+            .page(TRKEY("Default Paths"), DefaultPathManager::actionSettingsList() << "Default Path/Names And Paths")
         .end()
         .page(TRKEY("Key Bindings"), {"Hotkey/Compile", "Hotkey/Run", "Hotkey/Compile Run", "Hotkey/Format", "Hotkey/Kill",
                                    "Hotkey/Change View Mode", "Hotkey/Snippets"})

--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -52,10 +52,13 @@ class SettingsInfo
         return SettingInfo();
     }
 
+    static QList<SettingInfo> getSettings()
+    {
+        return settings;
+    }
+
   private:
     static QList<SettingInfo> settings;
-
-    friend class SettingsManager;
 };
 
 #endif // SETTINGSINFO_HPP

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -117,13 +117,13 @@ void SettingsManager::loadSettings(const QString &path)
     def = new QVariantMap();
 
     // default settings
-    for (const auto &si : SettingsInfo::settings)
+    for (const auto &si : SettingsInfo::getSettings())
         def->insert(si.name, si.def);
 
     if (!path.isEmpty())
     {
         QSettings setting(path, QSettings::IniFormat);
-        load(setting, "", SettingsInfo::settings);
+        load(setting, "", SettingsInfo::getSettings());
         SettingsUpdater::updateSetting(setting);
 
         // load file problem binding
@@ -139,7 +139,7 @@ void SettingsManager::saveSettings(const QString &path)
 
     QSettings setting(path, QSettings::IniFormat);
     setting.clear(); // Otherwise SettingsManager::remove won't work
-    save(setting, "", SettingsInfo::settings);
+    save(setting, "", SettingsInfo::getSettings());
 
     // save file problem binding
     setting.setValue("file_problem_binding", FileProblemBinder::toVariant());
@@ -166,9 +166,9 @@ QVariant SettingsManager::get(QString key, bool alwaysDefault)
     }
 }
 
-bool SettingsManager::contains(const QString &key)
+bool SettingsManager::contains(const QString &key, bool includingDefault)
 {
-    return cur->contains(key);
+    return cur->contains(key) || (includingDefault && def->contains(key));
 }
 
 void SettingsManager::set(const QString &key, QVariant value)

--- a/src/Settings/SettingsManager.hpp
+++ b/src/Settings/SettingsManager.hpp
@@ -36,7 +36,7 @@ class SettingsManager
     static void saveSettings(const QString &path);
 
     static QVariant get(QString key, bool alwaysDefault = false);
-    static bool contains(const QString &key);
+    static bool contains(const QString &key, bool includingDefault = false);
     static void set(const QString &key, QVariant value);
     static void remove(QStringList keys);
     static void reset();

--- a/src/Settings/SettingsUpdater.cpp
+++ b/src/Settings/SettingsUpdater.cpp
@@ -115,6 +115,15 @@ void SettingsUpdater::updateSetting(QSettings &setting)
         Core::SessionManager::saveSession(QJsonDocument(json).toJson());
     }
 
+    if (setting.contains("save_path"))
+    {
+        if (SettingsHelper::getDefaultPathNamesAndPaths().isEmpty())
+        {
+            SettingsHelper::setDefaultPathNamesAndPaths(
+                QVariantList{QStringList{"file", setting.value("save_path").toString()}});
+        }
+    }
+
     QString theme = SettingsManager::get("Editor Theme")
                         .toString()
                         .replace("Monkai", "Monokai")

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -516,10 +516,6 @@
         "tip": "The path to the CF Tool executable file"
     },
     {
-        "name": "Save Path",
-        "type": "QString"
-    },
-    {
         "name": "Show Compile And Run Only",
         "type": "bool",
         "tip": "Hide the Compile Only button and the Run Only button under the code editor in the main window."
@@ -948,5 +944,11 @@
         "default": "UTF-8",
         "ui": "CodecBox",
         "tip": "Text codec of the compiler output (errors, warnings, etc.)"
+    },
+    {
+        "name": "Default Path/Names And Paths",
+        "type": "QVariantList",
+        "param": "QVariantList { QStringList { tr(\"Name\"), tr(\"The name of a default path\") }, QStringList { tr(\"Path\"), tr(\"The path of a default path\") } }",
+        "tip": "A list of default paths.\nThey can be used in actions' corresponding default paths by using ${<default path name>} as a place holder.\nThey can be either manually set or automatically changed after choosing a path for an action."
     }
 ]

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -18,9 +18,9 @@
 #include "Widgets/TestCaseEdit.hpp"
 #include "Core/EventLogger.hpp"
 #include "Core/MessageLogger.hpp"
+#include "Settings/DefaultPathManager.hpp"
 #include "Util/FileUtil.hpp"
 #include <QApplication>
-#include <QFileDialog>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMimeData>
@@ -101,8 +101,9 @@ void TestCaseEdit::onCustomContextMenuRequested(const QPoint &pos)
         menu->addSeparator();
         menu->addAction(QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton), tr("Load From File"), [this] {
             LOG_INFO("Opening file dialog to Load from file");
-            auto res = QFileDialog::getOpenFileName(this, tr("Load From File"));
-            loadFromFile(res);
+            auto res = DefaultPathManager::getOpenFileName("Load Single Test Case", this, tr("Load From File"));
+            if (!res.isEmpty())
+                loadFromFile(res);
         });
         menu->addAction(
             QApplication::style()->standardIcon(QStyle::SP_TitleBarMaxButton), tr("Edit in Bigger Window"), [this] {

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -18,11 +18,11 @@
 #include "Widgets/TestCases.hpp"
 #include "Core/EventLogger.hpp"
 #include "Core/MessageLogger.hpp"
+#include "Settings/DefaultPathManager.hpp"
 #include "Util/FileUtil.hpp"
 #include "Widgets/TestCase.hpp"
 #include "generated/SettingsHelper.hpp"
 #include <QComboBox>
-#include <QFileDialog>
 #include <QFileInfo>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -74,9 +74,10 @@ TestCases::TestCases(MessageLogger *logger, QWidget *parent) : QWidget(parent), 
     moreMenu = new QMenu();
 
     moreMenu->addAction(tr("Add Pairs of Testcases From Files"), [this] {
-        QStringList paths = QFileDialog::getOpenFileNames(this, tr("Choose Testcase Files"), "");
+        QStringList paths =
+            DefaultPathManager::getOpenFileNames("Add Pairs Of Test Cases", this, tr("Choose Testcase Files"));
         LOG_INFO(paths.join(", "));
-        if (paths.size())
+        if (!paths.isEmpty())
         {
             QVariantList rules = SettingsHelper::getTestcasesMatchingRules();
             QSet<QString> remain;
@@ -485,7 +486,8 @@ void TestCases::on_addButton_clicked()
 void TestCases::on_addCheckerButton_clicked()
 {
     LOG_INFO("Add checker button clicked");
-    auto path = QFileInfo(QFileDialog::getOpenFileName(this, tr("Add Checker"))).canonicalFilePath();
+    auto path =
+        QFileInfo(DefaultPathManager::getOpenFileName("Custom Checker", this, tr("Add Checker"))).canonicalFilePath();
     if (!path.isEmpty())
     {
         checkerComboBox->addItem(path);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,12 +25,12 @@
 #include "Extensions/CFTool.hpp"
 #include "Extensions/ClangFormatter.hpp"
 #include "Extensions/CompanionServer.hpp"
+#include "Settings/DefaultPathManager.hpp"
 #include "Settings/FileProblemBinder.hpp"
 #include "Util/FileUtil.hpp"
 #include "Util/QCodeEditorUtil.hpp"
 #include "Widgets/TestCases.hpp"
 #include <QCodeEditor>
-#include <QFileDialog>
 #include <QFileSystemWatcher>
 #include <QFontDialog>
 #include <QInputDialog>
@@ -856,7 +856,8 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
                 }
             }
             if (defaultPath.isEmpty())
-                defaultPath = QDir(SettingsHelper::getSavePath()).filePath(getTabTitle(false, false));
+                defaultPath =
+                    QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(getTabTitle(false, false));
             if (language == "C++")
                 defaultPath += ".cpp";
             else if (language == "Java")
@@ -899,7 +900,7 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
 
         setFilePath(newFilePath);
 
-        SettingsHelper::setSavePath(QFileInfo(filePath).canonicalPath());
+        DefaultPathManager::changeDefaultPathForAction("Save File", QFileInfo(filePath).canonicalPath());
 
         auto suffix = QFileInfo(filePath).suffix();
         if (Util::cppSuffix.contains(suffix))

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -122,6 +122,8 @@ def addDefaultPaths(obj):
             "default": action[1],
             "trtip": f'tr("The default path used when choosing a path for %1.\\nYou can use ${{<default path name>}} as a place holder.").arg(tr("{action[0]}"))'
         })
+        if action[0] == "Save File":
+            obj[-1]["trtip"] += ' + "\\n" + tr("It can be overridden by %1.").arg(tr("Default File Paths For Problem URLs"))'
         obj.append({
             "name": f"Default Path/Action/{action[0]}/Changes",
             "trdesc": f'tr("Default paths changed by %1").arg(tr("{action[0]}"))',

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -117,14 +117,14 @@ def addDefaultPaths(obj):
     for action in actions:
         obj.append({
             "name": f"Default Path/Action/{action[0]}/Uses",
-            "trdesc": f'tr("The default path used for %1").arg(tr("{action[0]}"))',
+            "trdesc": f'tr("Default path used for %1").arg(tr("{action[0]}"))',
             "type": "QString",
             "default": action[1],
             "trtip": f'tr("The default path used when choosing a path for %1.\\nYou can use ${{<default path name>}} as a place holder.").arg(tr("{action[0]}"))'
         })
         obj.append({
             "name": f"Default Path/Action/{action[0]}/Changes",
-            "trdesc": f'tr("The default path changed by %1").arg(tr("{action[0]}"))',
+            "trdesc": f'tr("Default paths changed by %1").arg(tr("{action[0]}"))',
             "type": "QString",
             "default": action[2],
             "trtip": f'tr("The default paths changed after choosing a path for %1.\\nIt is a list of <default path name>s, separated by commas, and can be empty.").arg(tr("{action[0]}"))'

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -520,7 +520,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Load a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
+        <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -552,6 +552,14 @@
 Git commit hash: %2
 Build time: %3
 OS: %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1521,6 +1529,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Network Proxy</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Default Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1878,10 +1890,6 @@ This can be overridden for each parenthesis in each language.</source>
     </message>
     <message>
         <source>The path to the CF Tool executable file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Save Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2313,6 +2321,82 @@ kill the application with SIGKILL which could not be handled by the application.
     </message>
     <message>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Path Names And Paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A list of default paths.
+They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
+They can be either manually set or automatically changed after choosing a path for an action.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of a default path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The path of a default path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The default path used for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The default path used when choosing a path for %1.
+You can use ${&lt;default path name&gt;} as a place holder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The default path changed by %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The default paths changed after choosing a path for %1.
+It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Contest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Single Test Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Pairs Of Test Cases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom Checker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export And Import Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export And Load Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extract And Load Snippets</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2399,6 +2399,10 @@ It is a list of &lt;default path name&gt;s, separated by commas, and can be empt
         <source>Default paths changed by %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>It can be overridden by %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2346,20 +2346,12 @@ They can be either manually set or automatically changed after choosing a path f
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The default path used for %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The default path changed by %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2397,6 +2389,14 @@ It is a list of &lt;default path name&gt;s, separated by commas, and can be empt
     </message>
     <message>
         <source>Extract And Load Snippets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default path used for %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default paths changed by %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2415,7 +2415,7 @@ They can be either manually set or automatically changed after choosing a path f
         <translation>一个默认路径的路径</translation>
     </message>
     <message>
-        <source>The default path used for %1</source>
+        <source>Default path used for %1</source>
         <translation>用于 %1 的默认路径</translation>
     </message>
     <message>
@@ -2429,7 +2429,7 @@ You can use ${&lt;default path name&gt;} as a place holder.</source>
 你可以使用 ${&lt;默认路径名称&gt;} 来作为占位符。</translation>
     </message>
     <message>
-        <source>The default path changed by %1</source>
+        <source>Default paths changed by %1</source>
         <translation>被 %1 改变的默认路径</translation>
     </message>
     <message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -520,7 +520,7 @@
         <translation>加载会话</translation>
     </message>
     <message>
-        <source>Load a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
+        <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>从文件中加载会话会关闭当前的所有标签页并且不会保存文件。你确定要继续吗？</translation>
     </message>
     <message>
@@ -556,6 +556,14 @@ OS: %4</source>
 git 提交编号: %2
 构建时间: %3
 操作系统: %4</translation>
+    </message>
+    <message>
+        <source>Import Settings</source>
+        <translation>导入设置</translation>
+    </message>
+    <message>
+        <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
+        <translation>当前所有设置都会在从文件中导入设置后丢失。你确定要继续吗？</translation>
     </message>
 </context>
 <context>
@@ -1543,6 +1551,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Network Proxy</source>
         <translation>网络代理</translation>
     </message>
+    <message>
+        <source>Default Paths</source>
+        <translation>默认路径</translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1917,10 +1929,6 @@ This can be overridden for each parenthesis in each language.</source>
     <message>
         <source>The path to the CF Tool executable file</source>
         <translation>CF Tool 可执行文件路径</translation>
-    </message>
-    <message>
-        <source>Save Path</source>
-        <translation></translation>
     </message>
     <message>
         <source>Show Compile And Run Only</source>
@@ -2381,6 +2389,86 @@ kill the application with SIGKILL which could not be handled by the application.
     <message>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>编译器输出（错误，警告等）的文字编码</translation>
+    </message>
+    <message>
+        <source>Default Path Names And Paths</source>
+        <translation>默认路径的名称和路径</translation>
+    </message>
+    <message>
+        <source>A list of default paths.
+They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
+They can be either manually set or automatically changed after choosing a path for an action.</source>
+        <translation>默认路径的列表。
+它们以占位符的形式（${&lt;默认路径名称&gt;}）用于一些动作对应的默认路径中。
+它们可以被手动设置，也可以在为一个动作选择路径后被自动设置。</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <source>The name of a default path</source>
+        <translation>一个默认路径的名称</translation>
+    </message>
+    <message>
+        <source>The path of a default path</source>
+        <translation>一个默认路径的路径</translation>
+    </message>
+    <message>
+        <source>The default path used for %1</source>
+        <translation>用于 %1 的默认路径</translation>
+    </message>
+    <message>
+        <source>Open File</source>
+        <translation>打开文件</translation>
+    </message>
+    <message>
+        <source>The default path used when choosing a path for %1.
+You can use ${&lt;default path name&gt;} as a place holder.</source>
+        <translation>选择 %1 的路径时使用的默认路径。
+你可以使用 ${&lt;默认路径名称&gt;} 来作为占位符。</translation>
+    </message>
+    <message>
+        <source>The default path changed by %1</source>
+        <translation>被 %1 改变的默认路径</translation>
+    </message>
+    <message>
+        <source>The default paths changed after choosing a path for %1.
+It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
+        <translation>为 %1 选择一个路径后被改变的默认路径。
+它是一个 &lt;默认路径名称&gt; 的列表，相邻两项之间用半角逗号隔开，可以为空。</translation>
+    </message>
+    <message>
+        <source>Save File</source>
+        <translation>保存文件</translation>
+    </message>
+    <message>
+        <source>Open Contest</source>
+        <translation>打开比赛</translation>
+    </message>
+    <message>
+        <source>Load Single Test Case</source>
+        <translation>加载单个测试用例</translation>
+    </message>
+    <message>
+        <source>Add Pairs Of Test Cases</source>
+        <translation>添加多对测试用例</translation>
+    </message>
+    <message>
+        <source>Custom Checker</source>
+        <translation>自定义评测器</translation>
+    </message>
+    <message>
+        <source>Export And Import Settings</source>
+        <translation>导出和导入设置</translation>
+    </message>
+    <message>
+        <source>Export And Load Session</source>
+        <translation>导出和加载会话</translation>
+    </message>
+    <message>
+        <source>Extract And Load Snippets</source>
+        <translation>导出和加载代码片段</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2470,6 +2470,10 @@ It is a list of &lt;default path name&gt;s, separated by commas, and can be empt
         <source>Extract And Load Snippets</source>
         <translation>导出和加载代码片段</translation>
     </message>
+    <message>
+        <source>It can be overridden by %1.</source>
+        <translation>它可以被 %1 覆盖。</translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>


### PR DESCRIPTION
## Description

Add a system to set and change default paths for all choosing path actions.

You can read the tooltips and try it to understand how it works.

It doesn't apply to PathItem because the default path of a PathItem is the old value of it.

## Related Issue

It's a part of #269.

## Motivation and Context

Before this, only saving/opening a file can remember the last chosen path, and the rule is hard-coded —— the default path is always the last path you choose.

Now it applies to nearly all choosing path actions, and the rule is very flexible. You can use either a manually set path or an automatically changed path. You can use the same default path for several actions, or even change another action's default path when choosing a path.

## How Has This Been Tested?

On Arch Linux.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/86575356-b11bf880-bfa9-11ea-878c-0974d76cbb03.png)

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
