### PR TITLE
fix(FileProblemBinder): fix restoring old problem URL

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Fixed
+
+- Fixed the old problem URL is not restored when opening an old file with that option on. (#522)
+
 ## 6.5.3
 
 This version is the same as 6.5.2, but it's considered stable now.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -322,7 +322,7 @@ bool MainWindow::isUntitled() const
     return filePath.isEmpty();
 }
 
-void MainWindow::setFilePath(QString path)
+void MainWindow::setFilePath(QString path, bool updateBinder)
 {
     if (QFile::exists(path))
         path = QFileInfo(path).canonicalFilePath();
@@ -333,7 +333,8 @@ void MainWindow::setFilePath(QString path)
         return;
     }
     filePath = path;
-    FileProblemBinder::set(path, problemURL);
+    if (updateBinder)
+        FileProblemBinder::set(path, problemURL);
     emit editorFileChanged();
     updateWatcher();
 }
@@ -728,7 +729,7 @@ void MainWindow::loadFile(const QString &loadPath)
     auto path = loadPath;
 
     bool samePath = !isUntitled() && filePath == path;
-    setFilePath(path);
+    setFilePath(path, false);
 
     bool isTemplate = false;
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -209,7 +209,7 @@ class MainWindow : public QMainWindow
     void loadTests();
     void saveTests(bool safe);
     void setCFToolUI();
-    void setFilePath(QString path);
+    void setFilePath(QString path, bool updateBinder = true);
     void setText(const QString &text, bool keep = false);
     void updateWatcher();
     void loadFile(const QString &loadPath);


### PR DESCRIPTION
## Description

Before this commit, the binding is cleared in MainWindow::loadFile before loaded.

## How Has This Been Tested?

On Arch Linux.

## Type of changes

- [x] Bug fix (changes which fix an issue)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
