### PR TITLE
feat: add duplicate tab

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -29,6 +29,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - An option to disable toast messages of CF Tool. (#489)
 - Add Russian translations. (#494)
 - Now the test cases will be elided if they are too long. (#491)
+- Duplicate Tab (in the context menu of tabs). (#481 and #505)
 
 ### Fixed
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1341,6 +1341,13 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
         tabMenu->addAction(tr("Close All"), [this] { on_actionCloseAll_triggered(); });
         QString filePath = widget->getFilePath();
 
+        tabMenu->addSeparator();
+
+        tabMenu->addAction(tr("Duplicate Tab"), [widget, this] {
+            openTab("");
+            currentWindow()->loadStatus(widget->toStatus(), true);
+        });
+
         LOG_INFO(INFO_OF(filePath));
 
         if (!widget->isUntitled() && QFile::exists(filePath))

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -438,7 +438,7 @@ MainWindow::EditorStatus MainWindow::toStatus() const
     return status;
 }
 
-void MainWindow::loadStatus(const EditorStatus &status)
+void MainWindow::loadStatus(const EditorStatus &status, bool withoutFilePath)
 {
     LOG_INFO("Requesting loadStatus");
     setProblemURL(status.problemURL);
@@ -447,7 +447,8 @@ void MainWindow::loadStatus(const EditorStatus &status)
     untitledIndex = status.untitledIndex;
     testcases->addCustomCheckers(status.customCheckers);
     testcases->setCheckerIndex(status.checkerIndex);
-    setFilePath(status.filePath);
+    if (!withoutFilePath)
+        setFilePath(status.filePath);
     savedText = status.savedText;
     editor->setPlainText(status.editorText);
     auto cursor = editor->textCursor();

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -89,7 +89,7 @@ class MainWindow : public QMainWindow
     void setUntitledIndex(int index);
 
     EditorStatus toStatus() const;
-    void loadStatus(const EditorStatus &status);
+    void loadStatus(const EditorStatus &status, bool withoutFilePath = false);
 
     bool save(bool force, const QString &head, bool safe = true);
     void saveAs();

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -567,7 +567,7 @@ Git commit hash: %2
     </message>
     <message>
         <source>Duplicate Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>дублировать вкладку</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -567,7 +567,7 @@ Git commit hash: %2
     </message>
     <message>
         <source>Duplicate Tab</source>
-        <translation>дублировать вкладку</translation>
+        <translation>Дублировать вкладку</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -565,6 +565,10 @@ Git commit hash: %2
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Все текущие настройки будут потеряны после импорта файла настройки. Вы хотите продолжить?</translation>
     </message>
+    <message>
+        <source>Duplicate Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AppearancePage</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -301,7 +301,7 @@
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation>Клонировать строку</translation>
+        <translation>Дублировать строку</translation>
     </message>
     <message>
         <source>Ctrl+Shift+D</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -565,6 +565,10 @@ git 提交编号: %2
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>当前所有设置都会在从文件中导入设置后丢失。你确定要继续吗？</translation>
     </message>
+    <message>
+        <source>Duplicate Tab</source>
+        <translation>复制标签页</translation>
+    </message>
 </context>
 <context>
     <name>AppearancePage</name>


### PR DESCRIPTION
## Description

Add “Duplicate Tab" described in #481.

It opens a new tab with all information saved in hot-exit except the file path.

## Related Issue

This closes #481.

## Motivation and Context

For example, I may want to write a brute force solution with the same examples, or try some minor changes without losing the old codes.

## How Has This Been Tested?

On Arch Linux.

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.

@IZOBRETATEL777 @sadykhzadeh you can add the Russian translations.
