### PR TITLE
feat(Runner): set the working directory to the output path

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,15 +2,25 @@
 
 ### Added
 
-- Open recent files. (#527)
-- Reveal the executable file in file manager. (#537)
+-   Open recent files. (#527)
+-   Reveal the executable file in file manager. (#537)
 
 ### Fixed
 
-- Fixed the diff viewer crashes when the output is empty. (#517)
-- Fixed the background color of the diff viewer is black on Windows with the Dark Fusion theme. (#519 and #520)
-- Fixed the old problem URL is not restored when opening an old file with that option on. (#522)
-- Fixed the performance issue that makes the editor extremely slow when there are many lines. (cpeditor/QCodeEditor#27)
+-   Fixed the diff viewer crashes when the output is empty. (#517)
+-   Fixed the background color of the diff viewer is black on Windows with the Dark Fusion theme. (#519 and #520)
+-   Fixed the old problem URL is not restored when opening an old file with that option on. (#522)
+-   Fixed the performance issue that makes the editor extremely slow when there are many lines. (cpeditor/QCodeEditor#27)
+
+### Changed
+
+-   Now the working directory when executing programs is:
+
+    1.  The path of the executable file for C++;
+    2.  The class path for Java;
+    3.  The temp file path for Python.
+
+    If you write to files with relative paths in your codes, you can use "Reveal Executable File" to find the outputs.
 
 ## v6.6
 

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -128,6 +128,9 @@ bool Compiler::check(const QString &compileCommand)
 QString Compiler::outputPath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
                              bool createDirectory)
 {
+    if (lang == "Python")
+        return tmpFilePath;
+
     QFileInfo fileInfo(sourceFilePath.isEmpty() ? tmpFilePath : sourceFilePath);
     QString res = fileInfo.dir().filePath(SettingsManager::get(lang + "/Output Path")
                                               .toString()

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -68,13 +68,11 @@ class Compiler : public QObject
     static bool check(const QString &compileCommand);
 
     /**
-     * @brief get the output path (executable file path when compiling C++, class path when compiling Java)
+     * @brief get the output path (executable file path for C++, class path for Java, tmp file path for Python)
      * @param tmpFilePath the path to the temporary file which is compiled
      * @param sourceFilePath the path to the original source file, if it's empty, tmpFilePath will be used instead of it
      * @param lang the language being compiled
      * @param create the directory if it doesn't exist
-     * @note if lang is C++, the parent directory of the result will be created; if lang is Java, the result directory
-     * will be created
      */
     static QString outputPath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
                               bool createDirectory = true);

--- a/src/Core/Runner.cpp
+++ b/src/Core/Runner.cpp
@@ -92,6 +92,8 @@ void Runner::run(const QString &tmpFilePath, const QString &sourceFilePath, cons
 
     QString program = command.takeFirst();
 
+    setWorkingDirectory(tmpFilePath, sourceFilePath, lang);
+
     runProcess->start(program, command);
     bool started = runProcess->waitForStarted(2000);
 
@@ -111,6 +113,8 @@ void Runner::run(const QString &tmpFilePath, const QString &sourceFilePath, cons
 void Runner::runDetached(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
                          const QString &runCommand, const QString &args)
 {
+    setWorkingDirectory(tmpFilePath, sourceFilePath, lang);
+
     // different steps on different OSs
 #if defined(__unix__)
     // use xterm on Linux
@@ -223,6 +227,12 @@ QString Runner::getCommand(const QString &tmpFilePath, const QString &sourceFile
     LOG_INFO("Returning runCommand as : " << res);
 
     return res;
+}
+
+void Runner::setWorkingDirectory(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang)
+{
+    runProcess->setWorkingDirectory(
+        QFileInfo(Compiler::outputFilePath(tmpFilePath, sourceFilePath, lang, false)).path());
 }
 
 } // namespace Core

--- a/src/Core/Runner.hpp
+++ b/src/Core/Runner.hpp
@@ -166,6 +166,12 @@ class Runner : public QObject
     static QString getCommand(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
                               const QString &runCommand, const QString &args);
 
+    /**
+     * @brief set the working directory of runProcess
+     * @note the path of the executable file for C++, class path for Java, temp file path for Python
+     */
+    void setWorkingDirectory(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang);
+
     const int runnerIndex;                   // the index of the testcase
     QProcess *runProcess = nullptr;          // the process to run the program
     QTimer *killTimer = nullptr;             // the timer used to kill the process when the time limit is reached


### PR DESCRIPTION
## Description

Set the working directory to the output path when executing programs.

## Motivation and Context

To prevent creating files in random places, if you write to files in the code. Perhaps it's also useful in other situations.

## How Has This Been Tested?

On Arch Linux.

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
