### PR TITLE
fix: don't log snippets

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Fixed
+
+- Now the code snippets won't be in the log file. (#536)
+
 ## 6.6.3 (Beta)
 
 ### Fixed

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -178,7 +178,7 @@ bool SettingsManager::contains(const QString &key, bool includingDefault)
 
 void SettingsManager::set(const QString &key, QVariant value)
 {
-    LOG_INFO_IF(!key.startsWith("Snippets/"), INFO_OF(key) << INFO_OF(value.toString()));
+    LOG_INFO_IF(!key.startsWith("Language Config/"), INFO_OF(key) << INFO_OF(value.toString()));
     cur->insert(key, value);
 }
 


### PR DESCRIPTION
## Description

Don't log snippets.

## Motivation and Context

This bug was introduced by moving the path of snippets.

## How Has This Been Tested?

On Arch Linux.

## Type of changes

- [x] Bug fix (changes which fix an issue)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
