### PR TITLE
fix(DiffViewer): fix background color with Dark Fusion on Windows

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Fixed
+
+- Fixed the background color of the diff viewer is black on Windows with the Dark Fusion theme. (#519 and #520)
+
 ## 6.6.2 (Beta)
 
 ### Fixed

--- a/src/Widgets/DiffViewer.cpp
+++ b/src/Widgets/DiffViewer.cpp
@@ -79,6 +79,7 @@ void DiffViewer::setText(const QString &output, const QString &expected)
         differ.diff_cleanupEfficiency(diffs);
 
         QString outputHTML, expectedHTML;
+        outputHTML = expectedHTML = "<body style='background-color: white; color: black;'>";
         for (auto diff : diffs)
         {
             QString text = diff.text.toHtmlEscaped().replace(" ", "&nbsp;");
@@ -100,12 +101,9 @@ void DiffViewer::setText(const QString &output, const QString &expected)
                 break;
             }
         }
-        QPalette p = outputEdit->palette();
-        p.setColor(QPalette::Base, Qt::white); // for system dark theme
-        p.setColor(QPalette::Text, Qt::black);
-        outputEdit->setPalette(p);
+        outputHTML += "</body>";
+        expectedHTML += "</body>";
         outputEdit->setHtml(outputHTML);
-        expectedEdit->setPalette(p);
         expectedEdit->setHtml(expectedHTML);
     }
     else


### PR DESCRIPTION
## Description

It uses HTML style instead of palette.

## Related Issue

This fixes #519.

## Motivation and Context

Although the palette was set and it was working on Arch Linux with KDE with both Dark Breeze and Dark Fusion, the background is black on Windows with the Dark Fusion theme.

## How Has This Been Tested?

On Windows 10.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/88261570-26e9c900-ccf9-11ea-8ec6-a779ccd32ce1.png)

## Type of changes

- [x] Bug fix (changes which fix an issue)

## Checklist

- [ ] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
