### PR TITLE
ci(aur): check PKGBUILD and verify .SRCINFO is up to date

### DIFF
--- a/.github/workflows/check_srcinfo.yml
+++ b/.github/workflows/check_srcinfo.yml
@@ -1,0 +1,23 @@
+name: "Check .SRCINFO"
+
+on: [push, pull_request]
+
+jobs:
+  check-srcinfo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Copy Files
+        run: |
+          cp .ci/aur/stable cpeditor -r
+          cp .ci/aur/git cpeditor-git -r
+      - name: "Check .SRCINFO of cpeditor"
+        uses: 2m/arch-pkgbuild-builder@master
+        with:
+          target: "srcinfo"
+          pkgname: "cpeditor"
+      - name: "Check .SRCINFO of cpeditor-git"
+        uses: 2m/arch-pkgbuild-builder@master
+        with:
+          target: "srcinfo"
+          pkgname: "cpeditor-git"

--- a/.github/workflows/push_aur.yml
+++ b/.github/workflows/push_aur.yml
@@ -39,6 +39,12 @@ jobs:
           cp .ci/aur/git/.SRCINFO cpeditor-git
           sed -i "s/@PROJECT_VERSION@/$VERSION/" cpeditor-git/PKGBUILD cpeditor-git/.SRCINFO
 
+      - name: Check PKGBUILD
+        uses: 2m/arch-pkgbuild-builder@master
+        with:
+          target: "pkgbuild"
+          pkgname: "cpeditor-git"
+
       - name: Publish to AUR
         run: |
           VERSION=$(git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g')

--- a/.github/workflows/push_aur.yml
+++ b/.github/workflows/push_aur.yml
@@ -45,6 +45,12 @@ jobs:
           target: "pkgbuild"
           pkgname: "cpeditor-git"
 
+      - name: "Check .SRCINFO"
+        uses: 2m/arch-pkgbuild-builder@master
+        with:
+          target: "srcinfo"
+          pkgname: "cpeditor-git"
+
       - name: Publish to AUR
         run: |
           VERSION=$(git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g')

--- a/.github/workflows/release_aur.yml
+++ b/.github/workflows/release_aur.yml
@@ -49,6 +49,12 @@ jobs:
           sed -i "s/@PROJECT_VERSION@/${{ steps.get_version.outputs.VERSION }}/" PKGBUILD .SRCINFO
           sed -i "s/SKIP/${sha256sum}/" PKGBUILD .SRCINFO
 
+      - name: Check PKGBUILD
+        uses: 2m/arch-pkgbuild-builder@master
+        with:
+          target: "pkgbuild"
+          pkgname: "cpeditor"
+
       - name: Publish to AUR
         if: steps.get_version.outputs.ISSTABLE == 'true'
         run: |

--- a/.github/workflows/release_aur.yml
+++ b/.github/workflows/release_aur.yml
@@ -50,9 +50,17 @@ jobs:
           sed -i "s/SKIP/${sha256sum}/" PKGBUILD .SRCINFO
 
       - name: Check PKGBUILD
+        if: steps.get_version.outputs.ISSTABLE == 'true'
         uses: 2m/arch-pkgbuild-builder@master
         with:
           target: "pkgbuild"
+          pkgname: "cpeditor"
+
+      - name: "Check .SRCINFO"
+        if: steps.get_version.outputs.ISSTABLE == 'true'
+        uses: 2m/arch-pkgbuild-builder@master
+        with:
+          target: "srcinfo"
           pkgname: "cpeditor"
 
       - name: Publish to AUR


### PR DESCRIPTION
## Description

1. Check `PKGBUILD` and `.SRCINFO` before pushing to AUR.
2. Check `.SRCINFO` is up to date on each push and PR.

## Motivation and Context

To prevent invalid package (for example, with a missing dependency) and make sure `.SRCINFO` is up to date.

## How Has This Been Tested?

Checking `.SRCINFO` is tested in these commits and this PR. (And [it fails when `.SRCINFO` is not up to date](https://github.com/ouuan/cpeditor/actions/runs/191309899)).

I've tested checking `PKGBUILD` in my fork with some steps like setting the SSH key and pushing to AUR deleted. It fails when checking `.SRCINFO` of `cpeditor-git` after checking `PKGBUILD`, because the `PKGBUILD` is changed after checking `PKGBUILD` as it uses the master branch of `cpeditor/cpeditor` to build the package and uses its version as the version of the package, which is different from the version in the testing branch.

## Type of changes

- [x] CI (changes to CI configuration files and scripts)