### PR TITLE
chore(mainwindow):Use website instead of github url for problems parsed by competitive companion

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -496,7 +496,7 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
     {
         QString meta = data.toMetaString();
         meta.prepend("\n");
-        meta.append("Powered by CP Editor (https://github.com/cpeditor/cpeditor)");
+        meta.append("Powered by CP Editor (https://cpeditor.org)");
 
         if (language == "Python")
             meta.replace('\n', "\n# ");


### PR DESCRIPTION
This line was added prior to our website page. Website is our main entry point for new users to get themselves familiar to CP Editor. Moreover, Its short and easy to remember URL that github repository. Hence we now write "Powered by CP Editor (https://cpeditor.org)"

<!--- Provide a general summary of your changes in the Title above -->

## Related Issue
N/A

## How Has This Been Tested?
Arch

## Screenshots (if appropriate)
N/A

## Type of changes

- [x] Chore (changes which do not belong to any type above)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] If there are changes of the text displayed in the UI, I have wrapped them in `tr()` or `QCoreApplication::translate()`.
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
