### PR TITLE
feat(Settings): add an option to disable toast messages of CF Tool

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -25,6 +25,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - A flexible system to set and change default paths for several path choosing actions. (#483)
 - Settings to control whether to load external file changes. (#486)
 - Separated settings for format on manual save and format on auto-save. (#488)
+- An option to disable toast messages of CF Tool. (#489)
 
 ### Fixed
 

--- a/src/Extensions/CFTool.cpp
+++ b/src/Extensions/CFTool.cpp
@@ -18,6 +18,7 @@
 #include "Extensions/CFTool.hpp"
 #include "Core/EventLogger.hpp"
 #include "Core/MessageLogger.hpp"
+#include "generated/SettingsHelper.hpp"
 #include <QFileInfo>
 #include <QProcess>
 #include <QRegularExpression>
@@ -182,7 +183,8 @@ void CFTool::onFinished(int exitCode)
 
 void CFTool::showToastMessage(const QString &message)
 {
-    emit requestToastMessage(tr("Contest %1 Problem %2").arg(problemContestId).arg(problemCode), message);
+    if (SettingsHelper::isCFShowToastMessages())
+        emit requestToastMessage(tr("Contest %1 Problem %2").arg(problemContestId).arg(problemCode), message);
 }
 
 QString CFTool::getCFToolVersion() const

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -227,7 +227,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
             .end()
             .page(TRKEY("Competitive Companion"), {"Competitive Companion/Enable", "Competitive Companion/Open New Tab",
                                                 "Competitive Companion/Connection Port"})
-            .page(TRKEY("CF Tool"), {"CF/Path"})
+            .page(TRKEY("CF Tool"), {"CF/Path", "CF/Show Toast Messages"})
         .end()
         .dir(TRKEY("File Path"))
             .page(TRKEY("Testcases"), {"Input File Save Path", "Answer File Save Path", "Testcases Matching Rules"})

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -522,6 +522,13 @@
         "tip": "The path to the CF Tool executable file"
     },
     {
+        "name": "CF/Show Toast Messages",
+        "desc": "Show toast messages for submission verdicts",
+        "type": "bool",
+        "default": "true",
+        "tip": "Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor."
+    },
+    {
         "name": "Show Compile And Run Only",
         "type": "bool",
         "tip": "Hide the Compile Only button and the Run Only button under the code editor in the main window."

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2438,6 +2438,14 @@ If this is disabled, external file changes will be ignored unless they are loade
 &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show toast messages for submission verdicts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2510,6 +2510,14 @@ If this is disabled, external file changes will be ignored unless they are loade
         <translation>当 CP Editor 外部的文件修改发生且没有被“%1”自动加载时，询问是否加载修改。
 如果这个选项被禁用，那么除非被“%1”自动加载，外部文件修改会被忽略。</translation>
     </message>
+    <message>
+        <source>Show toast messages for submission verdicts</source>
+        <translation>为评测结果显示气泡消息</translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
+        <translation>当获知了一个提交的评测结果时，显示一条气泡消息。你可以在 CP Editor 外看到这条消息。</translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>


### PR DESCRIPTION
## Description

Add an option to disable toast messages of CF Tool.

## Related Issue

Part of #269.

## How Has This Been Tested?

On Arch Linux.

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
