### PR TITLE
tools(updateTranslation): support Windows and remove unnecessary arguments

### DIFF
--- a/tools/updateTranslation.bat
+++ b/tools/updateTranslation.bat
@@ -1,0 +1,19 @@
+@echo off
+
+if "%cd:~-5%" == "tools" cd ..
+
+if "%1" == "r" (
+	set LOCATIONS=relative
+) else if "%1" == "a" (
+	set LOCATIONS=absolute
+) else (
+	set LOCATIONS=none
+)
+
+set SOURCES=src build/generated build/cpeditor_autogen/ui build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen
+
+(for %%i in (zh_CN ru_RU) do (
+	lupdate -no-obsolete %SOURCES% -locations %LOCATIONS% -tr-function-alias tr+=TRKEY -ts translations/%%i.ts
+))
+
+pause

--- a/tools/updateTranslation.sh
+++ b/tools/updateTranslation.sh
@@ -8,18 +8,8 @@ else
 	LOCATIONS=none
 fi
 
-declare -a SOURCES
-declare -a DIRS
-declare -a INCS
-
-SOURCES=(src/*.cpp src/*/*.cpp build/generated/*.cpp build/generated/*.hpp build/cpeditor_autogen/ui/*.h build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen/include/*.h)
-DIRS=(Core Extensions Settings Telemetry Util Widgets)
-INCS=()
-
-for i in "${DIRS[@]}"; do
-	INCS=("${INCS[@]}" -I src/"$i");
-done
+SOURCES=(src build/generated build/cpeditor_autogen/ui build/third_party/QtFindReplaceDialog/dialogs/QtFindReplaceDialog_autogen)
 
 for i in zh_CN ru_RU; do
-	lupdate -no-obsolete "${SOURCES[@]}" -locations "$LOCATIONS" -tr-function-alias tr+=TRKEY -ts translations/$i.ts -I src "${INCS[@]}"
+	lupdate -no-obsolete "${SOURCES[@]}" -locations "$LOCATIONS" -tr-function-alias tr+=TRKEY -ts translations/$i.ts
 done


### PR DESCRIPTION
## Description

Add `updateTranslation.bat` for Windows and remove unnecessary arguments of `updateTranslation.sh`.

A screenshot of `lupdate --help`:

![image](https://user-images.githubusercontent.com/30581822/87236917-b9e55200-c421-11ea-950b-0466d34f96e8.png)

## How Has This Been Tested?

On my Windows 10 and Arch Linux.