### PR TITLE
ci(aur): cpeditor-git provides cpeditor

### DIFF
--- a/.ci/aur/git/.SRCINFO
+++ b/.ci/aur/git/.SRCINFO
@@ -17,6 +17,7 @@ pkgbase = cpeditor-git
 	optdepends = jre-openjdk: execute Java support
 	optdepends = python: execute Python support
 	optdepends = xterm: detached run support
+	provides = cpeditor
 	conflicts = cpeditor
 	source = git://github.com/cpeditor/cpeditor.git
 	source = git://github.com/cpeditor/QCodeEditor.git

--- a/.ci/aur/git/PKGBUILD
+++ b/.ci/aur/git/PKGBUILD
@@ -24,6 +24,7 @@ optdepends=(
 	'python: execute Python support'
 	'xterm: detached run support'
 )
+provides=('cpeditor')
 conflicts=("cpeditor")
 
 source=('git://github.com/cpeditor/cpeditor.git'


### PR DESCRIPTION
## Description

Add `cpeditor` in the `provides` array of `cpeditor-git`.

## Motivation and Context

So that users can use `cpeditor-git` as an option when they want to install `cpeditor`.
