### PR TITLE
build: fix release issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: "ubuntu-16.04", portable-option: "Off", portable-name: "" }
-          - {
-              os: "ubuntu-16.04",
-              portable-option: "On",
-              portable-name: "-portable",
-            }
+          - { os: "ubuntu-16.04", portable-option: "Off" }
           - {
               os: "windows-latest",
               portable-option: "Off",
@@ -32,12 +27,8 @@ jobs:
               portable-option: "On",
               portable-name: "-portable.zip",
             }
-          - { os: "macos-latest", portable-option: "Off", portable-name: "" }
-          - {
-              os: "macos-latest",
-              portable-option: "On",
-              portable-name: "-portable",
-            }
+          - { os: "macos-latest", portable-option: "Off" }
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -93,7 +84,7 @@ jobs:
           cp ../.ci/linux/cpeditor.desktop . && cp ../.ci/linux/cpeditor-icon.png .
           cp cpeditor.desktop default.desktop
           ./linuxdeployqt*.AppImage ./cpeditor -appimage -qmake=../../Qt/${{ env.QT_VERSION }}/gcc_64/bin/qmake
-          mv CP_Editor-${{steps.get_version.outputs.VERSION }}-x86_64.AppImage cpeditor-${{ steps.get_version.outputs.VERSION }}-linux-x86_64${{ matrix.config.portable-name }}.AppImage
+          mv CP_Editor-${{steps.get_version.outputs.VERSION }}-x86_64.AppImage cpeditor-${{ steps.get_version.outputs.VERSION }}-linux-x86_64.AppImage
 
       - name: Release AppImage
         if: startsWith(matrix.config.os, 'ubuntu')
@@ -101,19 +92,19 @@ jobs:
         with:
           draft: true
           prerelease: ${{ steps.get_version.outputs.ISBETA }}
-          files: build/cpeditor-${{ steps.get_version.outputs.VERSION }}-linux-x86_64${{ matrix.config.portable-name }}.AppImage
+          files: build/cpeditor-${{ steps.get_version.outputs.VERSION }}-linux-x86_64.AppImage
           name: CP Editor ${{ steps.get_version.outputs.VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package full Source
-        if: startsWith(matrix.config.os, 'ubuntu') && matrix.config.portable-option == 'Off'
+        if: startsWith(matrix.config.os, 'ubuntu')
         run: |
           wget https://raw.githubusercontent.com/Kentzo/git-archive-all/master/git_archive_all.py
           python3 git_archive_all.py cpeditor-${{ steps.get_version.outputs.VERSION }}-full-source.tar.gz
 
       - name: Release full source
-        if: startsWith(matrix.config.os, 'ubuntu') && matrix.config.portable-option == 'Off'
+        if: startsWith(matrix.config.os, 'ubuntu')
         uses: softprops/action-gh-release@v1
         with:
           draft: true
@@ -129,7 +120,7 @@ jobs:
           cd build
           ../../Qt/*/*/bin/macdeployqt cpeditor.app
           cp ../.ci/mac/cpeditor.icns cpeditor.app/Contents/Resources
-          hdiutil create -volname cpeditor-${{ steps.get_version.outputs.VERSION }}-x64 -srcfolder cpeditor.app -ov -format UDZO cpeditor-${{ steps.get_version.outputs.VERSION }}-macos-x64${{ matrix.config.portable-name }}.dmg
+          hdiutil create -volname cpeditor-${{ steps.get_version.outputs.VERSION }}-x64 -srcfolder cpeditor.app -ov -format UDZO cpeditor-${{ steps.get_version.outputs.VERSION }}-macos-x64.dmg
 
       - name: Release on Mac
         if: startsWith(matrix.config.os, 'macos')
@@ -137,7 +128,7 @@ jobs:
         with:
           draft: true
           prerelease: ${{ steps.get_version.outputs.ISBETA }}
-          files: build/cpeditor-${{ steps.get_version.outputs.VERSION }}-macos-x64${{ matrix.config.portable-name }}.dmg
+          files: build/cpeditor-${{ steps.get_version.outputs.VERSION }}-macos-x64.dmg
           name: CP Editor ${{ steps.get_version.outputs.VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,24 +49,14 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Install Qt on Ubuntu
-        if: startsWith(matrix.config.os, 'ubuntu')
-        run: |
-          sudo add-apt-repository ppa:beineri/opt-qt-5.15.0-xenial -y
-          sudo apt-get update -qq
-          sudo apt-get -y install qt515base libgl1-mesa-dev qt515svg qt515imageformats
-          bash /opt/qt*/bin/qt*-env.sh
-
-      - name: Restore Qt from cache on Windows and macOS
-        if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macos')
+      - name: Restore Qt from cache
         id: cache-qt
         uses: actions/cache@v1
         with:
           path: ../Qt
           key: Qt-${{ matrix.config.os }}-${{ env.QT_VERSION }}
 
-      - name: Set up Qt environment on Windows and macOS
-        if: startsWith(matrix.config.os, 'windows') || startsWith(matrix.config.os, 'macos')
+      - name: Set up Qt environment
         uses: jurplel/install-qt-action@v2
         with:
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
@@ -95,14 +85,14 @@ jobs:
       - name: Pack to AppImage
         if: startsWith(matrix.config.os, 'ubuntu')
         run: |
-          bash /opt/qt*/bin/qt*-env.sh
+          sudo apt install libxcb*
           cd build
           wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
           chmod a+x linuxdeployqt*.AppImage
           export VERSION=${{ steps.get_version.outputs.VERSION }}
           cp ../.ci/linux/cpeditor.desktop . && cp ../.ci/linux/cpeditor-icon.png .
           cp cpeditor.desktop default.desktop
-          ./linuxdeployqt*.AppImage ./cpeditor -appimage -qmake=/opt/qt515/bin/qmake
+          ./linuxdeployqt*.AppImage ./cpeditor -appimage -qmake=../../Qt/${{ env.QT_VERSION }}/gcc_64/bin/qmake
           mv CP_Editor-${{steps.get_version.outputs.VERSION }}-x86_64.AppImage cpeditor-${{ steps.get_version.outputs.VERSION }}-linux-x86_64${{ matrix.config.portable-name }}.AppImage
 
       - name: Release AppImage

--- a/.github/workflows/release_checksums.yml
+++ b/.github/workflows/release_checksums.yml
@@ -35,7 +35,7 @@ jobs:
           dn linux-x86_64.AppImage
           dn linux-x86_64-portable.AppImage
           dn windows-x64-setup.exe
-          dn windows-x64-portable.exe
+          dn windows-x64-portable.zip
           dn macos-x64.dmg
           dn macos-x64-portable.dmg
           dn full-source.tar.gz

--- a/.github/workflows/release_checksums.yml
+++ b/.github/workflows/release_checksums.yml
@@ -33,11 +33,9 @@ jobs:
             wget -c "https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/cpeditor-${{ steps.get_version.outputs.VERSION }}-$1"
           }
           dn linux-x86_64.AppImage
-          dn linux-x86_64-portable.AppImage
           dn windows-x64-setup.exe
           dn windows-x64-portable.zip
           dn macos-x64.dmg
-          dn macos-x64-portable.dmg
           dn full-source.tar.gz
           shasum -a 256 *.* > cpeditor-${{ steps.get_version.outputs.VERSION }}-sha256-checksums.txt
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### The Portable Version
 
-The portable version saves the config file in the same directory as the executable file of CP Editor, instead of the system config directory. And you can run it without installtion on Windows (on Linux and macOS, the normal version can also be run without installation).
+Now we provide the portable version on Windows. The portable version saves the config file in the same directory as the executable file of CP Editor, instead of the system config directory, and you can run it without installtion.
 
 With the portable version, you can easily store it in something like a USB disk, and the configs are always with you no matter you run it on which machine. However, the file paths in the settings can be broken when you change the machine.
 

--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -85,9 +85,9 @@ UpdateChecker::UpdateMetaInformation UpdateChecker::toMetaInformation(const QJso
         if (assetName.contains("linux"))
 #endif
 #ifdef PORTABLE_VERSION
-            if (assetName.contains("portable"))
+            if (result.assetDownloadUrl.isEmpty() || assetName.contains("portable"))
 #else
-            if (!assetName.contains("portable"))
+            if (result.assetDownloadUrl.isEmpty() || !assetName.contains("portable"))
 #endif
                 result.assetDownloadUrl = asset["browser_download_url"].toString();
     }

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -32,6 +32,7 @@
 #include "Util/FileUtil.hpp"
 #include "Util/Util.hpp"
 #include "generated/SettingsHelper.hpp"
+#include "generated/portable.hpp"
 #include "generated/version.hpp"
 #include "mainwindow.hpp"
 #include <QClipboard>
@@ -573,8 +574,13 @@ void AppWindow::on_actionAboutQt_triggered()
 void AppWindow::on_actionBuildInfo_triggered()
 {
     QMessageBox::about(this, tr("Build Info"),
-                       tr("App version: %1\nGit commit hash: %2\nBuild time: %3\nOS: %4")
+                       tr("App version: %1\nBuild type: %2\nGit commit hash: %3\nBuild time: %4\nOS: %5")
                            .arg(APP_VERSION)
+#ifdef PORTABLE_VERSION
+                           .arg(tr("Portable Version"))
+#else
+                           .arg(tr("Setup Version"))
+#endif
                            .arg(GIT_COMMIT_HASH)
                            .arg(__DATE__ " " __TIME__)
 #if defined(Q_OS_UNIX)

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -548,16 +548,6 @@
         <translation>Отчет об ошибках</translation>
     </message>
     <message>
-        <source>App version: %1
-Git commit hash: %2
-Build time: %3
-OS: %4</source>
-        <translation>Версия программы: %1
-Git commit hash: %2
-Время Сборки: %3
-ОС: %4</translation>
-    </message>
-    <message>
         <source>Import Settings</source>
         <translation>Импорт настроек</translation>
     </message>
@@ -568,6 +558,22 @@ Git commit hash: %2
     <message>
         <source>Duplicate Tab</source>
         <translation>Дублировать вкладку</translation>
+    </message>
+    <message>
+        <source>App version: %1
+Build type: %2
+Git commit hash: %3
+Build time: %4
+OS: %5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Portable Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Setup Version</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -565,15 +565,19 @@ Build type: %2
 Git commit hash: %3
 Build time: %4
 OS: %5</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия программы: %1
+Тип сборки: %2
+Git commit hash: %3
+Время сборки: %4
+ОС: %5</translation>
     </message>
     <message>
         <source>Portable Version</source>
-        <translation type="unfinished"></translation>
+        <translation>Portable-версия</translation>
     </message>
     <message>
         <source>Setup Version</source>
-        <translation type="unfinished"></translation>
+        <translation>Версия для установки</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -549,13 +549,15 @@
     </message>
     <message>
         <source>App version: %1
-Git commit hash: %2
-Build time: %3
-OS: %4</source>
+Build type: %2
+Git commit hash: %3
+Build time: %4
+OS: %5</source>
         <translation>应用版本: %1
-git 提交编号: %2
-构建时间: %3
-操作系统: %4</translation>
+构建类型: %2
+git 提交编号: %3
+构建时间: %4
+操作系统: %5</translation>
     </message>
     <message>
         <source>Import Settings</source>
@@ -568,6 +570,14 @@ git 提交编号: %2
     <message>
         <source>Duplicate Tab</source>
         <translation>复制标签页</translation>
+    </message>
+    <message>
+        <source>Portable Version</source>
+        <translation>绿色版</translation>
+    </message>
+    <message>
+        <source>Setup Version</source>
+        <translation>安装版</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

-   Use the Qt installed by aqtinstall to build the AppImage.
-   Added portable/setup in the build info.
-   Fixed the Windows portable suffix in release checksums.
-   Removed the portable version on Linux and macOS.

## Related Issue

#454.

## How Has This Been Tested?

The AppImage has been built in my fork and the release is [here](https://github.com/ouuan/cpeditor/releases/tag/release-test).