### PR TITLE
feat: Use contest dialog to open contest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,8 @@ CMakeSettings.json
 # Dependency directories
 node_modules/
 
+# Compile commands for LSP
+compile_commands.json
+
+# Translations
 resources/translations/*.qm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,8 @@ add_executable(cpeditor
     src/Util/Util.cpp
     src/Util/Util.hpp
 
+    src/Widgets/ContestDialog.cpp
+    src/Widgets/ContestDialog.hpp
     src/Widgets/DiffViewer.cpp
     src/Widgets/DiffViewer.hpp
     src/Widgets/TestCase.cpp

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It makes your competitive coding life easier :grin: by automating many things fo
 
 ## Get help
 
-1. Read the [manual](doc/MANUAL.md) and the [FAQ](#faq) first, also go through the menus and preferencecs to see if there are what you are looking for.
+1. Read the [manual](doc/MANUAL.md) and the [FAQ](#faq) first, also go through the menus and preferences to see if there are what you are looking for.
 2. Ask Google first if it's not very editor-related. (e.g. How to install Clang Format? What does this compilation error mean?)
 3. Search in the [Issues](https://github.com/cpeditor/cpeditor/issues) and make sure your bug report/feature request is not duplicated.
 4. Please follow the issue template and provide detailed information, it will help us to give you better feedback.

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Open recent files. (#527)
+- Use Dialog box to open new contests (#539 & #467)
 
 ### Fixed
 

--- a/src/Settings/DefaultPathManager.cpp
+++ b/src/Settings/DefaultPathManager.cpp
@@ -33,7 +33,7 @@ QString DefaultPathManager::defaultPathForAction(const QString &action)
     return result;
 }
 
-void DefaultPathManager::changeDefaultPathForAction(const QString &action, const QString &path)
+void DefaultPathManager::setDefaultPathForAction(const QString &action, const QString &path)
 {
     LOG_INFO(INFO_OF(action) << INFO_OF(path));
 
@@ -67,7 +67,7 @@ QString DefaultPathManager::getExistingDirectory(const QString &action, QWidget 
 {
     const auto result = QFileDialog::getExistingDirectory(parent, caption, defaultPathForAction(action), options);
     if (!result.isEmpty())
-        changeDefaultPathForAction(action, result);
+        setDefaultPathForAction(action, result);
     return result;
 }
 
@@ -78,7 +78,7 @@ QString DefaultPathManager::getOpenFileName(const QString &action, QWidget *pare
     const auto result =
         QFileDialog::getOpenFileName(parent, caption, defaultPathForAction(action), filter, selectedFilter, options);
     if (!result.isEmpty())
-        changeDefaultPathForAction(action, result);
+        setDefaultPathForAction(action, result);
     return result;
 }
 
@@ -89,7 +89,7 @@ QStringList DefaultPathManager::getOpenFileNames(const QString &action, QWidget 
     const auto result =
         QFileDialog::getOpenFileNames(parent, caption, defaultPathForAction(action), filter, selectedFilter, options);
     if (!result.isEmpty())
-        changeDefaultPathForAction(action, result.front());
+        setDefaultPathForAction(action, result.front());
     return result;
 }
 
@@ -100,7 +100,7 @@ QString DefaultPathManager::getSaveFileName(const QString &action, QWidget *pare
     const auto result =
         QFileDialog::getSaveFileName(parent, caption, defaultPathForAction(action), filter, selectedFilter, options);
     if (!result.isEmpty())
-        changeDefaultPathForAction(action, result);
+        setDefaultPathForAction(action, result);
     return result;
 }
 

--- a/src/Settings/DefaultPathManager.hpp
+++ b/src/Settings/DefaultPathManager.hpp
@@ -31,9 +31,9 @@ class DefaultPathManager
     static QString defaultPathForAction(const QString &action);
 
     /**
-     * @brief change the default path after getting the default path for *action*
+     * @brief set the default path after getting the default path for *action*
      */
-    static void changeDefaultPathForAction(const QString &action, const QString &path);
+    static void setDefaultPathForAction(const QString &action, const QString &path);
 
     /**
      * @brief a wrapper for QFileDialog::getExistingDirectory

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -1000,8 +1000,9 @@
         "notr": true
     },
     {
-       "name": "Last Root Path",
-       "type": "QString",
-       "notr": true
+        "name": "Number Of Problems In Contest",
+        "type": "int",
+        "default": 5,
+        "notr": true
     }
 ]

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -998,5 +998,10 @@
         "name": "Recent Files",
         "type": "QStringList",
         "notr": true
+    },
+    {
+       "name": "Last Root Path",
+       "type": "QString",
+       "notr": true
     }
 ]

--- a/src/Widgets/ContestDialog.cpp
+++ b/src/Widgets/ContestDialog.cpp
@@ -38,21 +38,64 @@ namespace Widgets
 {
 ContestDialog::ContestDialog(QWidget *parent) : QDialog(parent)
 {
-    allocate();
-    restrictWidgets();
-    setupUI();
+    auto groupBox = new QGroupBox(tr("Contest Details"), this);
+    auto formLayout = new QFormLayout(this);
+    auto problemCountSpinBox = new QSpinBox(this);
+    languageComboBox = new QComboBox(this);
+    contestNameLineEdit = new QLineEdit(this);
+    pathLineEdit = new QLineEdit(this);
+    auto pathToolButton = new QToolButton;
+    auto pathItem = new QHBoxLayout(this);
+
+    auto actionButtons = new QHBoxLayout(this);
+    auto reset = new QPushButton(tr("Reset"), this);
+    auto cancel = new QPushButton(tr("Cancel"), this);
+    auto create = new QPushButton(tr("Create"), this);
+
+    auto parentLayout = new QVBoxLayout(this);
+    
+    problemCountSpinBox->setMinimum(1);
+    problemCountSpinBox->setMaximum(20);
+    problemCountSpinBox->setValue(DEFAULT_PROBLEM_COUNT); // default
+
+    languageComboBox->addItems({"C++", "Java", "Python"});
+    languageComboBox->setMaxVisibleItems(3);
+    languageComboBox->setCurrentText(SettingsHelper::getDefaultLanguage());
+ 
+    pathItem->setContentsMargins(0, 0, 0, 0);
+    pathItem->addWidget(pathLineEdit);
+    pathItem->addWidget(pathToolButton);
+
+    formLayout->addRow(tr("Contest Root"), pathItem);
+    formLayout->addRow(tr("Contest Name"), contestNameLineEdit);
+    formLayout->addRow(tr("Contest language"), languageComboBox);
+    formLayout->addRow(tr("Number of problems"), problemCountSpinBox);
+
+    groupBox->setLayout(formLayout);
+
+    actionButtons->addWidget(cancel, 2);
+    actionButtons->addWidget(reset, 2);
+    actionButtons->addWidget(create, 6);
+
+    parentLayout->addWidget(groupBox);
+    parentLayout->addLayout(actionButtons);
+
+    setLayout(parentLayout);
+
+    pathToolButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton));   
+
     setWindowTitle(tr("Create a new contest"));
 
-    QObject::connect(reset, &QPushButton::clicked, [this]() {
+    QObject::connect(reset, &QPushButton::clicked, [problemCountSpinBox, this]() {
         pathLineEdit->clear();
         contestNameLineEdit->clear();
-        problemCountSpinBox->setValue(5);
+        problemCountSpinBox->setValue(DEFAULT_PROBLEM_COUNT);
         languageComboBox->setCurrentText(SettingsHelper::getDefaultLanguage());
     });
 
     QObject::connect(cancel, &QPushButton::clicked, [this]() { close(); });
 
-    QObject::connect(create, &QPushButton::clicked, [this]() {
+    QObject::connect(create, &QPushButton::clicked, [problemCountSpinBox, this]() {
         if (!validate())
         {
             QMessageBox::warning(this, tr("Cannot create contest"), validationErrorMessage);
@@ -93,53 +136,7 @@ void ContestDialog::updateContestDialog()
     pathLineEdit->setText(SettingsHelper::getLastRootPath());
 }
 
-ContestDialog::~ContestDialog()
-{
-    delete pathToolButton;
-    delete pathLineEdit;
-    delete pathItem;
-    delete contestNameLineEdit;
-    delete languageComboBox;
-    delete problemCountSpinBox;
-    delete formLayout;
-    delete groupBox;
-    delete cancel;
-    delete reset;
-    delete create;
-    delete actionButtons;
-    delete parentLayout;
-}
-
 // Private methods
-void ContestDialog::allocate()
-{
-    groupBox = new QGroupBox(tr("Contest Details"), this);
-    formLayout = new QFormLayout(this);
-    problemCountSpinBox = new QSpinBox(this);
-    languageComboBox = new QComboBox(this);
-    contestNameLineEdit = new QLineEdit(this);
-    pathLineEdit = new QLineEdit(this);
-    pathToolButton = new QToolButton;
-    pathItem = new QHBoxLayout(this);
-
-    actionButtons = new QHBoxLayout(this);
-    reset = new QPushButton(tr("Reset"), this);
-    cancel = new QPushButton(tr("Cancel"), this);
-    create = new QPushButton(tr("Create"), this);
-
-    parentLayout = new QVBoxLayout(this);
-}
-
-void ContestDialog::restrictWidgets()
-{
-    problemCountSpinBox->setMinimum(1);
-    problemCountSpinBox->setMaximum(20);
-    problemCountSpinBox->setValue(5); // default
-
-    languageComboBox->addItems({"C++", "Java", "Python"});
-    languageComboBox->setMaxVisibleItems(3);
-    languageComboBox->setCurrentText(SettingsHelper::getDefaultLanguage());
-}
 
 bool ContestDialog::validate()
 {
@@ -147,43 +144,26 @@ bool ContestDialog::validate()
     QDir dir(pathLineEdit->text());
     if (!dir.exists())
     {
-        validationErrorMessage = QString(tr("Contest path [ %1 ] does not exists").arg(pathLineEdit->text()));
-
+	    auto cpyDir = dir;
+	    cpyDir.cdUp();
+	    if(cpyDir.exists())
+	    {
+        validationErrorMessage = QString(tr("Contest path [ %1 ] does not exists. However a parent directory exists. You can create a directory by specifing its name below.").arg(pathLineEdit->text()));
+	    }
+	    else
+	    {
+		    validationErrorMessage = QString(tr("Contest path [ %1 ] does not exists."));
+	    }
         return false;
     }
 
-    if (!dir.mkpath(contestNameLineEdit->text()))
+    if (!contestNameLineEdit->text().isEmpty() && !dir.mkpath(contestNameLineEdit->text()))
     {
         validationErrorMessage =
             QString(tr("Cannot create directory with name [ %1 ]").arg(contestNameLineEdit->text()));
         return false;
     }
     return true;
-}
-
-void ContestDialog::setupUI()
-{
-    pathItem->setContentsMargins(0, 0, 0, 0);
-    pathItem->addWidget(pathLineEdit);
-    pathItem->addWidget(pathToolButton);
-
-    formLayout->addRow(tr("Contest Root"), pathItem);
-    formLayout->addRow(tr("Contest Name"), contestNameLineEdit);
-    formLayout->addRow(tr("Contest language"), languageComboBox);
-    formLayout->addRow(tr("Number of problems"), problemCountSpinBox);
-
-    groupBox->setLayout(formLayout);
-
-    actionButtons->addWidget(cancel, 2);
-    actionButtons->addWidget(reset, 2);
-    actionButtons->addWidget(create, 6);
-
-    parentLayout->addWidget(groupBox);
-    parentLayout->addLayout(actionButtons);
-
-    setLayout(parentLayout);
-
-    pathToolButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton));
 }
 
 } // namespace Widgets

--- a/src/Widgets/ContestDialog.cpp
+++ b/src/Widgets/ContestDialog.cpp
@@ -53,7 +53,7 @@ ContestDialog::ContestDialog(QWidget *parent) : QDialog(parent)
     auto create = new QPushButton(tr("Create"), this);
 
     auto parentLayout = new QVBoxLayout(this);
-    
+
     problemCountSpinBox->setMinimum(1);
     problemCountSpinBox->setMaximum(20);
     problemCountSpinBox->setValue(DEFAULT_PROBLEM_COUNT); // default
@@ -61,7 +61,7 @@ ContestDialog::ContestDialog(QWidget *parent) : QDialog(parent)
     languageComboBox->addItems({"C++", "Java", "Python"});
     languageComboBox->setMaxVisibleItems(3);
     languageComboBox->setCurrentText(SettingsHelper::getDefaultLanguage());
- 
+
     pathItem->setContentsMargins(0, 0, 0, 0);
     pathItem->addWidget(pathLineEdit);
     pathItem->addWidget(pathToolButton);
@@ -82,7 +82,7 @@ ContestDialog::ContestDialog(QWidget *parent) : QDialog(parent)
 
     setLayout(parentLayout);
 
-    pathToolButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton));   
+    pathToolButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_DialogOpenButton));
 
     setWindowTitle(tr("Create a new contest"));
 
@@ -144,16 +144,18 @@ bool ContestDialog::validate()
     QDir dir(pathLineEdit->text());
     if (!dir.exists())
     {
-	    auto cpyDir = dir;
-	    cpyDir.cdUp();
-	    if(cpyDir.exists())
-	    {
-        validationErrorMessage = QString(tr("Contest path [ %1 ] does not exists. However a parent directory exists. You can create a directory by specifing its name below.").arg(pathLineEdit->text()));
-	    }
-	    else
-	    {
-		    validationErrorMessage = QString(tr("Contest path [ %1 ] does not exists."));
-	    }
+        auto cpyDir = dir;
+        cpyDir.cdUp();
+        if (cpyDir.exists())
+        {
+            validationErrorMessage = QString(tr("Contest path [ %1 ] does not exists. However a parent directory "
+                                                "exists. You can create a directory by specifing its name below.")
+                                                 .arg(pathLineEdit->text()));
+        }
+        else
+        {
+            validationErrorMessage = QString(tr("Contest path [ %1 ] does not exists."));
+        }
         return false;
     }
 

--- a/src/Widgets/ContestDialog.cpp
+++ b/src/Widgets/ContestDialog.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#include <Core/EventLogger.hpp>
+#include <QComboBox>
+#include <QDir>
+#include <QFileInfo>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <Widgets/ContestDialog.hpp>
+#include <generated/SettingsHelper.hpp>
+
+namespace Widgets
+{
+ContestDialog::ContestDialog(QWidget *parent) : QDialog(parent)
+{
+    allocate();
+    restrictWidgets();
+    setupUI();
+
+    QObject::connect(reset, &QPushButton::clicked, []() {});
+    QObject::connect(cancel, &QPushButton::clicked, []() {});
+    QObject::connect(create, &QPushButton::clicked, []() {});
+
+    QObject::connect(pathToolButton, &QToolButton::clicked, []() {});
+}
+
+ContestDialog::ContestData &ContestDialog::contestData()
+{
+    return _data;
+}
+
+ContestDialog::~ContestDialog()
+{
+    delete pathToolButton;
+    delete pathLineEdit;
+    delete pathItem;
+    delete contestNameLineEdit;
+    delete languageComboBox;
+    delete problemCountSpinBox;
+    delete formLayout;
+    delete groupBox;
+    delete reset;
+    delete create;
+    delete cancel;
+    delete actionButtons;
+    delete parentLayout;
+}
+
+// Private methods
+void ContestDialog::allocate()
+{
+    groupBox = new QGroupBox(tr("Contest Details"), this);
+    formLayout = new QFormLayout(this);
+    problemCountSpinBox = new QSpinBox(this);
+    languageComboBox = new QComboBox(this);
+    contestNameLineEdit = new QLineEdit(this);
+    pathLineEdit = new QLineEdit(this);
+    pathToolButton = new QToolButton;
+    pathItem = new QHBoxLayout(this);
+
+    actionButtons = new QVBoxLayout(this);
+    reset = new QPushButton(tr("Reset"), this);
+    cancel = new QPushButton(tr("Cancel"), this);
+    create = new QPushButton(tr("Create"), this);
+
+    parentLayout = new QHBoxLayout(this);
+}
+
+void ContestDialog::restrictWidgets()
+{
+    problemCountSpinBox->setMinimum(1);
+    problemCountSpinBox->setMaximum(20);
+    problemCountSpinBox->setValue(5); // default
+
+    languageComboBox->addItems({"C++", "Java", "Python"});
+    languageComboBox->setMaxVisibleItems(3);
+    languageComboBox->setCurrentText(SettingsHelper::getDefaultLanguage());
+}
+
+bool ContestDialog::validate()
+{
+    validationErrorMessage.clear();
+    QDir dir(pathLineEdit->text());
+    if (!dir.exists())
+    {
+        validationErrorMessage = QString(tr("Contest path %1 does not exists").arg(pathLineEdit->text()));
+
+        return false;
+    }
+
+    if (!dir.mkpath(contestNameLineEdit->text()))
+    {
+        validationErrorMessage = QString(tr("Cannot create directory with name %1").arg(contestNameLineEdit->text()));
+        return false;
+    }
+    return true;
+}
+
+void ContestDialog::setupUI()
+{
+    pathItem->setContentsMargins(0, 0, 0, 0);
+    pathItem->addWidget(pathLineEdit);
+    pathItem->addWidget(pathToolButton);
+
+    formLayout->addRow(tr("Contest Root Path"), pathItem);
+    formLayout->addRow(tr("Contest Name"), contestNameLineEdit);
+    formLayout->addRow(tr("Contest language"), languageComboBox);
+    formLayout->addRow(tr("Number of problems"), problemCountSpinBox);
+
+    groupBox->setLayout(formLayout);
+
+    actionButtons->addWidget(cancel, 0, Qt::AlignRight);
+    actionButtons->addWidget(reset, 0, Qt::AlignRight);
+    actionButtons->addWidget(create, 0, Qt::AlignRight);
+
+    parentLayout->addWidget(groupBox);
+    parentLayout->addLayout(actionButtons);
+
+    setLayout(parentLayout);
+}
+
+} // namespace Widgets

--- a/src/Widgets/ContestDialog.hpp
+++ b/src/Widgets/ContestDialog.hpp
@@ -20,39 +20,50 @@
 
 #include <QDialog>
 
-#define DEFAULT_PROBLEM_COUNT (5)
-class QLineEdit;
 class QComboBox;
+class QLabel;
+class QLineEdit;
+class QSpinBox;
 
 namespace Widgets
 {
 class ContestDialog : public QDialog
 {
     Q_OBJECT
+
   public:
     struct ContestData
     {
-        int number;
         QString path;
+        int number;
         QString language;
     };
 
     explicit ContestDialog(QWidget *parent = nullptr);
-    void updateContestDialog();
-    ContestData &contestData();
-    void closeEvent(QCloseEvent *e) override;
-  signals:
-    void onContestCreated(ContestData const &data);
+
+    ContestData contestData() const;
+
+  protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+  private slots:
+    void reset();
+
+    void submit();
+
+    void chooseDirectory();
+
+    void updateContestPath();
 
   private:
-    bool validate();
+    QString fullPath() const;
 
-    QString validationErrorMessage;
-
-    ContestData _data;
+  private:
     QComboBox *languageComboBox = nullptr;
-    QLineEdit *contestNameLineEdit = nullptr;
-    QLineEdit *pathLineEdit = nullptr;
+    QLineEdit *mainDirectoryEdit = nullptr;
+    QLineEdit *subdirectoryEdit = nullptr;
+    QLabel *contestPathLabel = nullptr;
+    QSpinBox *problemCountSpinBox = nullptr;
 };
 } // namespace Widgets
 

--- a/src/Widgets/ContestDialog.hpp
+++ b/src/Widgets/ContestDialog.hpp
@@ -20,14 +20,8 @@
 
 #include <QDialog>
 
-class QGroupBox;
-class QPushButton;
+#define DEFAULT_PROBLEM_COUNT (5)
 class QLineEdit;
-class QToolButton;
-class QHBoxLayout;
-class QVBoxLayout;
-class QFormLayout;
-class QSpinBox;
 class QComboBox;
 
 namespace Widgets
@@ -47,35 +41,19 @@ class ContestDialog : public QDialog
     void updateContestDialog();
     ContestData &contestData();
     void closeEvent(QCloseEvent *e) override;
-    ~ContestDialog();
   signals:
-    void onContestCreated(ContestData data);
+    void onContestCreated(ContestData const &data);
 
   private:
-    void allocate();
-    void setupUI();
     bool validate();
-    void restrictWidgets();
 
     QString validationErrorMessage;
 
     ContestData _data;
-    QGroupBox *groupBox = nullptr;
-    QFormLayout *formLayout = nullptr;
-    QSpinBox *problemCountSpinBox = nullptr;
-    QComboBox *languageComboBox = nullptr;
+    QComboBox* languageComboBox = nullptr;
     QLineEdit *contestNameLineEdit = nullptr;
     QLineEdit *pathLineEdit = nullptr;
-    QToolButton *pathToolButton = nullptr;
-    QHBoxLayout *pathItem = nullptr;
 
-    QHBoxLayout *actionButtons = nullptr;
-
-    QPushButton *reset = nullptr;
-    QPushButton *create = nullptr;
-    QPushButton *cancel = nullptr;
-
-    QVBoxLayout *parentLayout = nullptr;
 };
 } // namespace Widgets
 

--- a/src/Widgets/ContestDialog.hpp
+++ b/src/Widgets/ContestDialog.hpp
@@ -44,7 +44,9 @@ class ContestDialog : public QDialog
     };
 
     explicit ContestDialog(QWidget *parent = nullptr);
+    void updateContestDialog();
     ContestData &contestData();
+    void closeEvent(QCloseEvent* e) override;
     ~ContestDialog();
   signals:
     void onContestCreated(ContestData data);
@@ -67,12 +69,14 @@ class ContestDialog : public QDialog
     QToolButton *pathToolButton = nullptr;
     QHBoxLayout *pathItem = nullptr;
 
-    QVBoxLayout *actionButtons = nullptr;
+    QHBoxLayout *actionButtons = nullptr;
+    
     QPushButton *reset = nullptr;
     QPushButton *create = nullptr;
     QPushButton *cancel = nullptr;
 
-    QHBoxLayout *parentLayout = nullptr;
+
+    QVBoxLayout *parentLayout = nullptr;
 };
 } // namespace Widgets
 

--- a/src/Widgets/ContestDialog.hpp
+++ b/src/Widgets/ContestDialog.hpp
@@ -50,10 +50,9 @@ class ContestDialog : public QDialog
     QString validationErrorMessage;
 
     ContestData _data;
-    QComboBox* languageComboBox = nullptr;
+    QComboBox *languageComboBox = nullptr;
     QLineEdit *contestNameLineEdit = nullptr;
     QLineEdit *pathLineEdit = nullptr;
-
 };
 } // namespace Widgets
 

--- a/src/Widgets/ContestDialog.hpp
+++ b/src/Widgets/ContestDialog.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#ifndef CONTEST_DIALOG_HPP
+#define CONTEST_DIALOG_HPP
+
+#include <QDialog>
+
+class QGroupBox;
+class QPushButton;
+class QLineEdit;
+class QToolButton;
+class QHBoxLayout;
+class QVBoxLayout;
+class QFormLayout;
+class QSpinBox;
+class QComboBox;
+
+namespace Widgets
+{
+class ContestDialog : public QDialog
+{
+    Q_OBJECT
+  public:
+    struct ContestData
+    {
+        int number;
+        QString path;
+        QString language;
+    };
+
+    explicit ContestDialog(QWidget *parent = nullptr);
+    ContestData &contestData();
+    ~ContestDialog();
+  signals:
+    void onContestCreated(ContestData data);
+
+  private:
+    void allocate();
+    void setupUI();
+    bool validate();
+    void restrictWidgets();
+
+    QString validationErrorMessage;
+
+    ContestData _data;
+    QGroupBox *groupBox = nullptr;
+    QFormLayout *formLayout = nullptr;
+    QSpinBox *problemCountSpinBox = nullptr;
+    QComboBox *languageComboBox = nullptr;
+    QLineEdit *contestNameLineEdit = nullptr;
+    QLineEdit *pathLineEdit = nullptr;
+    QToolButton *pathToolButton = nullptr;
+    QHBoxLayout *pathItem = nullptr;
+
+    QVBoxLayout *actionButtons = nullptr;
+    QPushButton *reset = nullptr;
+    QPushButton *create = nullptr;
+    QPushButton *cancel = nullptr;
+
+    QHBoxLayout *parentLayout = nullptr;
+};
+} // namespace Widgets
+
+#endif

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -666,30 +666,6 @@ void AppWindow::on_actionOpenContest_triggered()
 {
     contestDialog->updateContestDialog();
     contestDialog->show();
-
-    return;
-    auto path = DefaultPathManager::getExistingDirectory("Open Contest", this, tr("Open Contest"));
-    if (QFile::exists(path) && QFileInfo(path).isDir())
-    {
-        bool ok = false;
-        int number =
-            QInputDialog::getInt(this, tr("Open Contest"), tr("Number of problems in this contest:"), 5, 0, 26, 1, &ok);
-        if (ok)
-        {
-            int current = 0;
-            if (SettingsHelper::getDefaultLanguage() == "Java")
-                current = 1;
-            else if (SettingsHelper::getDefaultLanguage() == "Python")
-                current = 2;
-            auto lang = QInputDialog::getItem(this, tr("Open Contest"), tr("Choose a language"),
-                                              {"C++", "Java", "Python"}, current, false, &ok);
-            if (ok)
-            {
-                LOG_INFO("Opening contest with args " << INFO_OF(path) << INFO_OF(lang) << INFO_OF(number));
-               // openContest(path, lang, number);
-            }
-        }
-    }
 }
 
 void AppWindow::on_actionSave_triggered()

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -149,11 +149,7 @@ AppWindow::AppWindow(bool cpp, bool java, bool python, bool noHotExit, int numbe
         lang = "Java";
     else if (python)
         lang = "Python";
-    Widgets::ContestDialog::ContestData data;
-    data.path = path;
-    data.language = lang;
-    data.number = number;
-    openContest(data);
+    openContest({path, number, lang});
     if (ui->tabWidget->count() == 0)
         openTab("");
 
@@ -187,7 +183,6 @@ AppWindow::~AppWindow()
     delete server;
     delete findReplaceDialog;
     delete sessionManager;
-    delete contestDialog;
 
     SettingsManager::deinit();
 
@@ -243,7 +238,6 @@ void AppWindow::setConnections()
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this,
             SLOT(onTrayIconActivated(QSystemTrayIcon::ActivationReason)));
     connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(showOnTop()));
-    connect(contestDialog, &Widgets::ContestDialog::onContestCreated, this, &AppWindow::openContest);
 }
 
 void AppWindow::allocate()
@@ -279,7 +273,6 @@ void AppWindow::allocate()
     trayIcon->show();
 
     sessionManager = new Core::SessionManager(this);
-    contestDialog = new Widgets::ContestDialog(this);
 }
 
 void AppWindow::applySettings()
@@ -665,8 +658,9 @@ void AppWindow::on_actionOpen_triggered()
 
 void AppWindow::on_actionOpenContest_triggered()
 {
-    contestDialog->updateContestDialog();
-    contestDialog->show();
+    Widgets::ContestDialog dialog(this);
+    if (dialog.exec() == QDialog::Accepted)
+        openContest(dialog.contestData());
 }
 
 void AppWindow::on_actionSave_triggered()
@@ -827,11 +821,7 @@ void AppWindow::onReceivedMessage(quint32 instanceId, QByteArray message)
             lang = "Java";
         else if (python)
             lang = "Python";
-        Widgets::ContestDialog::ContestData data;
-        data.path = path;
-        data.language = lang;
-        data.number = number;
-        openContest(data);
+        openContest({path, number, lang});
     }
 }
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -148,7 +148,11 @@ AppWindow::AppWindow(bool cpp, bool java, bool python, bool noHotExit, int numbe
         lang = "Java";
     else if (python)
         lang = "Python";
-    openContest(path, lang, number);
+    Widgets::ContestDialog::ContestData data;
+    data.path = path;
+    data.language = lang;
+    data.number = number;
+    openContest(data);
     if (ui->tabWidget->count() == 0)
         openTab("");
 
@@ -182,6 +186,7 @@ AppWindow::~AppWindow()
     delete server;
     delete findReplaceDialog;
     delete sessionManager;
+    delete contestDialog;
 
     SettingsManager::deinit();
 
@@ -237,6 +242,7 @@ void AppWindow::setConnections()
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this,
             SLOT(onTrayIconActivated(QSystemTrayIcon::ActivationReason)));
     connect(trayIcon, SIGNAL(messageClicked()), this, SLOT(showOnTop()));
+    connect(contestDialog, &Widgets::ContestDialog::onContestCreated, this, &AppWindow::openContest);
 }
 
 void AppWindow::allocate()
@@ -272,6 +278,7 @@ void AppWindow::allocate()
     trayIcon->show();
 
     sessionManager = new Core::SessionManager(this);
+    contestDialog = new Widgets::ContestDialog(this);
 }
 
 void AppWindow::applySettings()
@@ -495,8 +502,12 @@ QStringList AppWindow::openFolder(const QString &path, bool cpp, bool java, bool
     return res;
 }
 
-void AppWindow::openContest(const QString &path, const QString &lang, int number)
+void AppWindow::openContest(Widgets::ContestDialog::ContestData data)
 {
+    const QString &path = data.path;
+    const QString &lang = data.language;
+    int number = data.number;
+
     QDir dir(path), parent(path);
     parent.cdUp();
     if (!dir.exists() && parent.exists())
@@ -653,6 +664,10 @@ void AppWindow::on_actionOpen_triggered()
 
 void AppWindow::on_actionOpenContest_triggered()
 {
+    contestDialog->updateContestDialog();
+    contestDialog->show();
+
+    return;
     auto path = DefaultPathManager::getExistingDirectory("Open Contest", this, tr("Open Contest"));
     if (QFile::exists(path) && QFileInfo(path).isDir())
     {
@@ -671,7 +686,7 @@ void AppWindow::on_actionOpenContest_triggered()
             if (ok)
             {
                 LOG_INFO("Opening contest with args " << INFO_OF(path) << INFO_OF(lang) << INFO_OF(number));
-                openContest(path, lang, number);
+               // openContest(path, lang, number);
             }
         }
     }
@@ -835,7 +850,11 @@ void AppWindow::onReceivedMessage(quint32 instanceId, QByteArray message)
             lang = "Java";
         else if (python)
             lang = "Python";
-        openContest(path, lang, number);
+        Widgets::ContestDialog::ContestData data;
+        data.path = path;
+        data.language = lang;
+        data.number = number;
+        openContest(data);
     }
 }
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -502,7 +502,7 @@ QStringList AppWindow::openFolder(const QString &path, bool cpp, bool java, bool
     return res;
 }
 
-void AppWindow::openContest(Widgets::ContestDialog::ContestData data)
+void AppWindow::openContest(Widgets::ContestDialog::ContestData const &data)
 {
     const QString &path = data.path;
     const QString &lang = data.language;

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -53,11 +53,6 @@ namespace Core
 class SessionManager;
 }
 
-namespace Widgets
-{
-class ContestDialog;
-}
-
 class AppWindow : public QMainWindow
 {
     Q_OBJECT
@@ -214,7 +209,6 @@ class AppWindow : public QMainWindow
     MessageLogger *activeLogger = nullptr;
 
     Core::SessionManager *sessionManager = nullptr;
-    Widgets::ContestDialog *contestDialog = nullptr;
 
     QTimer *lspTimerCpp = nullptr;
     QTimer *lspTimerPython = nullptr;

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -247,7 +247,7 @@ class AppWindow : public QMainWindow
     void openTabs(const QStringList &paths);
     void openPaths(const QStringList &paths, bool cpp = true, bool java = true, bool python = true, int depth = -1);
     QStringList openFolder(const QString &path, bool cpp, bool java, bool python, int depth);
-    void openContest(Widgets::ContestDialog::ContestData data);
+    void openContest(Widgets::ContestDialog::ContestData const &data);
     bool quit();
     int getNewUntitledIndex();
     void reAttachLanguageServer(MainWindow *window);

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -19,6 +19,7 @@
 #define APPWINDOW_HPP
 
 #include "mainwindow.hpp"
+#include "Widgets/ContestDialog.hpp"
 #include <QMainWindow>
 #include <QSystemTrayIcon>
 
@@ -50,6 +51,11 @@ class UpdateChecker;
 namespace Core
 {
 class SessionManager;
+}
+
+namespace Widgets
+{
+class ContestDialog;
 }
 
 class AppWindow : public QMainWindow
@@ -208,6 +214,7 @@ class AppWindow : public QMainWindow
     MessageLogger *activeLogger = nullptr;
 
     Core::SessionManager *sessionManager = nullptr;
+    Widgets::ContestDialog *contestDialog = nullptr;
 
     QTimer *lspTimerCpp = nullptr;
     QTimer *lspTimerPython = nullptr;
@@ -240,7 +247,7 @@ class AppWindow : public QMainWindow
     void openTabs(const QStringList &paths);
     void openPaths(const QStringList &paths, bool cpp = true, bool java = true, bool python = true, int depth = -1);
     QStringList openFolder(const QString &path, bool cpp, bool java, bool python, int depth);
-    void openContest(const QString &path, const QString &lang, int number);
+    void openContest(Widgets::ContestDialog::ContestData data);
     bool quit();
     int getNewUntitledIndex();
     void reAttachLanguageServer(MainWindow *window);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -356,6 +356,15 @@ void MainWindow::setFilePath(QString path, bool updateBinder)
     filePath = path;
     if (updateBinder)
         FileProblemBinder::set(path, problemURL);
+    if (!isUntitled())
+    {
+        auto recentFiles = SettingsHelper::getRecentFiles();
+        recentFiles.removeAll(filePath);
+        recentFiles.push_front(filePath);
+        if (recentFiles.length() > MAX_NUMBER_OF_RECENT_FILES)
+            recentFiles.erase(recentFiles.begin() + MAX_NUMBER_OF_RECENT_FILES, recentFiles.end());
+        SettingsHelper::setRecentFiles(recentFiles);
+    }
     emit editorFileChanged();
     updateWatcher();
 }
@@ -814,16 +823,6 @@ void MainWindow::loadFile(const QString &loadPath)
         setProblemURL(FileProblemBinder::getProblemForFile(filePath));
 
     setText(content, samePath);
-
-    if (!isUntitled())
-    {
-        auto recentFiles = SettingsHelper::getRecentFiles();
-        recentFiles.removeAll(filePath);
-        recentFiles.push_front(filePath);
-        if (recentFiles.length() > MAX_NUMBER_OF_RECENT_FILES)
-            recentFiles.erase(recentFiles.begin() + MAX_NUMBER_OF_RECENT_FILES, recentFiles.end());
-        SettingsHelper::setRecentFiles(recentFiles);
-    }
 
     if (isTemplate)
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -928,7 +928,7 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
 
         setFilePath(newFilePath);
 
-        DefaultPathManager::changeDefaultPathForAction("Save File", QFileInfo(filePath).canonicalPath());
+        DefaultPathManager::setDefaultPathForAction("Save File", QFileInfo(filePath).canonicalPath());
 
         auto suffix = QFileInfo(filePath).suffix();
         if (Util::cppSuffix.contains(suffix))

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2499,55 +2499,55 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     <name>Widgets::ContestDialog</name>
     <message>
         <source>Contest Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Детали соревнования</translation>
     </message>
     <message>
         <source>Reset</source>
-        <translation type="unfinished">Сбросить</translation>
+        <translation>Сбросить</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished">Отмена</translation>
+        <translation>Отмена</translation>
     </message>
     <message>
         <source>Create</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать</translation>
     </message>
     <message>
         <source>Contest Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Название соревнования</translation>
     </message>
     <message>
         <source>Contest language</source>
-        <translation type="unfinished"></translation>
+        <translation>Язык соревнования</translation>
     </message>
     <message>
         <source>Number of problems</source>
-        <translation type="unfinished"></translation>
+        <translation>Число задач</translation>
     </message>
     <message>
         <source>Create a new contest</source>
-        <translation type="unfinished"></translation>
+        <translation>Создать новое соревнование</translation>
     </message>
     <message>
         <source>Cannot create contest</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно создать соревнование</translation>
     </message>
     <message>
         <source>Choose Contest Root</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать корень соревнования</translation>
     </message>
     <message>
         <source>Contest path [ %1 ] does not exists</source>
-        <translation type="unfinished"></translation>
+        <translation>Соревнование с путем [ %1 ] не существует</translation>
     </message>
     <message>
         <source>Cannot create directory with name [ %1 ]</source>
-        <translation type="unfinished"></translation>
+        <translation>Невозможно создать директорию с именем [ %1 ]</translation>
     </message>
     <message>
         <source>Contest Root</source>
-        <translation type="unfinished"></translation>
+        <translation>Корень соревнования</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2507,47 +2507,47 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
     <message>
         <source>Main Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Главная директория</translation>
     </message>
     <message>
         <source>Subdirectory</source>
-        <translation type="unfinished"></translation>
+        <translation>Поддиректория</translation>
     </message>
     <message>
         <source>Number of Problems</source>
-        <translation type="unfinished"></translation>
+        <translation>Число задач</translation>
     </message>
     <message>
         <source>Main Directory doesn&apos;t exist</source>
-        <translation type="unfinished"></translation>
+        <translation>Главная директория не существует</translation>
     </message>
     <message>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Главная директория [%1] не существует. Вы хотите создать ее и продолжить?</translation>
     </message>
     <message>
         <source>Failed to create directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка при создании директории</translation>
     </message>
     <message>
         <source>Failed to create the directory [%1].</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка при создании директории [%1].</translation>
     </message>
     <message>
         <source>Contest Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Детали соревнования</translation>
     </message>
     <message>
         <source>Save Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохранить путь</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="unfinished">Язык</translation>
+        <translation>Язык</translation>
     </message>
     <message>
         <source>Choose Main Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать главную директорию</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -36,18 +36,6 @@
         <translation>Открыть файлы</translation>
     </message>
     <message>
-        <source>Open Contest</source>
-        <translation>Открыть соревнование</translation>
-    </message>
-    <message>
-        <source>Number of problems in this contest:</source>
-        <translation>Число задач в соревновании:</translation>
-    </message>
-    <message>
-        <source>Choose a language</source>
-        <translation>Выберите язык</translation>
-    </message>
-    <message>
         <source>Reset preferences</source>
         <translation>Сбросить настройки</translation>
     </message>
@@ -2526,18 +2514,6 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Contest path %1 does not exists</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cannot create directory with name %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Contest Root Path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Contest Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2547,6 +2523,30 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
     <message>
         <source>Number of problems</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new contest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot create contest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose Contest Root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest path [ %1 ] does not exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot create directory with name [ %1 ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest Root</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2538,16 +2538,20 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Выбрать корень соревнования</translation>
     </message>
     <message>
-        <source>Contest path [ %1 ] does not exists</source>
-        <translation>Соревнование с путем [ %1 ] не существует</translation>
-    </message>
-    <message>
         <source>Cannot create directory with name [ %1 ]</source>
         <translation>Невозможно создать директорию с именем [ %1 ]</translation>
     </message>
     <message>
         <source>Contest Root</source>
         <translation>Корень соревнования</translation>
+    </message>
+    <message>
+        <source>Contest path [ %1 ] does not exists. However a parent directory exists. You can create a directory by specifing its name below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest path [ %1 ] does not exists.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2502,59 +2502,51 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <source>Contest Details</source>
-        <translation>Детали соревнования</translation>
-    </message>
-    <message>
-        <source>Reset</source>
-        <translation>Сбросить</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Отмена</translation>
-    </message>
-    <message>
-        <source>Create</source>
-        <translation>Создать</translation>
-    </message>
-    <message>
-        <source>Contest Name</source>
-        <translation>Название соревнования</translation>
-    </message>
-    <message>
-        <source>Contest language</source>
-        <translation>Язык соревнования</translation>
-    </message>
-    <message>
-        <source>Number of problems</source>
-        <translation>Число задач</translation>
-    </message>
-    <message>
         <source>Create a new contest</source>
         <translation>Создать новое соревнование</translation>
     </message>
     <message>
-        <source>Cannot create contest</source>
-        <translation>Невозможно создать соревнование</translation>
-    </message>
-    <message>
-        <source>Choose Contest Root</source>
-        <translation>Выбрать корень соревнования</translation>
-    </message>
-    <message>
-        <source>Cannot create directory with name [ %1 ]</source>
-        <translation>Невозможно создать директорию с именем [ %1 ]</translation>
-    </message>
-    <message>
-        <source>Contest Root</source>
-        <translation>Корень соревнования</translation>
-    </message>
-    <message>
-        <source>Contest path [ %1 ] does not exists. However a parent directory exists. You can create a directory by specifing its name below.</source>
+        <source>Main Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Contest path [ %1 ] does not exists.</source>
+        <source>Subdirectory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of Problems</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Main Directory doesn&apos;t exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to create directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to create the directory [%1].</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Язык</translation>
+    </message>
+    <message>
+        <source>Choose Main Directory</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2508,6 +2508,49 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
 </context>
 <context>
+    <name>Widgets::ContestDialog</name>
+    <message>
+        <source>Contest Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished">Сбросить</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest path %1 does not exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot create directory with name %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest Root Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of problems</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Widgets::DiffViewer</name>
     <message>
         <source>Diff Viewer</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2500,6 +2500,49 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
 </context>
 <context>
+    <name>Widgets::ContestDialog</name>
+    <message>
+        <source>Contest Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation type="unfinished">重置</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest path %1 does not exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot create directory with name %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest Root Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of problems</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Widgets::DiffViewer</name>
     <message>
         <source>Diff Viewer</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2530,15 +2530,19 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Contest path [ %1 ] does not exists</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cannot create directory with name [ %1 ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Contest Root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest path [ %1 ] does not exists. However a parent directory exists. You can create a directory by specifing its name below.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest path [ %1 ] does not exists.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -36,18 +36,6 @@
         <translation>打开文件</translation>
     </message>
     <message>
-        <source>Open Contest</source>
-        <translation>打开比赛</translation>
-    </message>
-    <message>
-        <source>Number of problems in this contest:</source>
-        <translation>比赛题目数量：</translation>
-    </message>
-    <message>
-        <source>Choose a language</source>
-        <translation>选择语言</translation>
-    </message>
-    <message>
         <source>Reset preferences</source>
         <translation>重置设置</translation>
     </message>
@@ -2518,18 +2506,6 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Contest path %1 does not exists</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cannot create directory with name %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Contest Root Path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Contest Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2539,6 +2515,30 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
     </message>
     <message>
         <source>Number of problems</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create a new contest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot create contest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose Contest Root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest path [ %1 ] does not exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot create directory with name [ %1 ]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Contest Root</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2494,60 +2494,52 @@ A loaded test case will be elided and read-only if it&apos;s too long.</source>
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <source>Contest Details</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reset</source>
-        <translation type="unfinished">重置</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
-    </message>
-    <message>
-        <source>Create</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Contest Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Contest language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of problems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Create a new contest</source>
-        <translation type="unfinished"></translation>
+        <translation>创建一个新比赛</translation>
     </message>
     <message>
-        <source>Cannot create contest</source>
-        <translation type="unfinished"></translation>
+        <source>Main Directory</source>
+        <translation>主目录</translation>
     </message>
     <message>
-        <source>Choose Contest Root</source>
-        <translation type="unfinished"></translation>
+        <source>Subdirectory</source>
+        <translation>子目录</translation>
     </message>
     <message>
-        <source>Cannot create directory with name [ %1 ]</source>
-        <translation type="unfinished"></translation>
+        <source>Number of Problems</source>
+        <translation>题目数量</translation>
     </message>
     <message>
-        <source>Contest Root</source>
-        <translation type="unfinished"></translation>
+        <source>Main Directory doesn&apos;t exist</source>
+        <translation>主目录不存在</translation>
     </message>
     <message>
-        <source>Contest path [ %1 ] does not exists. However a parent directory exists. You can create a directory by specifing its name below.</source>
-        <translation type="unfinished"></translation>
+        <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
+        <translation>主目录 [%1] 不存在。你想要创建目录并继续吗？</translation>
     </message>
     <message>
-        <source>Contest path [ %1 ] does not exists.</source>
-        <translation type="unfinished"></translation>
+        <source>Failed to create directory</source>
+        <translation>创建目录失败</translation>
+    </message>
+    <message>
+        <source>Failed to create the directory [%1].</source>
+        <translation>未能成功创建目录 [%1]。</translation>
+    </message>
+    <message>
+        <source>Contest Details</source>
+        <translation>比赛细节</translation>
+    </message>
+    <message>
+        <source>Save Path</source>
+        <translation>保存路径</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>语言</translation>
+    </message>
+    <message>
+        <source>Choose Main Directory</source>
+        <translation>选择主目录</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Use contest dialogs to open Contests

## Description
This commit adds a dialog widget that can be used to open contest. 

## Related Issue
Fixes #467 

## Motivation and Context
This is better UI than last one.

## How Has This Been Tested?
Win 10 

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/22212259/88934817-b1ed3500-d29e-11ea-89da-b35b223fca44.png)

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [x] New feature (changes which add functionality)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] If there are changes in the text displayed in the UI, I have wrapped them in `tr()` or `QCoreApplication::translate()`.
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.

**Required translations** @IZOBRETATEL777 and @sadykhzadeh 