### PR TITLE
chore(Settings): disable Tab Jump Out Parentheses by default

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -44,6 +44,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now the default main class name of Java is `Main` instead of `a`. (#461)
 - Now the version displayed in `cpeditor --version` is `X.Y.Z.rXX.gGITHASH` if the current commit (HEAD) has no tag, otherwise, it is the actual version. (#468)
 - Now the manual URL contains the commit hash instead of the version number, so that it works on the master branch. (#468)
+- Now Tab Jump Out Parentheses is disabled by default. (#499)
 
 ## v6.5
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -304,7 +304,6 @@
         "name": "Tab Jump Out Parentheses",
         "desc": "Jump out of a parenthesis by pressing Tab",
         "type": "bool",
-        "default": true,
         "tip": "When this is enabled, you can use Tab instead of the\nclosing parenthesis to jump out of a parenthesis.\nThis can be overridden for each parenthesis in each language."
     },
     {


### PR DESCRIPTION
## Description

Disable Tab Jump Out Parentheses by default

## Related Issue

#498

## Motivation and Context

This feature could be confusing if you don't know it exists.

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
