### PR TITLE
fix: fix crash when compiling twice with large test cases 

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Fixed
+
+- Fixed crash when compiling twice in a row with large test cases. (#549 and #550)
+
 ## 6.5.4
 
 ### Fixed

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -673,6 +673,14 @@ void MainWindow::killProcesses()
 {
     LOG_INFO("Killing all processes");
 
+    if (killingProcesses) // prevent deleting the same pointer multiple times
+    {
+        LOG_INFO("Already killing processes");
+        return;
+    }
+
+    killingProcesses = true;
+
     if (compiler != nullptr)
     {
         delete compiler;
@@ -693,6 +701,8 @@ void MainWindow::killProcesses()
         delete detachedRunner;
         detachedRunner = nullptr;
     }
+
+    killingProcesses = false;
 }
 
 //***************** HELPER FUNCTIONS *****************

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -52,7 +52,8 @@
 // ***************************** RAII  ****************************
 
 MainWindow::MainWindow(const QString &fileOpen, int index, QWidget *parent)
-    : QMainWindow(parent), ui(new Ui::MainWindow), untitledIndex(index), fileWatcher(new QFileSystemWatcher(this))
+    : QMainWindow(parent), ui(new Ui::MainWindow), untitledIndex(index), fileWatcher(new QFileSystemWatcher(this)),
+      reloading(false), killingProcesses(false)
 {
     LOG_INFO(INFO_OF(fileOpen) << INFO_OF(index));
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -193,9 +193,9 @@ class MainWindow : public QMainWindow
     QString savedText;
     QString cftoolPath;
     QFileSystemWatcher *fileWatcher;
-    bool reloading = false;
 
-    bool killingProcesses = false;
+    std::atomic<bool> reloading;
+    std::atomic<bool> killingProcesses;
 
     QPushButton *submitToCodeforces = nullptr;
     Extensions::CFTool *cftool = nullptr;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -195,6 +195,8 @@ class MainWindow : public QMainWindow
     QFileSystemWatcher *fileWatcher;
     bool reloading = false;
 
+    bool killingProcesses = false;
+
     QPushButton *submitToCodeforces = nullptr;
     Extensions::CFTool *cftool = nullptr;
 


### PR DESCRIPTION
## Description

Now `MainWindow::killProcesses` won't be called twice at the same time, thus the double free is fixed.

## Related Issue

This fixes #549.

## How Has This Been Tested?

On Arch Linux.

## Type of changes

- [x] Bug fix (changes which fix an issue)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
