### PR TITLE
perf: load MainWindow::EditorStatus without opening an untitled tab

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -48,6 +48,10 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now the manual URL contains the commit hash instead of the version number, so that it works on the master branch. (#468)
 - Now Tab Jump Out Parentheses is disabled by default. (#499)
 
+### Improved
+
+- Now restoring the last session is faster. (#509)
+
 ## v6.5
 
 ### Added

--- a/src/Core/SessionManager.cpp
+++ b/src/Core/SessionManager.cpp
@@ -92,8 +92,7 @@ void SessionManager::restoreSession(const QString &path)
         if (progressDialog.wasCanceled())
             break;
         auto status = MainWindow::EditorStatus(tab.toObject().toVariantMap());
-        app->openTab("");
-        app->currentWindow()->loadStatus(status);
+        app->openTab(status);
         progressDialog.setLabelText(QString(tr("Restoring: [%1]")).arg(app->currentWindow()->getTabTitle(true, false)));
         progressDialog.setValue(progressDialog.value() + 1);
     }

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -33,7 +33,6 @@
 #include "Util/Util.hpp"
 #include "generated/SettingsHelper.hpp"
 #include "generated/version.hpp"
-#include "mainwindow.hpp"
 #include <QClipboard>
 #include <QDesktopServices>
 #include <QDragEnterEvent>
@@ -346,6 +345,25 @@ void AppWindow::saveSettings()
     // findReplaceDialog->writeSettings(*SettingsHelper::settings()); FIX IT!!!
 }
 
+void AppWindow::openTab(MainWindow *window)
+{
+    connect(window, SIGNAL(confirmTriggered(MainWindow *)), this, SLOT(onConfirmTriggered(MainWindow *)));
+    connect(window, SIGNAL(editorFileChanged()), this, SLOT(onEditorFileChanged()));
+    connect(window, SIGNAL(editorTmpPathChanged(MainWindow *, const QString &)), this,
+            SLOT(onEditorTmpPathChanged(MainWindow *, const QString &)));
+    connect(window, SIGNAL(editorLanguageChanged(MainWindow *)), this, SLOT(onEditorLanguageChanged(MainWindow *)));
+    connect(window, SIGNAL(editorTextChanged(MainWindow *)), this, SLOT(onEditorTextChanged(MainWindow *)));
+    connect(window, &MainWindow::editorFontChanged, this, [this] { onSettingsApplied("Appearance"); });
+    connect(window, SIGNAL(requestToastMessage(const QString &, const QString &)), trayIcon,
+            SLOT(showMessage(const QString &, const QString &)));
+    connect(window, SIGNAL(compileOrRunTriggered()), this, SLOT(onCompileOrRunTriggered()));
+
+    ui->tabWidget->setCurrentIndex(ui->tabWidget->addTab(window, window->getTabTitle(false, true)));
+
+    window->getEditor()->setFocus();
+    onEditorFileChanged();
+}
+
 void AppWindow::openTab(const QString &path)
 {
     LOG_INFO("OpenTab Path is " << path);
@@ -363,17 +381,7 @@ void AppWindow::openTab(const QString &path)
         }
     }
 
-    auto fsp = new MainWindow(path, getNewUntitledIndex(), this);
-    connect(fsp, SIGNAL(confirmTriggered(MainWindow *)), this, SLOT(onConfirmTriggered(MainWindow *)));
-    connect(fsp, SIGNAL(editorFileChanged()), this, SLOT(onEditorFileChanged()));
-    connect(fsp, SIGNAL(editorTmpPathChanged(MainWindow *, const QString &)), this,
-            SLOT(onEditorTmpPathChanged(MainWindow *, const QString &)));
-    connect(fsp, SIGNAL(editorLanguageChanged(MainWindow *)), this, SLOT(onEditorLanguageChanged(MainWindow *)));
-    connect(fsp, SIGNAL(editorTextChanged(MainWindow *)), this, SLOT(onEditorTextChanged(MainWindow *)));
-    connect(fsp, &MainWindow::editorFontChanged, this, [this] { onSettingsApplied("Appearance"); });
-    connect(fsp, SIGNAL(requestToastMessage(const QString &, const QString &)), trayIcon,
-            SLOT(showMessage(const QString &, const QString &)));
-    connect(fsp, SIGNAL(compileOrRunTriggered()), this, SLOT(onCompileOrRunTriggered()));
+    auto newWindow = new MainWindow(path, getNewUntitledIndex(), this);
 
     QString lang = SettingsHelper::getDefaultLanguage();
 
@@ -386,11 +394,15 @@ void AppWindow::openTab(const QString &path)
     else if (Util::pythonSuffix.contains(suffix))
         lang = "Python";
 
-    ui->tabWidget->setCurrentIndex(ui->tabWidget->addTab(fsp, fsp->getTabTitle(false, true)));
-    fsp->setLanguage(lang);
+    newWindow->setLanguage(lang);
 
-    currentWindow()->getEditor()->setFocus();
-    onEditorFileChanged();
+    openTab(newWindow);
+}
+
+void AppWindow::openTab(const MainWindow::EditorStatus &status, bool duplicate)
+{
+    auto newWindow = new MainWindow(status, duplicate, getNewUntitledIndex(), this);
+    openTab(newWindow);
 }
 
 void AppWindow::openTabs(const QStringList &paths)
@@ -1343,10 +1355,7 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
 
         tabMenu->addSeparator();
 
-        tabMenu->addAction(tr("Duplicate Tab"), [widget, this] {
-            openTab("");
-            currentWindow()->loadStatus(widget->toStatus(), true);
-        });
+        tabMenu->addAction(tr("Duplicate Tab"), [widget, this] { openTab(widget->toStatus(), true); });
 
         LOG_INFO(INFO_OF(filePath));
 

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -18,11 +18,11 @@
 #ifndef APPWINDOW_HPP
 #define APPWINDOW_HPP
 
+#include "mainwindow.hpp"
 #include <QMainWindow>
 #include <QSystemTrayIcon>
 
 class FindReplaceDialog;
-class MainWindow;
 class MessageLogger;
 class PreferencesWindow;
 class QMenu;
@@ -234,7 +234,9 @@ class AppWindow : public QMainWindow
     QVector<QShortcut *> hotkeyObjects;
     void maybeSetHotkeys();
     bool closeTab(int index);
+    void openTab(MainWindow *window);
     void openTab(const QString &path);
+    void openTab(const MainWindow::EditorStatus &status, bool duplicate = false);
     void openTabs(const QStringList &paths);
     void openPaths(const QStringList &paths, bool cpp = true, bool java = true, bool python = true, int depth = -1);
     QStringList openFolder(const QString &path, bool cpp, bool java, bool python, int depth);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,12 +51,11 @@
 
 // ***************************** RAII  ****************************
 
-MainWindow::MainWindow(const QString &fileOpen, int index, QWidget *parent)
+MainWindow::MainWindow(int index, QWidget *parent)
     : QMainWindow(parent), ui(new Ui::MainWindow), untitledIndex(index), fileWatcher(new QFileSystemWatcher(this)),
       autoSaveTimer(new QTimer(this))
 {
-    LOG_INFO(INFO_OF(fileOpen) << INFO_OF(index));
-
+    LOG_INFO(INFO_OF(index));
     ui->setupUi(this);
     setupCore();
     setTestCases();
@@ -66,10 +65,22 @@ MainWindow::MainWindow(const QString &fileOpen, int index, QWidget *parent)
         autoSaveTimer, &QTimer::timeout, autoSaveTimer, [this] { saveFile(AutoSave, tr("Auto Save"), false); },
         Qt::DirectConnection);
     applySettings("", true);
+    QTimer::singleShot(0, [this] { setLanguage(language); }); // See issue #187 for more information
+}
+
+MainWindow::MainWindow(const QString &fileOpen, int index, QWidget *parent) : MainWindow(index, parent)
+{
+    LOG_INFO(INFO_OF(fileOpen));
     loadFile(fileOpen);
     if (testcases->count() == 0)
         testcases->addTestCase();
-    QTimer::singleShot(0, [this] { setLanguage(language); }); // See issue #187 for more information
+}
+
+MainWindow::MainWindow(const EditorStatus &status, bool duplicate, int index, QWidget *parent)
+    : MainWindow(index, parent)
+{
+    LOG_INFO(INFO_OF(duplicate));
+    loadStatus(status, duplicate);
 }
 
 MainWindow::~MainWindow()
@@ -438,17 +449,19 @@ MainWindow::EditorStatus MainWindow::toStatus() const
     return status;
 }
 
-void MainWindow::loadStatus(const EditorStatus &status, bool withoutFilePath)
+void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
 {
     LOG_INFO("Requesting loadStatus");
     setProblemURL(status.problemURL);
     if (status.isLanguageSet)
         setLanguage(status.language);
-    untitledIndex = status.untitledIndex;
+    if (!duplicate)
+    {
+        untitledIndex = status.untitledIndex;
+        setFilePath(status.filePath);
+    }
     testcases->addCustomCheckers(status.customCheckers);
     testcases->setCheckerIndex(status.checkerIndex);
-    if (!withoutFilePath)
-        setFilePath(status.filePath);
     savedText = status.savedText;
     editor->setPlainText(status.editorText);
     auto cursor = editor->textCursor();

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -73,7 +73,9 @@ class MainWindow : public QMainWindow
         QMap<QString, QVariant> toMap() const;
     };
 
+    explicit MainWindow(int index, QWidget *parent);
     explicit MainWindow(const QString &fileOpen, int index, QWidget *parent);
+    explicit MainWindow(const EditorStatus &status, bool duplicate, int index, QWidget *parent);
     ~MainWindow() override;
 
     int getUntitledIndex() const;
@@ -89,7 +91,7 @@ class MainWindow : public QMainWindow
     void setUntitledIndex(int index);
 
     EditorStatus toStatus() const;
-    void loadStatus(const EditorStatus &status, bool withoutFilePath = false);
+    void loadStatus(const EditorStatus &status, bool duplicate = false);
 
     bool save(bool force, const QString &head, bool safe = true);
     void saveAs();


### PR DESCRIPTION
## Description

Now you can construct a new MainWindow with a `MainWindow::EditorStatus` without opening an untitled tab with a code template at first.

This also fixes the bug that the duplicated tab has the same untitled tab index as the original tab.

## Related Issue

This is a part of #191.

## Motivation and Context

It is a waste of time and makes the window title blinking between "untitled" and file paths to open an untitled tab before loading the status.

## How Has This Been Tested?

Tested on Arch Linux. It is about 70% faster when restoring empty files.

## Screenshots (if appropriate)

## Type of changes

- [x] Bug fix (changes which fix an issue)
- [x] Performance improve (changes which improve performance)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
