### PR TITLE
refactor: disable shortcut translations and change default format shortcut

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -47,6 +47,7 @@ With the portable version, you can easily store it in something like a USB disk,
 - Now the version displayed in `cpeditor --version` is `X.Y.Z.rXX.gGITHASH` if the current commit (HEAD) has no tag, otherwise, it is the actual version. (#468)
 - Now the manual URL contains the commit hash instead of the version number, so that it works on the master branch. (#468)
 - Now Tab Jump Out Parentheses is disabled by default. (#499)
+- The default shortcut to format codes is changed to `Ctrl+Shift+I`. (#512)
 
 ### Improved
 

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -160,16 +160,8 @@
         <translation>CP Editor: редактор, созданный для спортивного программирования</translation>
     </message>
     <message>
-        <source>Ctrl+N</source>
-        <translation>Ctrl+N</translation>
-    </message>
-    <message>
         <source>Save</source>
         <translation>Сохранить</translation>
-    </message>
-    <message>
-        <source>Ctrl+S</source>
-        <translation>Ctrl+S</translation>
     </message>
     <message>
         <source>Save As...</source>
@@ -180,20 +172,12 @@
         <translation>Сохранить как новый файл</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+S</source>
-        <translation>Ctrl+Shift+S</translation>
-    </message>
-    <message>
         <source>Save All</source>
         <translation>Сохранить все</translation>
     </message>
     <message>
         <source>Save all opened files</source>
         <translation>Сохранить все открытые файлы</translation>
-    </message>
-    <message>
-        <source>Ctrl+Alt+Shift+S</source>
-        <translation>Ctrl+Alt+Shift+S</translation>
     </message>
     <message>
         <source>Close Current</source>
@@ -204,20 +188,12 @@
         <translation>Закрыть текущую вкладку</translation>
     </message>
     <message>
-        <source>Ctrl+W</source>
-        <translation>Ctrl+W</translation>
-    </message>
-    <message>
         <source>Close Saved</source>
         <translation>Закрыть сохраненные</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
         <translation>Закрыть сохраненные вкладки</translation>
-    </message>
-    <message>
-        <source>Ctrl+Alt+W</source>
-        <translation>Ctrl+Alt+W</translation>
     </message>
     <message>
         <source>Close All</source>
@@ -228,20 +204,12 @@
         <translation>Закрыть все вкладки</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+W</source>
-        <translation>Ctrl+Shift+W</translation>
-    </message>
-    <message>
         <source>Quit</source>
         <translation>Выйти</translation>
     </message>
     <message>
         <source>Quit the application</source>
         <translation>Выйти из программы</translation>
-    </message>
-    <message>
-        <source>Ctrl+Q</source>
-        <translation>Ctrl+Q</translation>
     </message>
     <message>
         <source>Open File...</source>
@@ -252,10 +220,6 @@
         <translation>Открыть файлы</translation>
     </message>
     <message>
-        <source>Ctrl+O</source>
-        <translation>Ctrl+O</translation>
-    </message>
-    <message>
         <source>Open Contest...</source>
         <translation>Открыть соревнование...</translation>
     </message>
@@ -264,120 +228,60 @@
         <translation>Открыть соревнование</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+O</source>
-        <translation>Ctrl+Shift+O</translation>
-    </message>
-    <message>
         <source>Indent</source>
         <translation>Отступ</translation>
-    </message>
-    <message>
-        <source>Ctrl+]</source>
-        <translation>Ctrl+]</translation>
     </message>
     <message>
         <source>Unindent</source>
         <translation>Убрать отступ</translation>
     </message>
     <message>
-        <source>Ctrl+[</source>
-        <translation>Ctrl+[</translation>
-    </message>
-    <message>
         <source>Swap Line Up</source>
         <translation>Поднять строку</translation>
-    </message>
-    <message>
-        <source>Ctrl+Shift+Up</source>
-        <translation>Ctrl+Shift+Up</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
         <translation>Опустить строку</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+Down</source>
-        <translation>Ctrl+Shift+Down</translation>
-    </message>
-    <message>
         <source>Duplicate Line</source>
         <translation>Дублировать строку</translation>
-    </message>
-    <message>
-        <source>Ctrl+Shift+D</source>
-        <translation>Ctrl+Shift+D</translation>
     </message>
     <message>
         <source>Delete Line</source>
         <translation>Удалить линию</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+K</source>
-        <translation>Ctrl+Shift+K</translation>
-    </message>
-    <message>
         <source>Toggle Comment</source>
         <translation>Закомментировать строку</translation>
-    </message>
-    <message>
-        <source>Ctrl+/</source>
-        <translation>Ctrl+/</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
         <translation>Выбрать блок</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+/</source>
-        <translation>Ctrl+Shift+/</translation>
-    </message>
-    <message>
         <source>Compile</source>
         <translation>Скомпилировать</translation>
-    </message>
-    <message>
-        <source>Ctrl+Shift+C</source>
-        <translation>Ctrl+Shift+C</translation>
     </message>
     <message>
         <source>Compile and Run</source>
         <translation>Скомпилировать и запустить</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+R</source>
-        <translation>Ctrl+Shift+R</translation>
-    </message>
-    <message>
         <source>Run</source>
         <translation>Запустить</translation>
-    </message>
-    <message>
-        <source>Ctrl+R</source>
-        <translation>Ctrl+R</translation>
     </message>
     <message>
         <source>Format code</source>
         <translation>Форматировать код</translation>
     </message>
     <message>
-        <source>Ctrl+Alt+L</source>
-        <translation>Ctrl+Alt+L</translation>
-    </message>
-    <message>
         <source>Run Detached</source>
         <translation>Запустить отдельно</translation>
     </message>
     <message>
-        <source>Ctrl+Alt+D</source>
-        <translation>Ctrl+Alt+D</translation>
-    </message>
-    <message>
         <source>Kill Processes</source>
         <translation>Убить процесс</translation>
-    </message>
-    <message>
-        <source>Ctrl+K</source>
-        <translation>Ctrl+K</translation>
     </message>
     <message>
         <source>Find and Replace</source>
@@ -400,10 +304,6 @@
         <translation>Проверить обновления</translation>
     </message>
     <message>
-        <source>Ctrl+F</source>
-        <translation>Ctrl+F</translation>
-    </message>
-    <message>
         <source>New File</source>
         <translation>Новый файл</translation>
     </message>
@@ -420,20 +320,12 @@
         <translation>Использовать сниппет...</translation>
     </message>
     <message>
-        <source>Ctrl+T</source>
-        <translation>Ctrl+T</translation>
-    </message>
-    <message>
         <source>Export Settings...</source>
         <translation>Экспорт настроек...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
         <translation>Импорт настроек...</translation>
-    </message>
-    <message>
-        <source>Ctrl+P</source>
-        <translation>Ctrl+P</translation>
     </message>
     <message>
         <source>Reset Settings</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -160,16 +160,8 @@
         <translation>CP Editor: 一款为算法竞赛量身定制的编辑器</translation>
     </message>
     <message>
-        <source>Ctrl+N</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Save</source>
         <translation>保存</translation>
-    </message>
-    <message>
-        <source>Ctrl+S</source>
-        <translation></translation>
     </message>
     <message>
         <source>Save As...</source>
@@ -180,20 +172,12 @@
         <translation>保存到一个新文件</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+S</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Save All</source>
         <translation>保存所有</translation>
     </message>
     <message>
         <source>Save all opened files</source>
         <translation>保存所有打开的文件</translation>
-    </message>
-    <message>
-        <source>Ctrl+Alt+Shift+S</source>
-        <translation></translation>
     </message>
     <message>
         <source>Close Current</source>
@@ -204,20 +188,12 @@
         <translation>关闭当前标签页</translation>
     </message>
     <message>
-        <source>Ctrl+W</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Close Saved</source>
         <translation>关闭已保存</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
         <translation>关闭已保存的标签页</translation>
-    </message>
-    <message>
-        <source>Ctrl+Alt+W</source>
-        <translation></translation>
     </message>
     <message>
         <source>Close All</source>
@@ -228,20 +204,12 @@
         <translation>关闭所有标签页</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+W</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
         <source>Quit the application</source>
         <translation>退出程序</translation>
-    </message>
-    <message>
-        <source>Ctrl+Q</source>
-        <translation></translation>
     </message>
     <message>
         <source>Open File...</source>
@@ -252,10 +220,6 @@
         <translation>打开文件</translation>
     </message>
     <message>
-        <source>Ctrl+O</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Open Contest...</source>
         <translation>打开比赛...</translation>
     </message>
@@ -264,120 +228,60 @@
         <translation>打开一个比赛</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+O</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Indent</source>
         <translation>增加缩进</translation>
-    </message>
-    <message>
-        <source>Ctrl+]</source>
-        <translation></translation>
     </message>
     <message>
         <source>Unindent</source>
         <translation>减少缩进</translation>
     </message>
     <message>
-        <source>Ctrl+[</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Swap Line Up</source>
         <translation>向上交换当前行</translation>
-    </message>
-    <message>
-        <source>Ctrl+Shift+Up</source>
-        <translation></translation>
     </message>
     <message>
         <source>Swap Line Down</source>
         <translation>向下交换当前行</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+Down</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Duplicate Line</source>
         <translation>复制当前行</translation>
-    </message>
-    <message>
-        <source>Ctrl+Shift+D</source>
-        <translation></translation>
     </message>
     <message>
         <source>Delete Line</source>
         <translation>删除当前行</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+K</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Toggle Comment</source>
         <translation>开启/关闭单行注释</translation>
-    </message>
-    <message>
-        <source>Ctrl+/</source>
-        <translation></translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
         <translation>开启/关闭多行注释</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+/</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Compile</source>
         <translation>编译</translation>
-    </message>
-    <message>
-        <source>Ctrl+Shift+C</source>
-        <translation></translation>
     </message>
     <message>
         <source>Compile and Run</source>
         <translation>编译并运行</translation>
     </message>
     <message>
-        <source>Ctrl+Shift+R</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Run</source>
         <translation>运行</translation>
-    </message>
-    <message>
-        <source>Ctrl+R</source>
-        <translation></translation>
     </message>
     <message>
         <source>Format code</source>
         <translation>格式化代码</translation>
     </message>
     <message>
-        <source>Ctrl+Alt+L</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Run Detached</source>
         <translation>在终端中运行</translation>
     </message>
     <message>
-        <source>Ctrl+Alt+D</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Kill Processes</source>
         <translation>终止所有进程</translation>
-    </message>
-    <message>
-        <source>Ctrl+K</source>
-        <translation></translation>
     </message>
     <message>
         <source>Find and Replace</source>
@@ -400,10 +304,6 @@
         <translation>检查更新</translation>
     </message>
     <message>
-        <source>Ctrl+F</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>New File</source>
         <translation>新建文件</translation>
     </message>
@@ -420,20 +320,12 @@
         <translation>使用代码片段...</translation>
     </message>
     <message>
-        <source>Ctrl+T</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Export Settings...</source>
         <translation>导出设置...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
         <translation>导入设置...</translation>
-    </message>
-    <message>
-        <source>Ctrl+P</source>
-        <translation></translation>
     </message>
     <message>
         <source>Reset Settings</source>

--- a/ui/appwindow.ui
+++ b/ui/appwindow.ui
@@ -147,7 +147,7 @@
     <string>Open a new tab in the editor</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+N</string>
+    <string notr="true">Ctrl+N</string>
    </property>
   </action>
   <action name="actionSave">
@@ -158,7 +158,7 @@
     <string>Save the file on the disk</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+S</string>
+    <string notr="true">Ctrl+S</string>
    </property>
   </action>
   <action name="actionSaveAs">
@@ -169,7 +169,7 @@
     <string>Save as new file</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+S</string>
+    <string notr="true">Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionSaveAll">
@@ -180,7 +180,7 @@
     <string>Save all opened files</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+Shift+S</string>
+    <string notr="true">Ctrl+Alt+Shift+S</string>
    </property>
   </action>
   <action name="actionCloseCurrent">
@@ -191,7 +191,7 @@
     <string>Close current tab</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+W</string>
+    <string notr="true">Ctrl+W</string>
    </property>
   </action>
   <action name="actionCloseSaved">
@@ -202,7 +202,7 @@
     <string>Close saved tabs</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+W</string>
+    <string notr="true">Ctrl+Alt+W</string>
    </property>
   </action>
   <action name="actionCloseAll">
@@ -213,7 +213,7 @@
     <string>Close All the tabs</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+W</string>
+    <string notr="true">Ctrl+Shift+W</string>
    </property>
   </action>
   <action name="actionQuit">
@@ -224,7 +224,7 @@
     <string>Quit the application</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Q</string>
+    <string notr="true">Ctrl+Q</string>
    </property>
   </action>
   <action name="actionOpen">
@@ -235,7 +235,7 @@
     <string>Open files</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+O</string>
+    <string notr="true">Ctrl+O</string>
    </property>
   </action>
   <action name="actionOpenContest">
@@ -246,7 +246,7 @@
     <string>Open a Contest</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+O</string>
+    <string notr="true">Ctrl+Shift+O</string>
    </property>
   </action>
   <action name="actionIndent">
@@ -254,7 +254,7 @@
     <string>Indent</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+]</string>
+    <string notr="true">Ctrl+]</string>
    </property>
   </action>
   <action name="actionUnindent">
@@ -262,7 +262,7 @@
     <string>Unindent</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+[</string>
+    <string notr="true">Ctrl+[</string>
    </property>
   </action>
   <action name="actionSwapLineUp">
@@ -270,7 +270,7 @@
     <string>Swap Line Up</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+Up</string>
+    <string notr="true">Ctrl+Shift+Up</string>
    </property>
   </action>
   <action name="actionSwapLineDown">
@@ -278,7 +278,7 @@
     <string>Swap Line Down</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+Down</string>
+    <string notr="true">Ctrl+Shift+Down</string>
    </property>
   </action>
   <action name="actionDuplicateLine">
@@ -286,7 +286,7 @@
     <string>Duplicate Line</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+D</string>
+    <string notr="true">Ctrl+Shift+D</string>
    </property>
   </action>
   <action name="actionDeleteLine">
@@ -294,7 +294,7 @@
     <string>Delete Line</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+K</string>
+    <string notr="true">Ctrl+Shift+K</string>
    </property>
   </action>
   <action name="actionToggleComment">
@@ -302,7 +302,7 @@
     <string>Toggle Comment</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+/</string>
+    <string notr="true">Ctrl+/</string>
    </property>
   </action>
   <action name="actionToggleBlockComment">
@@ -310,7 +310,7 @@
     <string>Toggle Block Comment</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+/</string>
+    <string notr="true">Ctrl+Shift+/</string>
    </property>
   </action>
   <action name="actionCompile">
@@ -318,7 +318,7 @@
     <string>Compile</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+C</string>
+    <string notr="true">Ctrl+Shift+C</string>
    </property>
   </action>
   <action name="actionCompileRun">
@@ -326,7 +326,7 @@
     <string>Compile and Run</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+R</string>
+    <string notr="true">Ctrl+Shift+R</string>
    </property>
   </action>
   <action name="actionRun">
@@ -334,7 +334,7 @@
     <string>Run</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+R</string>
+    <string notr="true">Ctrl+R</string>
    </property>
   </action>
   <action name="actionFormatCode">
@@ -342,7 +342,7 @@
     <string>Format code</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+L</string>
+    <string notr="true">Ctrl+Alt+L</string>
    </property>
   </action>
   <action name="actionRunDetached">
@@ -350,7 +350,7 @@
     <string>Run Detached</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+D</string>
+    <string notr="true">Ctrl+Alt+D</string>
    </property>
   </action>
   <action name="actionKillProcesses">
@@ -358,7 +358,7 @@
     <string>Kill Processes</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+K</string>
+    <string notr="true">Ctrl+K</string>
    </property>
   </action>
   <action name="actionFindReplace">
@@ -366,7 +366,7 @@
     <string>Find and Replace</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+F</string>
+    <string notr="true">Ctrl+F</string>
    </property>
   </action>
   <action name="actionUseSnippets">
@@ -374,7 +374,7 @@
     <string>Use Snippet...</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+T</string>
+    <string notr="true">Ctrl+T</string>
    </property>
   </action>
   <action name="actionSettings">
@@ -382,7 +382,7 @@
     <string>Preferences</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+P</string>
+    <string notr="true">Ctrl+P</string>
    </property>
   </action>
   <action name="actionResetSettings">

--- a/ui/appwindow.ui
+++ b/ui/appwindow.ui
@@ -342,7 +342,7 @@
     <string>Format code</string>
    </property>
    <property name="shortcut">
-    <string notr="true">Ctrl+Alt+L</string>
+    <string notr="true">Ctrl+Shift+I</string>
    </property>
   </action>
   <action name="actionRunDetached">


### PR DESCRIPTION
## Description

As discussed in the Telegram group, now the default shortcut for formatting is changed to <kbd>Ctrl+Shift+I</kbd>.

The translations of shortcuts is also disabled.

## Motivation and Context

On some systems, Ctrl+Alt+L is the default global shortcut for locking the screen, so it's better not to use it.

## How Has This Been Tested?

On Arch Linux.

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
