### PR TITLE
fix: fix the zh_CN translation of missing OpenSSL is HTML escaped

### DIFF
--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2593,7 +2593,7 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
     <message>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
-        <translation>这个错误很可能是缺失 OpenSSL 库导致的。你可以访问 &amp;lt;a href=&amp;quot;https://wiki.openssl.org/index.php/Binaries&amp;quot;&amp;gt;OpenSSLWiki&amp;lt;/a&amp;gt; 来获取 OpenSSL 的下载地址，或使用你喜欢的包管理器来安装。你需要安装一个和此版本兼容的版本：[%1]</translation>
+        <translation>这个错误很可能是缺失 OpenSSL 库导致的。你可以访问 &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; 来获取 OpenSSL 的下载地址，或使用你喜欢的包管理器来安装。你需要安装一个和此版本兼容的版本：[%1]</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

The translation was HTML escaped, and the raw HTML was displayed in the UI. Now it isn't and the link is displayed in the UI.

## How Has This Been Tested?

On Windows 10.