### PR TITLE
feat: reveal executable file

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Open recent files. (#527)
+- Reveal the executable file in file manager. (#537)
 
 ### Fixed
 

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -17,6 +17,7 @@
 
 #include "Core/Compiler.hpp"
 #include "Core/EventLogger.hpp"
+#include "Util/FileUtil.hpp"
 #include "generated/SettingsHelper.hpp"
 #include <QDir>
 #include <QFileInfo>
@@ -124,7 +125,8 @@ bool Compiler::check(const QString &compileCommand)
     return finished && checkProcess.exitCode() == 0;
 }
 
-QString Compiler::outputPath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang)
+QString Compiler::outputPath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
+                             bool createDirectory)
 {
     QFileInfo fileInfo(sourceFilePath.isEmpty() ? tmpFilePath : sourceFilePath);
     QString res = fileInfo.dir().filePath(SettingsManager::get(lang + "/Output Path")
@@ -133,11 +135,27 @@ QString Compiler::outputPath(const QString &tmpFilePath, const QString &sourceFi
                                               .replace("${basename}", fileInfo.completeBaseName())
                                               .replace("${tmpdir}", QFileInfo(tmpFilePath).absolutePath())
                                               .replace("${tempdir}", QFileInfo(tmpFilePath).absolutePath()));
-    if (lang == "C++")
-        QDir().mkpath(QFileInfo(res).absolutePath());
-    else if (lang == "Java")
-        QDir().mkpath(res);
+    if (createDirectory)
+    {
+        if (lang == "C++")
+            QDir().mkpath(QFileInfo(res).absolutePath());
+        else if (lang == "Java")
+            QDir().mkpath(res);
+    }
     return res;
+}
+
+QString Compiler::outputFilePath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
+                                 bool createDirectory)
+{
+    auto path = outputPath(tmpFilePath, sourceFilePath, lang, createDirectory);
+
+    if (lang == "C++")
+        path += Util::exeSuffix;
+    else if (lang == "Java")
+        path = QDir(path).filePath(SettingsHelper::getJavaClassName() + ".class");
+
+    return path;
 }
 
 void Compiler::onProcessFinished(int exitCode)

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -72,10 +72,19 @@ class Compiler : public QObject
      * @param tmpFilePath the path to the temporary file which is compiled
      * @param sourceFilePath the path to the original source file, if it's empty, tmpFilePath will be used instead of it
      * @param lang the language being compiled
+     * @param create the directory if it doesn't exist
      * @note if lang is C++, the parent directory of the result will be created; if lang is Java, the result directory
      * will be created
      */
-    static QString outputPath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang);
+    static QString outputPath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
+                              bool createDirectory = true);
+
+    /**
+     * @brief Similar to Compiler::outputPath, but returns the path of the output file.
+     * i.e. with .exe on Windows for C++, class file instead of containing directory for Java
+     */
+    static QString outputFilePath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
+                                  bool createDirectory = true);
 
   signals:
     /**

--- a/src/Util/FileUtil.hpp
+++ b/src/Util/FileUtil.hpp
@@ -69,10 +69,12 @@ QString firstExistingConfigPath(const QStringList &paths);
 /**
  * @brief reveal a file in the file manager
  * @param filePath the path to the file
+ * @param name the name of what to be revealed, e.g. Source File, Executable File
  * @return the first element is a function that reveal the file in the file manager;
- * the second element is the name of the action. e.g. "Reveal in the Explorer" / "Reveal in the file manager"
+ * the second element is the name of the action. e.g. "Reveal *name* in Explorer" / "Reveal *name* in File Manager".
+ * You can use an empty *name* and QString::simplified if you don't want the *name*.
  */
-QPair<std::function<void()>, QString> revealInFileManager(const QString &filePath);
+QPair<std::function<void()>, QString> revealInFileManager(const QString &filePath, const QString &name = QString());
 
 } // namespace Util
 

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -461,15 +461,15 @@ Git commit hash: %3
     </message>
     <message>
         <source>Source File</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл исходного кода</translation>
     </message>
     <message>
         <source>Executable File</source>
-        <translation type="unfinished"></translation>
+        <translation>Исполняемый файл</translation>
     </message>
     <message>
         <source>Open Problem in Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть задачу в браузере</translation>
     </message>
 </context>
 <context>
@@ -2496,19 +2496,19 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
     <message>
         <source>Reveal %1 in Finder</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать %1 в Finder</translation>
     </message>
     <message>
         <source>Reveal %1 in Explorer</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать %1 в Проводнике</translation>
     </message>
     <message>
         <source>Open Containing Folder of %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Открыть папку содержащую %1</translation>
     </message>
     <message>
         <source>Reveal %1 in File Manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Показать %1 в Файловом менеджере</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -96,18 +96,6 @@
         <translation>Копировать путь файла</translation>
     </message>
     <message>
-        <source>Open Containing Folder</source>
-        <translation>Открыть папку содержания</translation>
-    </message>
-    <message>
-        <source>Copy path</source>
-        <translation>Копировать путь</translation>
-    </message>
-    <message>
-        <source>Open problem in browser</source>
-        <translation>Открыть в задачу в браузере</translation>
-    </message>
-    <message>
         <source>Copy Problem URL</source>
         <translation>Копировать URL задачи</translation>
     </message>
@@ -470,6 +458,18 @@ Git commit hash: %3
     <message>
         <source>Clear Recent Files</source>
         <translation>Очистить последние файлы</translation>
+    </message>
+    <message>
+        <source>Source File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Executable File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Problem in Browser</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2495,20 +2495,20 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Не удалось открыть файл [%1]. Предоставлен ли доступ к чтению фалйла?</translation>
     </message>
     <message>
-        <source>Open containing directory</source>
-        <translation>Открыть папку содержания</translation>
+        <source>Reveal %1 in Finder</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reveal in Finder</source>
-        <translation>Показать в Finder</translation>
+        <source>Reveal %1 in Explorer</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reveal in Explorer</source>
-        <translation>Показать в Проводнике</translation>
+        <source>Open Containing Folder of %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reveal in file manager</source>
-        <translation>Показать в файловом менеджере</translation>
+        <source>Reveal %1 in File Manager</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -96,18 +96,6 @@
         <translation>复制文件路径</translation>
     </message>
     <message>
-        <source>Open Containing Folder</source>
-        <translation>打开文件所在的目录</translation>
-    </message>
-    <message>
-        <source>Copy path</source>
-        <translation>复制路径</translation>
-    </message>
-    <message>
-        <source>Open problem in browser</source>
-        <translation>在浏览器中打开题目</translation>
-    </message>
-    <message>
         <source>Copy Problem URL</source>
         <translation>复制题目链接</translation>
     </message>
@@ -470,6 +458,18 @@ git 提交编号: %3
     <message>
         <source>Clear Recent Files</source>
         <translation>清空最近打开的文件</translation>
+    </message>
+    <message>
+        <source>Source File</source>
+        <translation>源文件</translation>
+    </message>
+    <message>
+        <source>Executable File</source>
+        <translation>可执行文件</translation>
+    </message>
+    <message>
+        <source>Open Problem in Browser</source>
+        <translation>在浏览器中打开题目</translation>
     </message>
 </context>
 <context>
@@ -2487,20 +2487,20 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation>打开 [%1] 失败。你拥有读取权限吗？</translation>
     </message>
     <message>
-        <source>Open containing directory</source>
-        <translation>打开文件所在的目录</translation>
+        <source>Reveal %1 in Finder</source>
+        <translation>在访达中查看%1</translation>
     </message>
     <message>
-        <source>Reveal in Finder</source>
-        <translation>在访达中打开</translation>
+        <source>Reveal %1 in Explorer</source>
+        <translation>在资源管理器中查看%1</translation>
     </message>
     <message>
-        <source>Reveal in Explorer</source>
-        <translation>在资源管理器中打开</translation>
+        <source>Open Containing Folder of %1</source>
+        <translation>打开包含%1的文件夹</translation>
     </message>
     <message>
-        <source>Reveal in file manager</source>
-        <translation>在文件管理器中打开</translation>
+        <source>Reveal %1 in File Manager</source>
+        <translation>在文件管理器中打开%1</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2500,7 +2500,7 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
     <message>
         <source>Reveal %1 in File Manager</source>
-        <translation>在文件管理器中打开%1</translation>
+        <translation>在文件管理器中查看%1</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

Add reveal executable files.

## Motivation and Context

This can be a partial solution for #17, because now it's easier to run programs like `gdb` on the executable file.

## How Has This Been Tested?

On Arch Linux.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/88931889-f92ff180-d2af-11ea-8845-2c2f0b869a97.png)

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist

- [ ] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.

@IZOBRETATEL777 You can add translations.
