### PR TITLE
ci: fix release checksums

### DIFF
--- a/.github/workflows/release_checksums.yml
+++ b/.github/workflows/release_checksums.yml
@@ -29,7 +29,9 @@ jobs:
         run: |
           mkdir -p downloads
           cd downloads
-          dn() { wget -c "https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/cpeditor-${{ steps.get_version.outputs.VERSION }}-$1" }
+          dn() {
+            wget -c "https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/cpeditor-${{ steps.get_version.outputs.VERSION }}-$1"
+          }
           dn linux-x86_64.AppImage
           dn linux-x86_64-portable.AppImage
           dn windows-x64-setup.exe


### PR DESCRIPTION
## Description

Make `dn()` in multi-lines.

## Motivation and Context

Bash functions need to be in multi-lines.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/87422615-8108d100-c60b-11ea-8a26-ab6f0fb0484a.png)