### PR TITLE
refactor(PathItem): use enum instead of an int id

### DIFF
--- a/src/Settings/PathItem.hpp
+++ b/src/Settings/PathItem.hpp
@@ -33,15 +33,19 @@ class PathItem : public QWidget
     Q_OBJECT
 
   public:
-    /**
-     * @brief construct a PathItem
-     */
-    explicit PathItem(const QString &pathFilter, const QString &dialogTitle, QWidget *parent = nullptr);
+    enum Type
+    {
+        AnyFile,
+        CppSource,
+        JavaSource,
+        PythonSource,
+        Executable,
+    };
 
     /**
-     * @brief construct a PathItem use builtin filter and title
+     * @brief construct a PathItem with the given type
      */
-    explicit PathItem(int filterId, int titleId, QWidget *parent = nullptr);
+    explicit PathItem(Type type = AnyFile, QWidget *parent = nullptr);
 
     /**
      * @brief get the line edit of the PathItem
@@ -55,12 +59,12 @@ class PathItem : public QWidget
     void onButtonClicked();
 
   private:
-    QString getFilters(int index);
+    QString filter() const;
 
-    QString getTitles(int index);
+    QString title() const;
 
   private:
-    QString filter, title;
+    Type fileType;
     QHBoxLayout *layout = nullptr;
     QLineEdit *lineEdit = nullptr;
     QToolButton *toolButton = nullptr;

--- a/src/Settings/ValueWrapper.cpp
+++ b/src/Settings/ValueWrapper.cpp
@@ -125,8 +125,7 @@ void ComboBoxWrapper::set(QString s)
 
 void PathItemWrapper::init(QWidget *parent, QVariant param)
 {
-    int id = param.toInt();
-    PathItem *item = new PathItem(id, id, parent); // TODO: split to two param
+    PathItem *item = new PathItem(PathItem::Type(param.toInt()), parent);
     connect(item->getLineEdit(), &QLineEdit::textChanged, this, &ValueWidget::emitSignal);
     widget = item;
 }

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -48,7 +48,7 @@
         "type": "QString",
         "default": "clang-format",
         "ui": "PathItem",
-        "param": "0",
+        "param": "PathItem::Executable",
         "tip": "The path to the Clang Format executable file"
     },
     {
@@ -63,7 +63,7 @@
         "name": "C++/Template Path",
         "type": "QString",
         "ui": "PathItem",
-        "param": "1",
+        "param": "PathItem::CppSource",
         "tip": "The template used when creating a new C++ file"
     },
     {
@@ -132,7 +132,7 @@
         "name": "Java/Template Path",
         "type": "QString",
         "ui": "PathItem",
-        "param": "2",
+        "param": "PathItem::JavaSource",
         "tip": "The template used when creating a new Java file"
     },
     {
@@ -212,7 +212,7 @@
         "name": "Python/Template Path",
         "type": "QString",
         "ui": "PathItem",
-        "param": "3",
+        "param": "PathItem::PythonSource",
         "tip": "The template used when creating a new Python file"
     },
     {
@@ -512,7 +512,7 @@
         "type": "QString",
         "default": "cf",
         "ui": "PathItem",
-        "param": "0",
+        "param": "PathItem::Executable",
         "tip": "The path to the CF Tool executable file"
     },
     {
@@ -584,7 +584,7 @@
         "desc": "Path to LSP executable",
         "default": "clangd",
         "type": "QString",
-        "param": "0",
+        "param": "PathItem::Executable",
         "requireAllDepends": false,
         "depends": [
             {
@@ -598,7 +598,7 @@
         "ui": "PathItem",
         "desc": "Path to LSP executable",
         "type": "QString",
-        "param": "0",
+        "param": "PathItem::Executable",
         "requireAllDepends": false,
         "depends": [
             {
@@ -613,7 +613,7 @@
         "desc": "Path to LSP executable",
         "default": "python",
         "type": "QString",
-        "param": "0",
+        "param": "PathItem::Executable",
         "requireAllDepends": false,
         "depends": [
             {

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -146,9 +146,10 @@ namespace SettingsHelper
                         mode="w", encoding="utf-8")
     setting_info.write(head)
     setting_info.write("""#include "Settings/SettingsInfo.hpp"
+#include "Core/StyleManager.hpp"
+#include "Settings/PathItem.hpp"
 #include <QFontDatabase>
 #include <QRect>
-#include "Core/StyleManager.hpp"
 
 QList<SettingsInfo::SettingInfo> SettingsInfo::settings;
 

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1301,15 +1301,19 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
-        <source>Excutable</source>
+        <source>Choose a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Choose Excutable</source>
+        <source>Excutable Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Choose %1 Sources</source>
+        <source>Choose a %1 source file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose an excutable file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1323,16 +1323,20 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
-        <source>Excutable</source>
+        <source>Choose a file</source>
+        <translation>选择一个文件</translation>
+    </message>
+    <message>
+        <source>Excutable Files</source>
         <translation>可执行文件</translation>
     </message>
     <message>
-        <source>Choose Excutable</source>
-        <translation>选择可执行文件</translation>
+        <source>Choose a %1 source file</source>
+        <translation>选择一个 %1 源文件</translation>
     </message>
     <message>
-        <source>Choose %1 Sources</source>
-        <translation>选择 %1 源代码</translation>
+        <source>Choose an excutable file</source>
+        <translation>选择一个可执行文件</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

Use enum instead of int for PathItem type.

## Motivation and Context

It's hard to understand what an int id means.

## Type of changes

- [x] Refactor (changes which affect the meaning of the code but neither fix a bug nor add a feature)