### PR TITLE
feat: elide test cases when they are too long

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -25,6 +25,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - A flexible system to set and change default paths for several path choosing actions. (#483)
 - Settings to control whether to load external file changes. (#486)
 - Separated settings for format on manual save and format on auto-save. (#488)
+- Now the test cases will be elided if they are too long. (#491)
 
 ### Fixed
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -35,7 +35,6 @@ With the portable version, you can easily store it in something like a USB disk,
 
 ### Changed
 
-- Now the lengths of the files added by "Add Pairs of Testcases From Files" are limited by Preferences->Advanced->Limits->Load Test Case File Length Limit. (#405)
 - The default font is set to the system fixed-width font instead of the font named "Monospace". (#422)
 - Now the session is stored in a separate file, which was stored along with the settings. So now when exporting/importing settings, the session won't be included, but you can export/load the session separately. (#437 and #442)
 - Now the hidden (not in the search result) pages are skipped when navigating pages in the preferences window via Ctrl+Tab and Ctrl+Shift+Tab. (#447)

--- a/src/Core/MessageLogger.cpp
+++ b/src/Core/MessageLogger.cpp
@@ -32,11 +32,20 @@ void MessageLogger::setContainer(QTextBrowser *container)
     box->setOpenExternalLinks(true);
 }
 
-void MessageLogger::message(const QString &head, const QString &body, const QString &color)
+void MessageLogger::message(const QString &head, const QString &body, const QString &color, bool htmlEscaped)
 {
-    // replace spaces by "&nbsp;" to avoid multiple spaces becoming one, important for compilation errors
-    auto newHead = head.toHtmlEscaped().replace(" ", "&nbsp;");
-    auto newBody = body.toHtmlEscaped().replace(" ", "&nbsp;");
+    QString newHead, newBody;
+    if (htmlEscaped)
+    {
+        // replace spaces by "&nbsp;" to avoid multiple spaces becoming one, important for compilation errors
+        newHead = head.toHtmlEscaped().replace(" ", "&nbsp;");
+        newBody = body.toHtmlEscaped().replace(" ", "&nbsp;");
+    }
+    else
+    {
+        newHead = head;
+        newBody = body;
+    }
 
     // don't display too long messages, otherwise the application may stuck
     if (newBody.length() > SettingsHelper::getMessageLengthLimit())
@@ -58,22 +67,22 @@ void MessageLogger::message(const QString &head, const QString &body, const QStr
     box->append(res);
 }
 
-void MessageLogger::info(const QString &head, const QString &body)
+void MessageLogger::info(const QString &head, const QString &body, bool htmlEscaped)
 {
     LOG_INFO("MessageLogger Information " << INFO_OF(head) << INFO_OF(body));
-    message(head, body, "");
+    message(head, body, "", htmlEscaped);
 }
 
-void MessageLogger::warn(const QString &head, const QString &body)
+void MessageLogger::warn(const QString &head, const QString &body, bool htmlEscaped)
 {
     LOG_INFO("MessageLogger Warning " << INFO_OF(head) << INFO_OF(body));
-    message(head, body, "green");
+    message(head, body, "green", htmlEscaped);
 }
 
-void MessageLogger::error(const QString &head, const QString &body)
+void MessageLogger::error(const QString &head, const QString &body, bool htmlEscaped)
 {
     LOG_INFO("MessageLogger Error " << INFO_OF(head) << INFO_OF(body));
-    message(head, body, "red");
+    message(head, body, "red", htmlEscaped);
 }
 
 void MessageLogger::clear()

--- a/src/Core/MessageLogger.hpp
+++ b/src/Core/MessageLogger.hpp
@@ -38,32 +38,36 @@ class MessageLogger : public QObject
      * @param head the head of the message, indicates where the message is from
      * @param body the main part of the message
      * @param color the color of the message, use the default color if this parameter is empty
+     * @param htmlEscaped convert the message to the HTML escaped format to avoid hidden "<>" and wrong spaces
      */
-    void message(const QString &head, const QString &body, const QString &color);
+    void message(const QString &head, const QString &body, const QString &color, bool htmlEscaped = true);
 
     /**
      * @brief show a warning message
      * @param head the head of the message, indicates where the message is from
      * @param body the main part of the message
+     * @param htmlEscaped convert the message to the HTML escaped format to avoid hidden "<>" and wrong spaces
      * @note the message is green
      */
-    void warn(const QString &head, const QString &body);
+    void warn(const QString &head, const QString &body, bool htmlEscaped = true);
 
     /**
      * @brief show a infomation message
      * @param head the head of the message, indicates where the message is from
      * @param body the main part of the message
+     * @param htmlEscaped convert the message to the HTML escaped format to avoid hidden "<>" and wrong spaces
      * @note the message is in the default color
      */
-    void info(const QString &head, const QString &body);
+    void info(const QString &head, const QString &body, bool htmlEscaped = true);
 
     /**
      * @brief show a error message
      * @param head the head of the message, indicates where the message is from
      * @param body the main part of the message
+     * @param htmlEscaped convert the message to the HTML escaped format to avoid hidden "<>" and wrong spaces
      * @note the message is red
      */
-    void error(const QString &head, const QString &body);
+    void error(const QString &head, const QString &body, bool htmlEscaped = true);
 
     /**
      * @brief clear all messages in the message logger

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -238,8 +238,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                                    "Hotkey/Change View Mode", "Hotkey/Snippets"})
         .dir(TRKEY("Advanced"))
             .page(TRKEY("Update"), {"Check Update", "Beta"})
-            .page(TRKEY("Limits"), {"Time Limit", "Output Length Limit", "Message Length Limit", "HTML Diff Viewer Length Limit",
-                                 "Open File Length Limit", "Load Test Case File Length Limit"})
+            .page(TRKEY("Limits"), {"Time Limit", "Output Length Limit", "Output Display Length Limit", "Message Length Limit",
+                                    "HTML Diff Viewer Length Limit", "Open File Length Limit", "Load Test Case File Length Limit"})
             .page(TRKEY("Network Proxy"), {"Proxy/Enabled", "Proxy/Type", "Proxy/Host Name", "Proxy/Port", "Proxy/User", "Proxy/Password"})
         .end();
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -239,7 +239,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .dir(TRKEY("Advanced"))
             .page(TRKEY("Update"), {"Check Update", "Beta"})
             .page(TRKEY("Limits"), {"Time Limit", "Output Length Limit", "Output Display Length Limit", "Message Length Limit",
-                                    "HTML Diff Viewer Length Limit", "Open File Length Limit", "Load Test Case File Length Limit"})
+                                    "HTML Diff Viewer Length Limit", "Open File Length Limit", "Load Test Case Length Limit"})
             .page(TRKEY("Network Proxy"), {"Proxy/Enabled", "Proxy/Type", "Proxy/Host Name", "Proxy/Port", "Proxy/User", "Proxy/Password"})
         .end();
 

--- a/src/Settings/SettingsUpdater.cpp
+++ b/src/Settings/SettingsUpdater.cpp
@@ -64,6 +64,7 @@ const static QMap<QString, QString> updateInfo = {
     {"cf_path", "CF/Path"},
     {"compile_and_run_only", "Show Compile And Run Only"},
     {"language", "Locale"},
+    {"load_test_case_file_length_limit", "Load Test Case Length Limit"},
 };
 
 void SettingsUpdater::updateSetting(QSettings &setting)

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -553,6 +553,13 @@
         "tip": "The maximum number of characters in the output of the program.\nThe program will be killed if either of its stdout or stderr is too long."
     },
     {
+        "name": "Output Display Length Limit",
+        "type": "int",
+        "default": 50000,
+        "param": "QVariantList {2,100000000}",
+        "tip": "The maximum number of characters to be displayed for the output of the program.\nIf the output is too long, it will be elided."
+    },
+    {
         "name": "Message Length Limit",
         "type": "int",
         "default": 20000,
@@ -578,7 +585,7 @@
         "type": "int",
         "default": 500000,
         "param": "QVariantList {2,1000000000}",
-        "tip": "The maximum number of characters in a testcase file to load.\nA testcase file won't be loaded if it's too long."
+        "tip": "The maximum number of characters in a test case file to load.\nA test case loaded from file will be elided and read-only if it's too long."
     },
     {
         "name": "LSP/Path C++",

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -581,11 +581,11 @@
         "tip": "The maximum number of characters in a source file to open.\nA source file won't be opened if it's too long."
     },
     {
-        "name": "Load Test Case File Length Limit",
+        "name": "Load Test Case Length Limit",
         "type": "int",
         "default": 500000,
         "param": "QVariantList {2,1000000000}",
-        "tip": "The maximum number of characters in a test case file to load.\nA test case loaded from file will be elided and read-only if it's too long."
+        "tip": "The maximum number of characters in a test case to be loaded.\nA loaded test case will be elided and read-only if it's too long."
     },
     {
         "name": "LSP/Path C++",

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -55,16 +55,12 @@ TestCase::TestCase(int index, MessageLogger *logger, QWidget *parent, const QStr
     runButton = new QPushButton(tr("Run"), this);
     diffButton = new QPushButton("**", this);
     delButton = new QPushButton(tr("Del"), this);
-    inputEdit = new TestCaseEdit(true, log, in, this);
-    outputEdit = new TestCaseEdit(false, log, QString(), this);
-    expectedEdit = new TestCaseEdit(true, log, exp, this);
+    inputEdit = new TestCaseEdit(TestCaseEdit::Input, log, in, this);
+    outputEdit = new TestCaseEdit(TestCaseEdit::Output, log, QString(), this);
+    expectedEdit = new TestCaseEdit(TestCaseEdit::Expected, log, exp, this);
     diffViewer = new DiffViewer(this);
 
     setID(index);
-    outputEdit->setReadOnly(true);
-    inputEdit->setWordWrapMode(QTextOption::NoWrap);
-    outputEdit->setWordWrapMode(QTextOption::NoWrap);
-    expectedEdit->setWordWrapMode(QTextOption::NoWrap);
 
     showCheckBox->setMinimumWidth(20);
     showCheckBox->setChecked(true);
@@ -111,23 +107,11 @@ void TestCase::setInput(const QString &text)
 
 void TestCase::setOutput(const QString &text)
 {
-    auto newOutput = text;
-
-    if (text.length() > SettingsHelper::getOutputLengthLimit())
-    {
-        newOutput = tr("Output Length Limit Exceeded");
-        log->error(tr("Testcases"),
-                   tr("The output #%1 contains more than %2 characters, so it's not displayed. You can set the "
-                      "output length limit in Preferences->Advanced->Limits->Output Length Limit")
-                       .arg(id + 1)
-                       .arg(SettingsHelper::getOutputLengthLimit()));
-    }
-
-    outputEdit->modifyText(newOutput);
+    outputEdit->modifyText(text);
     outputEdit->startAnimation();
 
     if (!diffViewer->isHidden())
-        diffViewer->setText(newOutput, expected());
+        diffViewer->setText(text, expected());
 }
 
 void TestCase::setExpected(const QString &text)
@@ -145,17 +129,17 @@ void TestCase::clearOutput()
 
 QString TestCase::input() const
 {
-    return inputEdit->toPlainText();
+    return inputEdit->getText();
 }
 
 QString TestCase::output() const
 {
-    return outputEdit->toPlainText();
+    return outputEdit->getText();
 }
 
 QString TestCase::expected() const
 {
-    return expectedEdit->toPlainText();
+    return expectedEdit->getText();
 }
 
 void TestCase::setID(int index)

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -55,9 +55,9 @@ TestCase::TestCase(int index, MessageLogger *logger, QWidget *parent, const QStr
     runButton = new QPushButton(tr("Run"), this);
     diffButton = new QPushButton("**", this);
     delButton = new QPushButton(tr("Del"), this);
-    inputEdit = new TestCaseEdit(TestCaseEdit::Input, log, in, this);
-    outputEdit = new TestCaseEdit(TestCaseEdit::Output, log, QString(), this);
-    expectedEdit = new TestCaseEdit(TestCaseEdit::Expected, log, exp, this);
+    inputEdit = new TestCaseEdit(TestCaseEdit::Input, index, log, in, this);
+    outputEdit = new TestCaseEdit(TestCaseEdit::Output, index, log, QString(), this);
+    expectedEdit = new TestCaseEdit(TestCaseEdit::Expected, index, log, exp, this);
     diffViewer = new DiffViewer(this);
 
     setID(index);

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -92,8 +92,8 @@ void TestCaseEdit::modifyText(const QString &text, bool keepHistory)
 {
     this->text = text;
 
-    const int limit = role == Output ? SettingsHelper::getOutputDisplayLengthLimit()
-                                     : SettingsHelper::getLoadTestCaseFileLengthLimit();
+    const int limit =
+        role == Output ? SettingsHelper::getOutputDisplayLengthLimit() : SettingsHelper::getLoadTestCaseLengthLimit();
 
     QString displayText;
 
@@ -110,9 +110,8 @@ void TestCaseEdit::modifyText(const QString &text, bool keepHistory)
         setReadOnly(true);
 
         const QString name = role == Input ? tr("input") : (role == Output ? tr("output") : tr("expected"));
-        const QString setLimitPlace = role == Output
-                                          ? tr("Preferences->Advanced->Limits->Output Display Length Limit")
-                                          : tr("Preferences->Advanced->Limits->Load Test Case File Length Limit");
+        const QString setLimitPlace = role == Output ? tr("Preferences->Advanced->Limits->Output Display Length Limit")
+                                                     : tr("Preferences->Advanced->Limits->Load Test Case Length Limit");
 
         displayText = tr("The %1 is too long, only the first %2 characters are shown. You can set the length limit in "
                          "%3.\n\n%4...")

--- a/src/Widgets/TestCaseEdit.hpp
+++ b/src/Widgets/TestCaseEdit.hpp
@@ -30,12 +30,19 @@ class TestCaseEdit : public QPlainTextEdit
     Q_OBJECT
 
   public:
-    explicit TestCaseEdit(bool autoAnimation, MessageLogger *logger, const QString &text = QString(),
-                          QWidget *parent = nullptr);
+    enum Role
+    {
+        Input,
+        Output,
+        Expected
+    };
+
+    explicit TestCaseEdit(Role role, MessageLogger *logger, const QString &text = QString(), QWidget *parent = nullptr);
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
-    void modifyText(const QString &text);
+    void modifyText(const QString &text, bool keepHistory = true);
+    QString getText();
 
   public slots:
     void startAnimation();
@@ -49,6 +56,8 @@ class TestCaseEdit : public QPlainTextEdit
   private:
     QPropertyAnimation *animation;
     MessageLogger *log;
+    QString text;
+    Role role;
 };
 } // namespace Widgets
 #endif // TESTCASEEDIT_HPP

--- a/src/Widgets/TestCaseEdit.hpp
+++ b/src/Widgets/TestCaseEdit.hpp
@@ -37,7 +37,8 @@ class TestCaseEdit : public QPlainTextEdit
         Expected
     };
 
-    explicit TestCaseEdit(Role role, MessageLogger *logger, const QString &text = QString(), QWidget *parent = nullptr);
+    explicit TestCaseEdit(Role role, int id, MessageLogger *logger, const QString &text = QString(),
+                          QWidget *parent = nullptr);
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
@@ -58,6 +59,7 @@ class TestCaseEdit : public QPlainTextEdit
     MessageLogger *log;
     QString text;
     Role role;
+    int id;
 };
 } // namespace Widgets
 #endif // TESTCASEEDIT_HPP

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -347,17 +347,7 @@ void TestCases::saveToFiles(const QString &filePath, bool safe)
 
 QString TestCases::loadTestCaseFromFile(const QString &path, const QString &head)
 {
-    auto content = Util::readFile(path, tr("Load %1").arg(head), log, true);
-    if (content.length() > SettingsHelper::getLoadTestCaseFileLengthLimit())
-    {
-        log->error(tr("Testcases"),
-                   tr("The testcase file [%1] contains more than %2 characters, so it's not loaded. You can "
-                      "change the length limit in Preferences->Advanced->Limits->Load Test Case File Length Limit")
-                       .arg(path)
-                       .arg(SettingsHelper::getLoadTestCaseFileLengthLimit()));
-        return QString();
-    }
-    return content;
+    return Util::readFile(path, tr("Load %1").arg(head), log, true);
 }
 
 void TestCases::setTestCaseEditFont(const QFont &font)

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1963,7 +1963,7 @@ A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Load Test Case File Length Limit</source>
+        <source>Load Test Case Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2443,8 +2443,8 @@ If the output is too long, it will be elided.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The maximum number of characters in a test case file to load.
-A test case loaded from file will be elided and read-only if it&apos;s too long.</source>
+        <source>The maximum number of characters in a test case to be loaded.
+A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2641,7 +2641,7 @@ A test case loaded from file will be elided and read-only if it&apos;s too long.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
+        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1967,11 +1967,6 @@ A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The maximum number of characters in a testcase file to load.
-A testcase file won&apos;t be loaded if it&apos;s too long.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Path to LSP executable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2438,6 +2433,20 @@ If this is disabled, external file changes will be ignored unless they are loade
 &quot;%1&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Output Display Length Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum number of characters to be displayed for the output of the program.
+If the output is too long, it will be elided.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in a test case file to load.
+A test case loaded from file will be elided and read-only if it&apos;s too long.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>
@@ -2573,18 +2582,6 @@ If this is disabled, external file changes will be ignored unless they are loade
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Output Length Limit Exceeded</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Testcases</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The output #%1 contains more than %2 characters, so it&apos;s not displayed. You can set the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Input #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2628,11 +2625,29 @@ If this is disabled, external file changes will be ignored unless they are loade
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Testcases</source>
+        <source>input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
+        <source>output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Output Display Length Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The %1 is too long, only the first %2 characters are shown. You can set the length limit in %3.
+
+%4...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2784,10 +2799,6 @@ If this is disabled, external file changes will be ignored unless they are loade
     </message>
     <message>
         <source>Testcases</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2633,18 +2633,6 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>input</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>output</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>expected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Output Display Length Limit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2653,9 +2641,23 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The %1 is too long, only the first %2 characters are shown. You can set the length limit in %3.
-
-%4...</source>
+        <source>Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Now the test case editor is read-only. You can set the length limit in %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only the first %1 characters are shown.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1984,7 +1984,7 @@ stdout 或 stderr 过长的程序将会被终止。</translation>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>主窗口右上角内每条信息的最大长度。
-超出部分将会被省略。</translation>
+超长部分将会被省略。</translation>
     </message>
     <message>
         <source>HTML Diff Viewer Length Limit</source>
@@ -2008,13 +2008,7 @@ A source file won&apos;t be opened if it&apos;s too long.</source>
     </message>
     <message>
         <source>Load Test Case File Length Limit</source>
-        <translation>加载测试用例文件最大长度</translation>
-    </message>
-    <message>
-        <source>The maximum number of characters in a testcase file to load.
-A testcase file won&apos;t be loaded if it&apos;s too long.</source>
-        <translation>允许加载的测试文件的最大字符数。
-如果超长，将不会加载。</translation>
+        <translation>加载测试用例文件长度限制</translation>
     </message>
     <message>
         <source>Path to LSP executable</source>
@@ -2510,6 +2504,20 @@ If this is disabled, external file changes will be ignored unless they are loade
         <translation>当 CP Editor 外部的文件修改发生且没有被“%1”自动加载时，询问是否加载修改。
 如果这个选项被禁用，那么除非被“%1”自动加载，外部文件修改会被忽略。</translation>
     </message>
+    <message>
+        <source>Output Display Length Limit</source>
+        <translation>输出显示长度限制</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters to be displayed for the output of the program.
+If the output is too long, it will be elided.</source>
+        <translation>会显示出来的程序输出的最大字符数。如果输出过长，超长部分会被省略。</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in a test case file to load.
+A test case loaded from file will be elided and read-only if it&apos;s too long.</source>
+        <translation>被加载的测试用例文件的最大字符数。从文件中加载的测试用例如果过长，超长部分会被省略。</translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>
@@ -2645,18 +2653,6 @@ If this is disabled, external file changes will be ignored unless they are loade
         <translation>打开差异查看器</translation>
     </message>
     <message>
-        <source>Output Length Limit Exceeded</source>
-        <translation>超出输出长度限制（OLE）</translation>
-    </message>
-    <message>
-        <source>Testcases</source>
-        <translation>测试点</translation>
-    </message>
-    <message>
-        <source>The output #%1 contains more than %2 characters, so it&apos;s not displayed. You can set the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
-        <translation>测试点 #%1 的输出包含超过 %2 个字符，因此没有显示。你可以在设置-&gt;高级-&gt;限制-&gt;输出限制中更改限制大小</translation>
-    </message>
-    <message>
         <source>Input #%1</source>
         <translation>输入 #%1</translation>
     </message>
@@ -2700,12 +2696,32 @@ If this is disabled, external file changes will be ignored unless they are loade
         <translation>编辑测试点</translation>
     </message>
     <message>
-        <source>Testcases</source>
-        <translation>测试点</translation>
+        <source>input</source>
+        <translation>输入</translation>
     </message>
     <message>
-        <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
-        <translation>测试点文件 [%1] 包含超过 %2 个字符，因此没有被加载。你可以在设置-&gt;高级-&gt;限制-&gt;加载测试用例文件最大长度长度限制中更改限制大小</translation>
+        <source>output</source>
+        <translation>输出</translation>
+    </message>
+    <message>
+        <source>expected</source>
+        <translation>答案</translation>
+    </message>
+    <message>
+        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Output Display Length Limit</source>
+        <translation>设置-&gt;高级-&gt;限制-&gt;输出显示长度限制</translation>
+    </message>
+    <message>
+        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
+        <translation>设置-&gt;高级-&gt;限制-&gt;加载测试用例文件长度限制</translation>
+    </message>
+    <message>
+        <source>The %1 is too long, only the first %2 characters are shown. You can set the length limit in %3.
+
+%4...</source>
+        <translation>%1太长了，只有开头 %2 个字符会被显示。你可以在 %3 中设置长度限制。
+
+%4……</translation>
     </message>
 </context>
 <context>
@@ -2857,10 +2873,6 @@ If this is disabled, external file changes will be ignored unless they are loade
     <message>
         <source>Testcases</source>
         <translation>测试点</translation>
-    </message>
-    <message>
-        <source>The testcase file [%1] contains more than %2 characters, so it&apos;s not loaded. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
-        <translation>测试点文件 [%1] 包含超过 %2 个字符，因此没有被加载。你可以在设置-&gt;高级-&gt;限制-&gt;加载测试用例文件最大长度长度限制中更改限制大小</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2704,18 +2704,6 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation>编辑测试点</translation>
     </message>
     <message>
-        <source>input</source>
-        <translation>输入</translation>
-    </message>
-    <message>
-        <source>output</source>
-        <translation>输出</translation>
-    </message>
-    <message>
-        <source>expected</source>
-        <translation>答案</translation>
-    </message>
-    <message>
         <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Output Display Length Limit</source>
         <translation>设置-&gt;高级-&gt;限制-&gt;输出显示长度限制</translation>
     </message>
@@ -2724,12 +2712,24 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation>设置-&gt;高级-&gt;限制-&gt;加载测试用例长度限制</translation>
     </message>
     <message>
-        <source>The %1 is too long, only the first %2 characters are shown. You can set the length limit in %3.
-
-%4...</source>
-        <translation>%1太长了，只有开头 %2 个字符会被显示。你可以在 %3 中设置长度限制。
-
-%4……</translation>
+        <source>Input</source>
+        <translation>输入</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>输出</translation>
+    </message>
+    <message>
+        <source>Expected</source>
+        <translation>答案</translation>
+    </message>
+    <message>
+        <source>Now the test case editor is read-only. You can set the length limit in %1.</source>
+        <translation>现在测试用例编辑器是只读的。你可以在 %1 中设置长度限制。</translation>
+    </message>
+    <message>
+        <source>Only the first %1 characters are shown.</source>
+        <translation>只显示了前 %1 个字符。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2007,8 +2007,8 @@ A source file won&apos;t be opened if it&apos;s too long.</source>
 如果超长，将不会打开。</translation>
     </message>
     <message>
-        <source>Load Test Case File Length Limit</source>
-        <translation>加载测试用例文件长度限制</translation>
+        <source>Load Test Case Length Limit</source>
+        <translation>加载测试用例长度限制</translation>
     </message>
     <message>
         <source>Path to LSP executable</source>
@@ -2514,9 +2514,9 @@ If the output is too long, it will be elided.</source>
         <translation>会显示出来的程序输出的最大字符数。如果输出过长，超长部分会被省略。</translation>
     </message>
     <message>
-        <source>The maximum number of characters in a test case file to load.
-A test case loaded from file will be elided and read-only if it&apos;s too long.</source>
-        <translation>被加载的测试用例文件的最大字符数。从文件中加载的测试用例如果过长，超长部分会被省略。</translation>
+        <source>The maximum number of characters in a test case to be loaded.
+A loaded test case will be elided and read-only if it&apos;s too long.</source>
+        <translation>一个被加载的测试用例中最大的字符数量。一个被加载的测试用例如果过长，超长部分会被省略。</translation>
     </message>
 </context>
 <context>
@@ -2712,8 +2712,8 @@ A test case loaded from file will be elided and read-only if it&apos;s too long.
         <translation>设置-&gt;高级-&gt;限制-&gt;输出显示长度限制</translation>
     </message>
     <message>
-        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case File Length Limit</source>
-        <translation>设置-&gt;高级-&gt;限制-&gt;加载测试用例文件长度限制</translation>
+        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case Length Limit</source>
+        <translation>设置-&gt;高级-&gt;限制-&gt;加载测试用例长度限制</translation>
     </message>
     <message>
         <source>The %1 is too long, only the first %2 characters are shown. You can set the length limit in %3.


### PR DESCRIPTION
## Description

Now the test cases loaded from files and program output are elided and read-only if they are too long.

## Related Issue

This closes #487.

## Motivation and Context

Users may want to test on big test cases while the performance is good.

## How Has This Been Tested?

On Arch Linux.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/86993795-84e5bf00-c1d7-11ea-9a11-0da5ff30c802.png)

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
