### PR TITLE
refactor: use SettingsHelper::getPath to get the path of a setting

### DIFF
--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -204,13 +204,14 @@ void Checker::onRunTimeout(int index)
 
 void Checker::onRunOutputLimitExceeded(int index, const QString &type)
 {
-    log->warn(tr("Checker[%1]").arg(index + 1),
-              tr("The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer "
-                 "than the output length limit, so the process is killed. You can change the output length limit "
-                 "in Preferences->Advanced->Limits->Output Length Limit")
-                  .arg(type)
-                  .arg(index + 1)
-                  .arg(SettingsHelper::getOutputLengthLimit()));
+    log->warn(
+        tr("Checker[%1]").arg(index + 1),
+        tr("The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer "
+           "than the output length limit, so the process is killed. You can change the output length limit at %4.")
+            .arg(type)
+            .arg(index + 1)
+            .arg(SettingsHelper::getOutputLengthLimit())
+            .arg(SettingsHelper::pathOfOutputLengthLimit()));
 }
 
 void Checker::onRunKilled(int index)

--- a/src/Core/Runner.cpp
+++ b/src/Core/Runner.cpp
@@ -197,10 +197,16 @@ void Runner::onErrorOccurred(QProcess::ProcessError error)
     if (error == QProcess::FailedToStart)
     {
         if (isDetachedRun)
-            emit failedToStartRun(runnerIndex, tr("Failed to start detached execution. Please check your terminal "
-                                                  "emulator settings in Preferences->Actions->Detached Execution."));
+        {
+            emit failedToStartRun(
+                runnerIndex,
+                tr("Failed to start detached execution. Please check your terminal emulator settings in %1.")
+                    .arg(SettingsHelper::pathOfDetachedRunTerminalProgram(true)));
+        }
         else
+        {
             emit failedToStartRun(runnerIndex, tr("Failed to start running. Please compile first."));
+        }
     }
 }
 

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -19,6 +19,7 @@
 #include "Core/EventLogger.hpp"
 #include "Core/MessageLogger.hpp"
 #include "Util/FileUtil.hpp"
+#include "generated/SettingsHelper.hpp"
 #include <QCodeEditor>
 #include <QJsonDocument>
 #include <QProcess>
@@ -195,7 +196,8 @@ QPair<int, QString> ClangFormatter::getFormatResult(const QStringList &args)
         log->warn(
             tr("Formatter"),
             tr("The format process didn't finish in 2 seconds. This is probably because the clang-format binary is not "
-               "found by CP Editor. You can set the path to clang-format in Preferences->Extensions->Clang Format."));
+               "found by CP Editor. You can set the path to clang-format at %1.")
+                .arg(SettingsHelper::pathOfClangFormatPath()));
         return QPair<int, QString>(-1, QString());
     }
 

--- a/src/Extensions/LanguageServer.cpp
+++ b/src/Extensions/LanguageServer.cpp
@@ -288,8 +288,8 @@ void LanguageServer::onLSPServerProcessError(QProcess::ProcessError error)
     {
     case QProcess::FailedToStart:
         logger->error(tr("Langauge Server [%1]").arg(language),
-                      tr("Failed to start LSP Process. Have you set the path to the Language Server program in "
-                         "Preferences->Extensions->Language Server?"));
+                      tr("Failed to start LSP Process. Have you set the path to the Language Server program at %1?")
+                          .arg(SettingsManager::getPathText("LSP/Path " + language)));
         break;
     case QProcess::Crashed:
         break;

--- a/src/Settings/PreferencesPage.hpp
+++ b/src/Settings/PreferencesPage.hpp
@@ -95,7 +95,7 @@ class PreferencesPage : public QWidget
     /**
      * @brief set the path to this page in the preferences window
      */
-    void setPath(const QString &path);
+    virtual void setPath(const QString &path);
 
     /**
      * @brief set the title of the page

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -104,6 +104,13 @@ QStringList PreferencesPageTemplate::content()
     return ret;
 }
 
+void PreferencesPageTemplate::setPath(const QString &path)
+{
+    PreferencesPage::setPath(path);
+    for (const QString &name : options)
+        SettingsManager::setPath(name, path + "/" + SettingsInfo::findSetting(name).desc);
+}
+
 bool PreferencesPageTemplate::areSettingsChanged()
 {
     for (int i = 0; i < options.size(); ++i)

--- a/src/Settings/PreferencesPageTemplate.hpp
+++ b/src/Settings/PreferencesPageTemplate.hpp
@@ -29,6 +29,8 @@ class PreferencesPageTemplate : public PreferencesGridPage
 
     virtual QStringList content() override;
 
+    virtual void setPath(const QString &path) override;
+
   private:
     bool areSettingsChanged() override;
     void makeUITheSameAsDefault() override;

--- a/src/Settings/SettingsManager.hpp
+++ b/src/Settings/SettingsManager.hpp
@@ -43,7 +43,17 @@ class SettingsManager
     static void remove(QStringList keys);
     static void reset();
 
+    /**
+     * @breif set the path of a setting in the preferences window
+     * @param key the name of the setting
+     * @param path The path to the setting, in the form "X/Y/Z/<desc>". The <desc> shouldn't contain slashes.
+     */
     static void setPath(const QString &key, const QString &path);
+    /**
+     * @brief get the path of a setting which can be shown in the UI
+     * @param key the name of the setting
+     * @param parent get the path to the parent directory instead of the setting itself
+     */
     static QString getPathText(const QString &key, bool parent = false);
 
     static QStringList keyStartsWith(const QString &head);

--- a/src/Settings/SettingsManager.hpp
+++ b/src/Settings/SettingsManager.hpp
@@ -43,12 +43,16 @@ class SettingsManager
     static void remove(QStringList keys);
     static void reset();
 
+    static void setPath(const QString &key, const QString &path);
+    static QString getPathText(const QString &key, bool parent = false);
+
     static QStringList keyStartsWith(const QString &head);
     static QStringList itemUnder(const QString &head);
 
   private:
     static QVariantMap *cur;
     static QVariantMap *def;
+    static QMap<QString, QString> *settingPath;
 };
 
 #endif // SETTINGSMANAGER_HPP

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -263,8 +263,9 @@ void TestCase::onToLongForHtml()
 {
     log->warn(tr("Diff Viewer[%1]").arg(id + 1),
               tr("The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change "
-                 "the length limit in Preferences->Advanced->Limits->HTML Diff Viewer Length Limit")
-                  .arg(SettingsHelper::getHTMLDiffViewerLengthLimit()));
+                 "the length limit at %2.")
+                  .arg(SettingsHelper::getHTMLDiffViewerLengthLimit())
+                  .arg(SettingsHelper::pathOfHTMLDiffViewerLengthLimit()));
 }
 
 } // namespace Widgets

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -112,14 +112,14 @@ void TestCaseEdit::modifyText(const QString &text, bool keepHistory)
         displayText = text.left(limit) + "...";
 
         const QString name = role == Input ? tr("Input") : (role == Output ? tr("Output") : tr("Expected"));
-        const QString setLimitPlace = role == Output ? tr("Preferences->Advanced->Limits->Output Display Length Limit")
-                                                     : tr("Preferences->Advanced->Limits->Load Test Case Length Limit");
+        const QString setLimitPlace = role == Output ? SettingsHelper::pathOfOutputDisplayLengthLimit()
+                                                     : SettingsHelper::pathOfLoadTestCaseLengthLimit();
 
         log->warn(
             QString("%1[%2]").arg(name).arg(id + 1),
             QString("<span title='%1'>%2</span>")
                 .arg(
-                    tr("Now the test case editor is read-only. You can set the length limit in %1.").arg(setLimitPlace))
+                    tr("Now the test case editor is read-only. You can set the length limit at %1.").arg(setLimitPlace))
                 .arg(tr("Only the first %1 characters are shown.").arg(limit)),
             false);
     }

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -139,8 +139,9 @@ TestCases::TestCases(MessageLogger *logger, QWidget *parent) : QWidget(parent), 
                     remainPaths.push_back(QString("[%1]").arg(path));
                 log->warn(tr("Load Testcases"),
                           tr("The following files are not loaded because they are not matched:%1. You can set the "
-                             "matching rules at Preferences->File Path->Testcases->Add Testcases From Files Rules.")
-                              .arg(remainPaths.join(", ")));
+                             "matching rules at %2.")
+                              .arg(remainPaths.join(", "))
+                              .arg(SettingsHelper::pathOfTestcasesMatchingRules()));
             }
         }
     });

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -821,9 +821,10 @@ void MainWindow::loadFile(const QString &loadPath)
     {
         log->error(tr("Open File"),
                    tr("The file [%1] contains more than %2 characters, so it's not opened. You can change the "
-                      "open file length limit in Preferences->Advanced->Limits->Open File Length Limit")
+                      "open file length limit at %3.")
                        .arg(path)
-                       .arg(SettingsHelper::getOpenFileLengthLimit()));
+                       .arg(SettingsHelper::getOpenFileLengthLimit())
+                       .arg(SettingsHelper::pathOfOpenFileLengthLimit()));
         setText("");
         setFilePath("");
         return;
@@ -1268,9 +1269,10 @@ void MainWindow::onCompilationErrorOccurred(const QString &error)
         log->error(tr("Compile Errors"), error);
         if (language == "Java" && error.contains("public class"))
         {
-            log->warn(tr("Compile Errors"),
-                      tr("Have you set a proper name for the main class in your solution? If not, you can set it in "
-                         "Preferences->Lanugages->Java->Java Commands->Java Class Name."));
+            log->warn(
+                tr("Compile Errors"),
+                tr("Have you set a proper name for the main class in your solution? If not, you can set it at %1.")
+                    .arg(SettingsHelper::pathOfJavaClassName()));
         }
     }
 }
@@ -1331,13 +1333,14 @@ void MainWindow::onRunTimeout(int index)
 
 void MainWindow::onRunOutputLimitExceeded(int index, const QString &type)
 {
-    log->warn(getRunnerHead(index),
-              tr("The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer "
-                 "than the output length limit, so the process is killed. You can change the output length limit "
-                 "in Preferences->Advanced->Limits->Output Length Limit")
-                  .arg(type)
-                  .arg(index + 1)
-                  .arg(SettingsHelper::getOutputLengthLimit()));
+    log->warn(
+        getRunnerHead(index),
+        tr("The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer "
+           "than the output length limit, so the process is killed. You can change the output length limit at %4.")
+            .arg(type)
+            .arg(index + 1)
+            .arg(SettingsHelper::getOutputLengthLimit())
+            .arg(SettingsHelper::pathOfOutputLengthLimit()));
 }
 
 void MainWindow::onRunKilled(int index)

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -38,6 +38,8 @@ def writeHelper(f, obj, pre, indent):
             else:
                 f.write(
                     f"{ids}inline {typename} get{key}() {{ return SettingsManager::get({json.dumps(name)}).value<{typename}>(); }}\n")
+        f.write(
+            f"{ids}inline QString pathOf{key}(bool parent = false) {{ return SettingsManager::getPathText({json.dumps(name)}, parent); }}\n")
 
 
 def writeInfo(f, obj, lst):

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -659,10 +659,11 @@ Git commit hash: %3
     <message>
         <source>Program finished with exit code %1
 Press any key to exit</source>
-        <translation>Программа завершилась с кодом %1 Нажмите на любую клавишу для выхода</translation>
+        <translation>Программа завершилась с кодом %1
+Нажмите на любую клавишу для выхода</translation>
     </message>
     <message>
-        <source>Failed to start detached execution. Please check your terminal emulator settings %1.</source>
+        <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Не удалось запустить отдельно. Пожалуйста, проверьте настройки вашего эмулятора терминала в %1.</translation>
     </message>
 </context>
@@ -2653,8 +2654,8 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>Отображение различий[%1]</translation>
     </message>
     <message>
-        <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2</source>
-        <translation>Вывод/ответ содержит более %1 знаков, HTML diff viewer отключён. Вы можете изменить лимит длины в %2</translation>
+        <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
+        <translation>Вывод/ответ содержит более %1 знаков, HTML diff viewer отключён. Вы можете изменить лимит длины в %2.</translation>
     </message>
 </context>
 <context>
@@ -2684,7 +2685,7 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>Ожидаемо</translation>
     </message>
     <message>
-        <source>Now the test case editor is read-only. You can set the length limit in %1.</source>
+        <source>Now the test case editor is read-only. You can set the length limit at %1.</source>
         <translation>Сейчас тесткейсы доступны только для чтения. Вы можете установить лимит длины в %1.</translation>
     </message>
     <message>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -615,8 +615,8 @@ Git commit hash: %3
         <translation>Превышено ограничение по времени (TLE)</translation>
     </message>
     <message>
-        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
-        <translation>%1 из процессов при работе на тесткейсе #%2 содержит более чем %3 символов и превосходит лимит. Процесс убит. Вы можете изменить этот лимит в Параметры-&gt;Дополнительно-&gt;Лимиты-&gt;Лимит длины строки вывода</translation>
+        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
+        <translation>%1 из процессов при работе на тесткейсе #%2 содержит более чем %3 символов и превосходит лимит. Процесс убит. Вы можете изменить этот лимит в %4.</translation>
     </message>
     <message>
         <source>Killed</source>
@@ -662,8 +662,8 @@ Press any key to exit</source>
         <translation>Программа завершилась с кодом %1 Нажмите на любую клавишу для выхода</translation>
     </message>
     <message>
-        <source>Failed to start detached execution. Please check your terminal emulator settings in Preferences-&gt;Actions-&gt;Detached Execution.</source>
-        <translation>Не удалось запустить отдельно. Пожалуйста, проверьте настройки вашего эмулятора терминала в Параметры -&gt; Действия -&gt; Отдельный запуск.</translation>
+        <source>Failed to start detached execution. Please check your terminal emulator settings %1.</source>
+        <translation>Не удалось запустить отдельно. Пожалуйста, проверьте настройки вашего эмулятора терминала в %1.</translation>
     </message>
 </context>
 <context>
@@ -739,8 +739,8 @@ Press any key to exit</source>
         <translation>Форматирование завершено</translation>
     </message>
     <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format in Preferences-&gt;Extensions-&gt;Clang Format.</source>
-        <translation>Процесс форматировния не завершился за 2 секунды. Возможно исполняемый файл clang-format не найден CP Editor&apos;ом. Вы можете установить путь к clang-format в Параметры-&gt;Расширения-&gt;Clang Format.</translation>
+        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format at %1.</source>
+        <translation>Процесс форматировния не завершился за 2 секунды. Возможно исполняемый файл clang-format не найден CP Editor&apos;ом. Вы можете установить путь к clang-format в %1.</translation>
     </message>
     <message>
         <source>The format command is: %1 %2</source>
@@ -799,8 +799,8 @@ Press any key to exit</source>
         <translation>Langauge server выдает ошибку. Пожалуйста, проверьте логи.</translation>
     </message>
     <message>
-        <source>Failed to start LSP Process. Have you set the path to the Language Server program in Preferences-&gt;Extensions-&gt;Language Server?</source>
-        <translation>Ошибка при старте Процесса LSP. Вы установили путь к программе Language Server в Параметры-&gt;Расширения-&gt;Language Server?</translation>
+        <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
+        <translation>Ошибка при старте Процесса LSP. Вы установили путь к программе Language Server в %1?</translation>
     </message>
     <message>
         <source>LSP Process timed out</source>
@@ -972,8 +972,8 @@ p, li { white-space: pre-wrap; }
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Open File Length Limit</source>
-        <translation>Файл [%1] содержит более чем %2 символов и он не был открыт. Вы можете установить лимит количества символов в файле в Параметрах-&gt;Дополонительно-&gt;Лимиты-&gt;Лмиит символов в открываемом файле</translation>
+        <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
+        <translation>Файл [%1] содержит более чем %2 символов и он не был открыт. Вы можете установить лимит количества символов в файле в %3.</translation>
     </message>
     <message>
         <source>Save File</source>
@@ -1102,8 +1102,8 @@ Do you want to reload it?</source>
         <translation>Превышен лимит времени выполнения программы (TLE)</translation>
     </message>
     <message>
-        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
-        <translation>Процесс %1 на тесткейсе #%2 содержит более %3 символов, что превосходит лимит длины. Процесс будет убит. Вы можете изменить лимит длины выходного файла в Параметры&gt;Дополнительно-&gt;Лимиты-&gt;Лимит длины выходного файла</translation>
+        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
+        <translation>Процесс %1 на тесткейсе #%2 содержит более %3 символов, что превосходит лимит длины. Процесс будет убит. Вы можете изменить лимит длины выходного файла в %4.</translation>
     </message>
     <message>
         <source>%1 has been killed</source>
@@ -1154,8 +1154,8 @@ Do you want to reload it?</source>
         <translation>Автосохранение</translation>
     </message>
     <message>
-        <source>Have you set a proper name for the main class in your solution? If not, you can set it in Preferences-&gt;Lanugages-&gt;Java-&gt;Java Commands-&gt;Java Class Name.</source>
-        <translation>Вы установили подходящее имя для главного класса в решении? Если нет, Вы можете установить имя в Параметрах-&gt;Языки-&gt;Java-&gt;Java Commands-&gt;Java Class Name.</translation>
+        <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
+        <translation>Вы установили подходящее имя для главного класса в решении? Если нет, Вы можете установить имя в at %1.</translation>
     </message>
 </context>
 <context>
@@ -2653,8 +2653,8 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>Отображение различий[%1]</translation>
     </message>
     <message>
-        <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;HTML Diff Viewer Length Limit</source>
-        <translation>Вывод/ответ содержит более %1 знаков, HTML diff viewer отключён. Вы можете изменить лимит длины в Параметры-&gt;Дополнительно-&gt;Лимиты-&gt;Лимит длины HTML Diff Viewer</translation>
+        <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2</source>
+        <translation>Вывод/ответ содержит более %1 знаков, HTML diff viewer отключён. Вы можете изменить лимит длины в %2</translation>
     </message>
 </context>
 <context>
@@ -2670,14 +2670,6 @@ Consult your terminal emulator for the suitable arguments.</source>
     <message>
         <source>Edit Testcase</source>
         <translation>Изменить тесткейс</translation>
-    </message>
-    <message>
-        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Output Display Length Limit</source>
-        <translation>Параметры-&gt;Дополнительный-&gt;Лимиты-&gt;Лимит длины выводимых данных</translation>
-    </message>
-    <message>
-        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case Length Limit</source>
-        <translation>Параметры-&gt;Дополнительный-&gt;Лимиты-&gt;Лимит длины тесткейсов</translation>
     </message>
     <message>
         <source>Input</source>
@@ -2751,8 +2743,8 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>Вводные данные [%1] загружены</translation>
     </message>
     <message>
-        <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at Preferences-&gt;File Path-&gt;Testcases-&gt;Add Testcases From Files Rules.</source>
-        <translation>Следующие файлы не загружаются, потому что они не совпадают:%1. Можно установить правила соответствия в Параметры-&gt;Путь файла-&gt;Тесткейсы-&gt;Добавить тесткейсы по правилам файлов.</translation>
+        <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
+        <translation>Следующие файлы не загружаются, потому что они не совпадают:%1. Можно установить правила соответствия в %2.</translation>
     </message>
     <message>
         <source>Remove Empty</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -615,8 +615,8 @@ git 提交编号: %3
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
-        <translation>测试点 #%2 的 %1 超过 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在设置-&gt;高级-&gt;限制-&gt;输出长度限制中更改限制大小</translation>
+        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
+        <translation>测试点 #%2 的 %1 超过 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在 %4 更改限制大小。</translation>
     </message>
     <message>
         <source>Killed</source>
@@ -663,8 +663,8 @@ Press any key to exit</source>
 按任意键退出</translation>
     </message>
     <message>
-        <source>Failed to start detached execution. Please check your terminal emulator settings in Preferences-&gt;Actions-&gt;Detached Execution.</source>
-        <translation>未能成功在终端中运行。请在 设置-&gt;动作-&gt;终端中运行 中检查终端模拟器的设置。</translation>
+        <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
+        <translation>未能成功在终端中运行。请在 %1 中检查终端模拟器的设置。</translation>
     </message>
 </context>
 <context>
@@ -740,8 +740,8 @@ Press any key to exit</source>
         <translation>格式化完毕</translation>
     </message>
     <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format in Preferences-&gt;Extensions-&gt;Clang Format.</source>
-        <translation>格式化进程未能在 2 秒内结束。这可能是因为 CP Editor 未能找到 clang-format 的可执行文件。你可以在 设置-&gt;扩展-&gt;Clang Format 中设置 clang-format 可执行文件的路径。</translation>
+        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format at %1.</source>
+        <translation>格式化进程未能在 2 秒内结束。这可能是因为 CP Editor 未能找到 clang-format 的可执行文件。你可以在 %1 设置 clang-format 可执行文件的路径。</translation>
     </message>
     <message>
         <source>The format command is: %1 %2</source>
@@ -800,8 +800,8 @@ Press any key to exit</source>
         <translation>Language server 出现错误。请检查日志文件以获取详细信息。</translation>
     </message>
     <message>
-        <source>Failed to start LSP Process. Have you set the path to the Language Server program in Preferences-&gt;Extensions-&gt;Language Server?</source>
-        <translation>启动 Language server 进程失败。你是否已在设置-&gt;扩展-&gt;Language Server 中设置语言服务器的路径？</translation>
+        <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
+        <translation>启动 Language server 进程失败。你是否已在 %1 设置语言服务器的路径？</translation>
     </message>
     <message>
         <source>LSP Process timed out</source>
@@ -973,8 +973,8 @@ p, li { white-space: pre-wrap; }
         <translation>打开文件</translation>
     </message>
     <message>
-        <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Open File Length Limit</source>
-        <translation>文件 [%1] 包含超过 %2 个字符，因此没有被打开。你可以在设置-&gt;高级-&gt;限制-&gt;打开文件长度限制中更改长度限制</translation>
+        <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
+        <translation>文件 [%1] 包含超过 %2 个字符，因此没有被打开。你可以在 %3 更改长度限制。</translation>
     </message>
     <message>
         <source>Save File</source>
@@ -1103,8 +1103,8 @@ Do you want to reload it?</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;Output Length Limit</source>
-        <translation>在测试点 #%2 上运行的程序的 %1 包含多于 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在设置-&gt;高级-&gt;限制-&gt;输出限制中更改长度限制</translation>
+        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
+        <translation>在测试点 #%2 上运行的程序的 %1 包含多于 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在 %4 更改长度限制。</translation>
     </message>
     <message>
         <source>%1 has been killed</source>
@@ -1155,8 +1155,8 @@ Do you want to reload it?</source>
         <translation>自动保存</translation>
     </message>
     <message>
-        <source>Have you set a proper name for the main class in your solution? If not, you can set it in Preferences-&gt;Lanugages-&gt;Java-&gt;Java Commands-&gt;Java Class Name.</source>
-        <translation>你设置了你代码中主类的名字吗？如果没有，你可以在 设置-&gt;语言-&gt;Java-&gt;Java 命令-&gt;Java 类名称 中进行设置。</translation>
+        <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
+        <translation>你设置了你代码中主类的名字吗？如果没有，你可以在 %1 进行设置。</translation>
     </message>
 </context>
 <context>
@@ -2646,8 +2646,8 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>差异查看器[%1]</translation>
     </message>
     <message>
-        <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit in Preferences-&gt;Advanced-&gt;Limits-&gt;HTML Diff Viewer Length Limit</source>
-        <translation>输出或答案超过了 %1 个字符，因此 HTML 差异查看器已被禁用。你可以在设置-&gt;高级-&gt;限制-&gt;HTML 差异查看器长度限制中更改限制大小</translation>
+        <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
+        <translation>输出或答案超过了 %1 个字符，因此 HTML 差异查看器已被禁用。你可以在 %2 更改限制大小。</translation>
     </message>
 </context>
 <context>
@@ -2665,14 +2665,6 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>编辑测试点</translation>
     </message>
     <message>
-        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Output Display Length Limit</source>
-        <translation>设置-&gt;高级-&gt;限制-&gt;输出显示长度限制</translation>
-    </message>
-    <message>
-        <source>Preferences-&gt;Advanced-&gt;Limits-&gt;Load Test Case Length Limit</source>
-        <translation>设置-&gt;高级-&gt;限制-&gt;加载测试用例长度限制</translation>
-    </message>
-    <message>
         <source>Input</source>
         <translation>输入</translation>
     </message>
@@ -2685,7 +2677,7 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>答案</translation>
     </message>
     <message>
-        <source>Now the test case editor is read-only. You can set the length limit in %1.</source>
+        <source>Now the test case editor is read-only. You can set the length limit at %1.</source>
         <translation>现在测试用例编辑器是只读的。你可以在 %1 中设置长度限制。</translation>
     </message>
     <message>
@@ -2744,8 +2736,8 @@ Consult your terminal emulator for the suitable arguments.</source>
         <translation>已加载输入 [%1]</translation>
     </message>
     <message>
-        <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at Preferences-&gt;File Path-&gt;Testcases-&gt;Add Testcases From Files Rules.</source>
-        <translation>下列文件由于没有匹配而未加载：%1。你可以在设置-&gt;文件路径-&gt;测试点-&gt;测试数据匹配规则中设置匹配规则。</translation>
+        <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
+        <translation>下列文件由于没有匹配而未加载：%1。你可以在 %2 设置匹配规则。</translation>
     </message>
     <message>
         <source>Remove Empty</source>


### PR DESCRIPTION
## Description

Now we can use `SettingsHelper:getPathXXX` or `SettingsManager::getPathTextXXX` to get the path of a setting in the preferences window.

## Motivation and Context

This reduces duplicated translations, and prevent forgetting to change the path after moving a setting.

## How Has This Been Tested?

On Arch Linux.

## Type of changes

- [x] Refactor (changes which affect the meaning of the code but neither fix a bug nor add a feature)