### PR TITLE
feat: add features for solving grader problems

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Customizable head comments. (#203 and #561)
 -   Now in C++, you can use relative paths to include headers files. (#565)
 -   Now you can set different compile commands and time limits for each tab by setting them in the context menu of the tabs. (#565)
+-   Now you can use the time limit from Competitive Companion as the time limit for the corresponding tab. (#565)
 -   Now the compiler works in the same directory as the source file, so that you can use relative paths in the compile command. For example, you can add `grader.cpp` to compile the source file with the grader in the same directory. (#565)
 
 ### Fixed

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,9 @@
 -   Choose detached execution terminal on Linux (#554 and #474)
 -   Add "save to file" in the context menu of the test cases. (#529 and #560)
 -   Customizable head comments. (#203 and #561)
+-   Now in C++, you can use relative paths to include headers files. (#565)
+-   Now you can set different compile commands and time limits for each tab by setting them in the context menu of the tabs. (#565)
+-   Now the compiler works in the same directory as the source file, so that you can use relative paths in the compile command. For example, you can add `grader.cpp` to compile the source file with the grader in the same directory. (#565)
 
 ### Fixed
 

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -303,7 +303,7 @@ void Checker::check(int index, const QString &input, const QString &output, cons
             connect(tmp, SIGNAL(runKilled(int)), this, SLOT(onRunKilled(int)));
             tmp->run(checkerPath, "", "C++", "",
                      "\"" + inputPath + "\" \"" + outputPath + "\" \"" + expectedPath + "\"", "",
-                     SettingsHelper::getTimeLimit());
+                     SettingsHelper::getDefaultTimeLimit());
         }
         break;
     }

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -83,6 +83,8 @@ void Compiler::start(const QString &tmpFilePath, const QString &sourceFilePath, 
     if (lang == "C++")
     {
         args << QFileInfo(tmpFilePath).canonicalFilePath() << "-o" << outputPath(tmpFilePath, sourceFilePath, "C++");
+        if (QFile::exists(sourceFilePath))
+            args << "-I" << QFileInfo(sourceFilePath).canonicalPath();
     }
     else if (lang == "Java")
     {
@@ -95,7 +97,7 @@ void Compiler::start(const QString &tmpFilePath, const QString &sourceFilePath, 
     }
 
     LOG_INFO(INFO_OF(lang) << INFO_OF(program) << INFO_OF(args.join(" ")));
-    // start compilation
+
     compileProcess->start(program, args);
 }
 

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -98,6 +98,9 @@ void Compiler::start(const QString &tmpFilePath, const QString &sourceFilePath, 
 
     LOG_INFO(INFO_OF(lang) << INFO_OF(program) << INFO_OF(args.join(" ")));
 
+    compileProcess->setWorkingDirectory(
+        QFileInfo(QFile::exists(sourceFilePath) ? sourceFilePath : tmpFilePath).canonicalPath());
+
     compileProcess->start(program, args);
 }
 

--- a/src/Extensions/CompanionServer.cpp
+++ b/src/Extensions/CompanionServer.cpp
@@ -118,6 +118,7 @@ void CompanionServer::onReadReady()
             payload.doc = doc;
 
             payload.url = doc["url"].toString();
+            payload.timeLimit = doc["timeLimit"].toInt();
 
             QJsonArray testArray = doc["tests"].toArray();
             for (auto tests : testArray)

--- a/src/Extensions/CompanionServer.hpp
+++ b/src/Extensions/CompanionServer.hpp
@@ -38,6 +38,7 @@ struct CompanionData
     };
 
     QString url;
+    int timeLimit;
     QJsonDocument doc;
     QVector<TestCases> testcases;
 };

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -243,7 +243,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                                    "Hotkey/Change View Mode", "Hotkey/Snippets"})
         .dir(TRKEY("Advanced"))
             .page(TRKEY("Update"), {"Check Update", "Beta"})
-            .page(TRKEY("Limits"), {"Time Limit", "Output Length Limit", "Output Display Length Limit", "Message Length Limit",
+            .page(TRKEY("Limits"), {"Default Time Limit", "Output Length Limit", "Output Display Length Limit", "Message Length Limit",
                                     "HTML Diff Viewer Length Limit", "Open File Length Limit", "Load Test Case Length Limit"})
             .page(TRKEY("Network Proxy"), {"Proxy/Enabled", "Proxy/Type", "Proxy/Host Name", "Proxy/Port", "Proxy/User", "Proxy/Password"})
         .end();

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -229,7 +229,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                 .page("Python Server", tr("%1 Server").arg(tr("Python")), {"LSP/Use Linting Python", "LSP/Delay Python", "LSP/Path Python", "LSP/Args Python"})
             .end()
             .page(TRKEY("Competitive Companion"), new PreferencesPageTemplate({"Competitive Companion/Enable",
-                "Competitive Companion/Open New Tab", "Competitive Companion/Connection Port",
+                "Competitive Companion/Open New Tab", "Competitive Companion/Set Time Limit For Tab",
+                "Competitive Companion/Connection Port",
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
                 "Competitive Companion/Head Comments Powered By CP Editor"}, false))
             .page(TRKEY("CF Tool"), {"CF/Path", "CF/Show Toast Messages"})

--- a/src/Settings/SettingsUpdater.cpp
+++ b/src/Settings/SettingsUpdater.cpp
@@ -65,6 +65,7 @@ const static QMap<QString, QString> updateInfo = {
     {"compile_and_run_only", "Show Compile And Run Only"},
     {"language", "Locale"},
     {"load_test_case_file_length_limit", "Load Test Case Length Limit"},
+    {"time_limit", "Default Time Limit"},
 };
 
 void SettingsUpdater::updateSetting(QSettings &setting)

--- a/src/Settings/ValueWrapper.cpp
+++ b/src/Settings/ValueWrapper.cpp
@@ -177,6 +177,8 @@ void SpinBoxWrapper::init(QWidget *parent, QVariant param)
     {
         QVariantList il = param.toList();
         item->setRange(il[0].toInt(), il[1].toInt());
+        if (il.length() >= 3)
+            item->setSingleStep(il[2].toInt());
     }
     connect(item, QOverload<int>::of(&QSpinBox::valueChanged), this, &SpinBoxWrapper::emitSignal);
     widget = item;

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -341,7 +341,7 @@
         "desc": "Auto Save Interval (ms)",
         "type": "int",
         "default": 1000,
-        "param": "QVariantList {100, 36000000}",
+        "param": "QVariantList {100, 36000000, 1000}",
         "depends": [
             {
                 "name": "Auto Save"
@@ -565,7 +565,7 @@
         "desc": "Auto-save Session Interval",
         "type": "int",
         "default": 20000,
-        "param": "QVariantList {1000, 36000000}",
+        "param": "QVariantList {1000, 36000000, 1000}",
         "depends": [
             {
                 "name": "Hot Exit/Enable"
@@ -618,7 +618,7 @@
         "desc": "Default Time Limit (ms)",
         "type": "int",
         "default": 5000,
-        "param": "QVariantList {1,3600000}",
+        "param": "QVariantList {1,3600000,1000}",
         "tip": "The default time limit when executing the program.\nThe program will be killed if it doesn't terminate in the time limit."
     },
     {
@@ -748,7 +748,7 @@
         "type": "int",
         "desc": "Delay in Linting (ms)",
         "default": 2000,
-        "param": "QVariantList {10, 3600000}",
+        "param": "QVariantList {10, 3600000, 1000}",
         "depends": [
             {
                 "name": "LSP/Use Linting C++"
@@ -761,7 +761,7 @@
         "type": "int",
         "desc": "Delay in Linting (ms)",
         "default": 2000,
-        "param": "QVariantList {10, 3600000}",
+        "param": "QVariantList {10, 3600000, 1000}",
         "depends": [
             {
                 "name": "LSP/Use Linting Java"
@@ -774,7 +774,7 @@
         "type": "int",
         "desc": "Delay in Linting (ms)",
         "default": 2000,
-        "param": "QVariantList {10, 3600000}",
+        "param": "QVariantList {10, 3600000, 1000}",
         "depends": [
             {
                 "name": "LSP/Use Linting Python"

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -453,11 +453,27 @@
         "tip": "Open a new tab for each problem parsed by Competitive Companion."
     },
     {
+        "name": "Competitive Companion/Set Time Limit For Tab",
+        "desc": "Use the time limit from Competitive Companion",
+        "type": "bool",
+        "depends": [
+            {
+                "name": "Competitive Companion/Enable"
+            }
+        ],
+        "tip": "Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab."
+    },
+    {
         "name": "Competitive Companion/Head Comments",
         "desc": "Head Comments",
         "type": "QString",
         "ui": "QPlainTextEdit",
         "default": "Problem: ${json.name}\nContest: ${json.group}\nURL: ${json.url}\nMemory Limit: ${json.memoryLimit} MB\nTime Limit: ${json.timeLimit} ms",
+        "depends": [
+            {
+                "name": "Competitive Companion/Enable"
+            }
+        ],
         "tip": "The comments added at the head of the code when parsing a problem.\nAvailable place holders are:\n${time}: the time when parsing the problem\n${json.X.Y}: an attribute of the data provided by Competitive Companion, you can read more at https://github.com/jmerle/competitive-companion#explanation"
     },
     {
@@ -465,6 +481,11 @@
         "desc": "Time format for the head comments",
         "type": "QString",
         "default": "yyyy-MM-dd HH:mm:ss",
+        "depends": [
+            {
+                "name": "Competitive Companion/Enable"
+            }
+        ],
         "tip": "The format of the ${time} place holder in the head comments.\nYou can read the Qt documentation for available expressions:\nhttps://doc.qt.io/qt-5/qdate.html#toString\nhttps://doc.qt.io/qt-5/qtime.html#toString"
     },
     {
@@ -472,6 +493,11 @@
         "desc": "Add \"Powered By CP Editor\" in the head comments",
         "type": "bool",
         "default": true,
+        "depends": [
+            {
+                "name": "Competitive Companion/Enable"
+            }
+        ],
         "tip": "Add a line saying \"Powered By CP Editor\" in the head comments.\nThis doesn't cost you anyting, but helps more people to know CP Editor."
     },
     {

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -588,12 +588,12 @@
         "tip": "Always use QFile instead of QSaveFile to save files.\nThis will be faster but with a little bit more risk of losing the file (with a very small possibility)."
     },
     {
-        "name": "Time Limit",
-        "desc": "Time Limit (ms)",
+        "name": "Default Time Limit",
+        "desc": "Default Time Limit (ms)",
         "type": "int",
         "default": 5000,
         "param": "QVariantList {1,3600000}",
-        "tip": "The time limit when executing the program.\nThe program will be killed if it doesn't terminate in the time limit."
+        "tip": "The default time limit when executing the program.\nThe program will be killed if it doesn't terminate in the time limit."
     },
     {
         "name": "Output Length Limit",

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -371,8 +371,8 @@ void AppWindow::openTab(MainWindow *window)
 {
     connect(window, SIGNAL(confirmTriggered(MainWindow *)), this, SLOT(onConfirmTriggered(MainWindow *)));
     connect(window, SIGNAL(editorFileChanged()), this, SLOT(onEditorFileChanged()));
-    connect(window, SIGNAL(editorTmpPathChanged(MainWindow *, const QString &)), this,
-            SLOT(onEditorTmpPathChanged(MainWindow *, const QString &)));
+    connect(window, SIGNAL(requestUpdateLanguageServerFilePath(MainWindow *, const QString &)), this,
+            SLOT(updateLanguageServerFilePath(MainWindow *, const QString &)));
     connect(window, SIGNAL(editorLanguageChanged(MainWindow *)), this, SLOT(onEditorLanguageChanged(MainWindow *)));
     connect(window, SIGNAL(editorTextChanged(MainWindow *)), this, SLOT(onEditorTextChanged(MainWindow *)));
     connect(window, &MainWindow::editorFontChanged, this, [this] { onSettingsApplied("Appearance"); });
@@ -951,7 +951,7 @@ void AppWindow::onEditorTextChanged(MainWindow *window)
     }
 }
 
-void AppWindow::onEditorTmpPathChanged(MainWindow *window, const QString &path)
+void AppWindow::updateLanguageServerFilePath(MainWindow *window, const QString &path)
 {
     if (currentWindow() == window)
     {
@@ -1455,19 +1455,19 @@ void AppWindow::reAttachLanguageServer(MainWindow *window)
 
     if (window->getLanguage() == "C++")
     {
-        cppServer->openDocument(window->tmpPath(), window->getEditor(), window->getLogger());
+        cppServer->openDocument(window->filePathOrTmpPath(), window->getEditor(), window->getLogger());
         cppServer->requestLinting();
         lspTimerCpp->start();
     }
     else if (window->getLanguage() == "Java")
     {
-        javaServer->openDocument(window->tmpPath(), window->getEditor(), window->getLogger());
+        javaServer->openDocument(window->filePathOrTmpPath(), window->getEditor(), window->getLogger());
         javaServer->requestLinting();
         lspTimerJava->start();
     }
     else if (window->getLanguage() == "Python")
     {
-        pythonServer->openDocument(window->tmpPath(), window->getEditor(), window->getLogger());
+        pythonServer->openDocument(window->filePathOrTmpPath(), window->getEditor(), window->getLogger());
         pythonServer->requestLinting();
         lspTimerPython->start();
     }

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1335,7 +1335,7 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
     {
         LOG_INFO(INFO_OF(index));
 
-        auto widget = windowAt(index);
+        auto window = windowAt(index);
 
         if (tabMenu != nullptr)
             delete tabMenu;
@@ -1343,14 +1343,14 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
 
         tabMenu->addAction(tr("Close"), [index, this] { closeTab(index); });
 
-        tabMenu->addAction(tr("Close Others"), [widget, this] {
+        tabMenu->addAction(tr("Close Others"), [window, this] {
             for (int i = 0; i < ui->tabWidget->count(); ++i)
-                if (windowAt(i) != widget && closeTab(i))
+                if (windowAt(i) != window && closeTab(i))
                     --i;
         });
 
-        tabMenu->addAction(tr("Close to the Left"), [widget, this] {
-            for (int i = 0; i < ui->tabWidget->count() && windowAt(i) != widget; ++i)
+        tabMenu->addAction(tr("Close to the Left"), [window, this] {
+            for (int i = 0; i < ui->tabWidget->count() && windowAt(i) != window; ++i)
                 if (closeTab(i))
                     --i;
         });
@@ -1363,23 +1363,23 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
         tabMenu->addAction(tr("Close Saved"), [this] { on_actionCloseSaved_triggered(); });
 
         tabMenu->addAction(tr("Close All"), [this] { on_actionCloseAll_triggered(); });
-        QString filePath = widget->getFilePath();
+        QString filePath = window->getFilePath();
 
         tabMenu->addSeparator();
 
-        tabMenu->addAction(tr("Duplicate Tab"), [widget, this] { openTab(widget->toStatus(), true); });
+        tabMenu->addAction(tr("Duplicate Tab"), [window, this] { openTab(window->toStatus(), true); });
 
         tabMenu->addSeparator();
 
-        if (widget->getLanguage() != "Python")
-            tabMenu->addAction(tr("Set Compile Command"), [widget] { widget->updateCompileCommand(); });
+        if (window->getLanguage() != "Python")
+            tabMenu->addAction(tr("Set Compile Command"), [window] { window->updateCompileCommand(); });
 
-        tabMenu->addAction(tr("Set Time Limit"), [widget] { widget->updateTimeLimit(); });
+        tabMenu->addAction(tr("Set Time Limit"), [window] { window->updateTimeLimit(); });
 
         LOG_INFO(INFO_OF(filePath));
 
         const auto outputFilePath =
-            Core::Compiler::outputFilePath(widget->tmpPath(), widget->getFilePath(), widget->getLanguage(), false);
+            Core::Compiler::outputFilePath(window->tmpPath(), window->getFilePath(), window->getLanguage(), false);
 
         const auto revealSourceFile = Util::revealInFileManager(filePath, tr("Source File"));
         const auto revealExecutableFile = Util::revealInFileManager(outputFilePath, tr("Executable File"));
@@ -1399,16 +1399,16 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
         }
 
         tabMenu->addSeparator();
-        if (!widget->getProblemURL().isEmpty())
+        if (!window->getProblemURL().isEmpty())
         {
             tabMenu->addAction(tr("Open Problem in Browser"),
-                               [widget] { QDesktopServices::openUrl(widget->getProblemURL()); });
+                               [window] { QDesktopServices::openUrl(window->getProblemURL()); });
             tabMenu->addAction(tr("Copy Problem URL"),
-                               [widget] { QGuiApplication::clipboard()->setText(widget->getProblemURL()); });
+                               [window] { QGuiApplication::clipboard()->setText(window->getProblemURL()); });
         }
-        tabMenu->addAction(tr("Set Codeforces URL"), [widget, this] {
+        tabMenu->addAction(tr("Set Codeforces URL"), [window, this] {
             QString contestId, problemCode;
-            Extensions::CFTool::parseCfUrl(widget->getProblemURL(), contestId, problemCode);
+            Extensions::CFTool::parseCfUrl(window->getProblemURL(), contestId, problemCode);
             bool ok = false;
             contestId = QInputDialog::getText(this, tr("Set CF URL"), tr("Enter the contest ID:"), QLineEdit::Normal,
                                               contestId, &ok);
@@ -1418,18 +1418,18 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
             if (ok)
             {
                 auto url = "https://codeforces.com/contest/" + contestId + "/problem/" + problemCode;
-                widget->setProblemURL(url);
+                window->setProblemURL(url);
             }
         });
-        tabMenu->addAction(tr("Set Problem URL"), [widget, this] {
+        tabMenu->addAction(tr("Set Problem URL"), [window, this] {
             bool ok = false;
             auto url = QInputDialog::getText(this, tr("Set Problem URL"), tr("Enter the new problem URL:"),
-                                             QLineEdit::Normal, widget->getProblemURL(), &ok);
+                                             QLineEdit::Normal, window->getProblemURL(), &ok);
             if (ok)
             {
-                if (url.isEmpty() && widget->isUntitled())
-                    widget->setUntitledIndex(getNewUntitledIndex());
-                widget->setProblemURL(url);
+                if (url.isEmpty() && window->isUntitled())
+                    window->setUntitledIndex(getNewUntitledIndex());
+                window->setProblemURL(url);
             }
         });
         tabMenu->popup(ui->tabWidget->tabBar()->mapToGlobal(pos));

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1369,6 +1369,13 @@ void AppWindow::onTabContextMenuRequested(const QPoint &pos)
 
         tabMenu->addAction(tr("Duplicate Tab"), [widget, this] { openTab(widget->toStatus(), true); });
 
+        tabMenu->addSeparator();
+
+        if (widget->getLanguage() != "Python")
+            tabMenu->addAction(tr("Set Compile Command"), [widget] { widget->updateCompileCommand(); });
+
+        tabMenu->addAction(tr("Set Time Limit"), [widget] { widget->updateTimeLimit(); });
+
         LOG_INFO(INFO_OF(filePath));
 
         const auto outputFilePath =

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -180,7 +180,7 @@ class AppWindow : public QMainWindow
 
     void onEditorTextChanged(MainWindow *window);
 
-    void onEditorTmpPathChanged(MainWindow *window, const QString &path);
+    void updateLanguageServerFilePath(MainWindow *window, const QString &path);
 
     void onEditorLanguageChanged(MainWindow *window);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -564,6 +564,9 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
         testcases->addTestCase(data.testcases[i].input, data.testcases[i].output);
 
     setProblemURL(data.url);
+
+    if (SettingsHelper::isCompetitiveCompanionSetTimeLimitForTab())
+        customTimeLimit = data.timeLimit;
 }
 
 void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigonistic)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1080,7 +1080,7 @@ void MainWindow::updateCompileCommand()
 void MainWindow::updateTimeLimit()
 {
     bool ok = false;
-    const int limit = QInputDialog::getInt(this, tr("Set Time Limit"), tr("Custom time limit for this tab:"),
+    const int limit = QInputDialog::getInt(this, tr("Set Time Limit"), tr("Custom time limit for this tab: (ms)"),
                                            timeLimit(), 1, 3600000, 1000, &ok);
     if (ok)
         customTimeLimit = limit;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -166,8 +166,7 @@ void MainWindow::compile()
     connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
             SLOT(onCompilationErrorOccurred(const QString &)));
     connect(compiler, SIGNAL(compilationKilled()), this, SLOT(onCompilationKilled()));
-    compiler->start(path, filePath, SettingsManager::get(QString("%1/Compile Command").arg(language)).toString(),
-                    language);
+    compiler->start(path, filePath, compileCommand(), language);
 }
 
 void MainWindow::run()
@@ -211,7 +210,7 @@ void MainWindow::run(int index)
     connect(tmp, SIGNAL(runKilled(int)), this, SLOT(onRunKilled(int)));
     tmp->run(tmpPath(), filePath, language, SettingsManager::get(QString("%1/Run Command").arg(language)).toString(),
              SettingsManager::get(QString("%1/Run Arguments").arg(language)).toString(), testcases->input(index),
-             SettingsHelper::getTimeLimit());
+             timeLimit());
     runner.push_back(tmp);
 }
 
@@ -388,7 +387,8 @@ void MainWindow::setUntitledIndex(int index)
     untitledIndex = index;
 }
 
-#define FROMSTATUS(x) x = status[#x]
+#define FROMSTATUS(x) x = status.value(#x)
+#define FROMSTATUS_DEFAULT(x, y) x = status.value(#x, y)
 MainWindow::EditorStatus::EditorStatus(const QMap<QString, QVariant> &status)
 {
     LOG_INFO("Window status from map");
@@ -398,12 +398,14 @@ MainWindow::EditorStatus::EditorStatus(const QMap<QString, QVariant> &status)
     FROMSTATUS(problemURL).toString();
     FROMSTATUS(editorText).toString();
     FROMSTATUS(language).toString();
+    FROMSTATUS(customCompileCommand).toString();
     FROMSTATUS(editorCursor).toInt();
     FROMSTATUS(editorAnchor).toInt();
     FROMSTATUS(horizontalScrollBarValue).toInt();
     FROMSTATUS(verticalScrollbarValue).toInt();
     FROMSTATUS(untitledIndex).toInt();
     FROMSTATUS(checkerIndex).toInt();
+    FROMSTATUS_DEFAULT(customTimeLimit, -1).toInt();
     FROMSTATUS(input).toStringList();
     FROMSTATUS(expected).toStringList();
     FROMSTATUS(customCheckers).toStringList();
@@ -423,12 +425,14 @@ QMap<QString, QVariant> MainWindow::EditorStatus::toMap() const
     TOSTATUS(problemURL);
     TOSTATUS(editorText);
     TOSTATUS(language);
+    TOSTATUS(customCompileCommand);
     TOSTATUS(editorCursor);
     TOSTATUS(editorAnchor);
     TOSTATUS(horizontalScrollBarValue);
     TOSTATUS(verticalScrollbarValue);
     TOSTATUS(untitledIndex);
     TOSTATUS(checkerIndex);
+    TOSTATUS(customTimeLimit);
     TOSTATUS(input);
     TOSTATUS(expected);
     TOSTATUS(customCheckers);
@@ -446,6 +450,7 @@ MainWindow::EditorStatus MainWindow::toStatus() const
     status.filePath = filePath;
     status.problemURL = problemURL;
     status.language = language;
+    status.customCompileCommand = customCompileCommand;
     status.untitledIndex = untitledIndex;
     status.checkerIndex = testcases->checkerIndex();
     status.customCheckers = testcases->customCheckers();
@@ -454,6 +459,7 @@ MainWindow::EditorStatus MainWindow::toStatus() const
     status.editorAnchor = editor->textCursor().anchor();
     status.horizontalScrollBarValue = editor->horizontalScrollBar()->value();
     status.verticalScrollbarValue = editor->verticalScrollBar()->value();
+    status.customTimeLimit = customTimeLimit;
     status.input = testcases->inputs();
     status.expected = testcases->expecteds();
     for (int i = 0; i < testcases->count(); ++i)
@@ -469,6 +475,7 @@ void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
     setProblemURL(status.problemURL);
     if (status.isLanguageSet)
         setLanguage(status.language);
+    customCompileCommand = status.customCompileCommand; // this must be after setLanguage
     if (!duplicate)
     {
         untitledIndex = status.untitledIndex;
@@ -484,6 +491,7 @@ void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
     editor->setTextCursor(cursor);
     editor->horizontalScrollBar()->setValue(status.horizontalScrollBarValue);
     editor->verticalScrollBar()->setValue(status.verticalScrollbarValue);
+    customTimeLimit = status.customTimeLimit;
     testcases->loadStatus(status.input, status.expected);
     for (int i = 0; i < status.testcasesIsShow.count() && i < testcases->count(); ++i)
         testcases->setShow(i, status.testcasesIsShow[i].toBool());
@@ -713,6 +721,7 @@ void MainWindow::setLanguage(const QString &lang)
     if (language != "Python" && language != "Java")
         language = "C++";
     Util::applySettingsToEditor(editor, language);
+    customCompileCommand.clear();
     ui->changeLanguageButton->setText(language);
     performCompileAndRunDiagonistics();
     isLanguageSet = true;
@@ -1055,6 +1064,25 @@ QString MainWindow::filePathOrTmpPath()
     return isUntitled() ? tmpPath() : filePath;
 }
 
+void MainWindow::updateCompileCommand()
+{
+    bool ok = false;
+    const auto command =
+        QInputDialog::getText(this, tr("Set Compile Command"), tr("Custom compile command for this tab:"),
+                              QLineEdit::Normal, compileCommand(), &ok);
+    if (ok)
+        customCompileCommand = command;
+}
+
+void MainWindow::updateTimeLimit()
+{
+    bool ok = false;
+    const int limit = QInputDialog::getInt(this, tr("Set Time Limit"), tr("Custom time limit for this tab:"),
+                                           timeLimit(), 1, 3600000, 1000, &ok);
+    if (ok)
+        customTimeLimit = limit;
+}
+
 bool MainWindow::isTextChanged() const
 {
     if (isUntitled())
@@ -1261,6 +1289,22 @@ void MainWindow::performCompileAndRunDiagonistics()
     if (!runResult)
         log->error(tr("Runner"),
                    tr("The run command for %1 is invalid. Is the runner in the system Path?").arg(language));
+}
+
+QString MainWindow::compileCommand() const
+{
+    if (customCompileCommand.isEmpty())
+        return SettingsManager::get(QString("%1/Compile Command").arg(language)).toString();
+    else
+        return customCompileCommand;
+}
+
+int MainWindow::timeLimit() const
+{
+    if (customTimeLimit == -1)
+        return SettingsHelper::getTimeLimit();
+    else
+        return customTimeLimit;
 }
 
 // -------------------- COMPILER SLOTS ---------------------------

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1302,7 +1302,7 @@ QString MainWindow::compileCommand() const
 int MainWindow::timeLimit() const
 {
     if (customTimeLimit == -1)
-        return SettingsHelper::getTimeLimit();
+        return SettingsHelper::getDefaultTimeLimit();
     else
         return customTimeLimit;
 }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -60,8 +60,9 @@ class MainWindow : public QMainWindow
     struct EditorStatus
     {
         bool isLanguageSet;
-        QString filePath, savedText, problemURL, editorText, language;
-        int editorCursor, editorAnchor, horizontalScrollBarValue, verticalScrollbarValue, untitledIndex, checkerIndex;
+        QString filePath, savedText, problemURL, editorText, language, customCompileCommand;
+        int editorCursor, editorAnchor, horizontalScrollBarValue, verticalScrollbarValue, untitledIndex, checkerIndex,
+            customTimeLimit;
         QStringList input, expected, customCheckers;
         QVariantList testcasesIsShow;
         QVariantList testCaseSplitterStates;
@@ -125,6 +126,16 @@ class MainWindow : public QMainWindow
      * @brief get the file path of a titled path, get the tmp path of an untitled path
      */
     QString filePathOrTmpPath();
+
+    /**
+     * @brief ask the user for the new compile command for this tab
+     */
+    void updateCompileCommand();
+
+    /**
+     * @brief ask the user for the new time limit for this tab
+     */
+    void updateTimeLimit();
 
   private slots:
     void onCompilationStarted();
@@ -215,6 +226,9 @@ class MainWindow : public QMainWindow
 
     QTimer *autoSaveTimer = nullptr;
 
+    int customTimeLimit = -1;     // the custom time limit for this tab, -1 represents for the same as settings
+    QString customCompileCommand; // the custom compile command for this tab, empty represents for the same as settings
+
     void setTestCases();
     void setEditor();
     void setupCore();
@@ -231,5 +245,7 @@ class MainWindow : public QMainWindow
     bool saveFile(SaveMode mode, const QString &head, bool safe);
     void performCompileAndRunDiagonistics();
     QString getRunnerHead(int index);
+    QString compileCommand() const;
+    int timeLimit() const;
 };
 #endif // MAINWINDOW_HPP

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -121,6 +121,11 @@ class MainWindow : public QMainWindow
     void setViewMode(const QString &mode);
     QString tmpPath();
 
+    /**
+     * @brief get the file path of a titled path, get the tmp path of an untitled path
+     */
+    QString filePathOrTmpPath();
+
   private slots:
     void onCompilationStarted();
     void onCompilationFinished(const QString &warning);
@@ -155,7 +160,7 @@ class MainWindow : public QMainWindow
 
   signals:
     void editorFileChanged();
-    void editorTmpPathChanged(MainWindow *window, const QString &path);
+    void requestUpdateLanguageServerFilePath(MainWindow *window, const QString &path);
     void editorTextChanged(MainWindow *window);
     void editorFontChanged();
     void confirmTriggered(MainWindow *widget);

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1179,7 +1179,7 @@ Do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Custom time limit for this tab:</source>
+        <source>Custom time limit for this tab: (ms)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1865,16 +1865,6 @@ This will be faster but with a little bit more risk of losing the file (with a v
 Это будет быстрее, но с немного большим риском потери файла (с очень малой вероятностью).</translation>
     </message>
     <message>
-        <source>Time Limit (ms)</source>
-        <translation>Лимит времени (в мс)</translation>
-    </message>
-    <message>
-        <source>The time limit when executing the program.
-The program will be killed if it doesn&apos;t terminate in the time limit.</source>
-        <translation>Ограничение по времени при выполнении программы.
-Программа будет убита, если она не завершится в срок.</translation>
-    </message>
-    <message>
         <source>Output Length Limit</source>
         <translation>Лимит длины выходных данных</translation>
     </message>
@@ -2493,6 +2483,15 @@ https://doc.qt.io/qt-5/qtime.html#toString</translation>
 This doesn&apos;t cost you anyting, but helps more people to know CP Editor.</source>
         <translation>Добавить строку &quot;Powered By CP Editor&quot; в комментарии шапки
 Это ничего Вам не стоит, но помогает многим людям узнавать о CP Editor.</translation>
+    </message>
+    <message>
+        <source>Default Time Limit (ms)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The default time limit when executing the program.
+The program will be killed if it doesn&apos;t terminate in the time limit.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -459,6 +459,14 @@ Git commit hash: %3
         <source>Open Problem in Browser</source>
         <translation>Открыть задачу в браузере</translation>
     </message>
+    <message>
+        <source>Set Compile Command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Time Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AppearancePage</name>
@@ -1157,6 +1165,22 @@ Do you want to reload it?</source>
     <message>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Неизвестный атрибут: [%1]. Пожалуйста, проверьте настройку комментариев шапки в %2.</translation>
+    </message>
+    <message>
+        <source>Set Compile Command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom compile command for this tab:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Time Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom time limit for this tab:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2493,6 +2493,14 @@ This doesn&apos;t cost you anyting, but helps more people to know CP Editor.</so
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use the time limit from Competitive Companion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -461,11 +461,11 @@ Git commit hash: %3
     </message>
     <message>
         <source>Set Compile Command</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить команду компиляции</translation>
     </message>
     <message>
         <source>Set Time Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить лими времени</translation>
     </message>
 </context>
 <context>
@@ -1168,19 +1168,19 @@ Do you want to reload it?</source>
     </message>
     <message>
         <source>Set Compile Command</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить команду компиляции</translation>
     </message>
     <message>
         <source>Custom compile command for this tab:</source>
-        <translation type="unfinished"></translation>
+        <translation>Нестандартная команда компиляции для этой вкладки:</translation>
     </message>
     <message>
         <source>Set Time Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Установить лимит времени</translation>
     </message>
     <message>
         <source>Custom time limit for this tab: (ms)</source>
-        <translation type="unfinished"></translation>
+        <translation>Нестандартный лимит времени для этой вкладки: (в мс)</translation>
     </message>
 </context>
 <context>
@@ -2486,20 +2486,21 @@ This doesn&apos;t cost you anyting, but helps more people to know CP Editor.</so
     </message>
     <message>
         <source>Default Time Limit (ms)</source>
-        <translation type="unfinished"></translation>
+        <translation>Стандартный лимит времни (в мс)</translation>
     </message>
     <message>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
-        <translation type="unfinished"></translation>
+        <translation>Стандартный лимит времени выполнения при запуске программы.
+Программа будет убита, если будет превышен лимит выполнения.</translation>
     </message>
     <message>
         <source>Use the time limit from Competitive Companion</source>
-        <translation type="unfinished"></translation>
+        <translation>Исопльзовать лимит времени из Competitive Companion</translation>
     </message>
     <message>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать лимит времени взятым Competitive Companion-ом как лимит времени соответствующей вкладки.</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1179,8 +1179,8 @@ Do you want to reload it?</source>
         <translation>设置时间限制</translation>
     </message>
     <message>
-        <source>Custom time limit for this tab:</source>
-        <translation>这个标签页的自定义时间限制：</translation>
+        <source>Custom time limit for this tab: (ms)</source>
+        <translation>这个标签页的自定义时间限制：(毫秒)</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1796,7 +1796,7 @@ This can be overridden for each parenthesis in each language.</source>
     </message>
     <message>
         <source>Open New Tabs</source>
-        <translation>打开新标签</translation>
+        <translation>打开新标签页</translation>
     </message>
     <message>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
@@ -2485,6 +2485,14 @@ This doesn&apos;t cost you anyting, but helps more people to know CP Editor.</so
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>执行程序的默认时间限制。
 超时的程序会被终止。</translation>
+    </message>
+    <message>
+        <source>Use the time limit from Competitive Companion</source>
+        <translation>使用从 Competitive Companion 获取的时间限制</translation>
+    </message>
+    <message>
+        <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
+        <translation>为对应的标签页使用由 Competitive Companion 解析得到的时间限制。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -459,6 +459,14 @@ git 提交编号: %3
         <source>Open Problem in Browser</source>
         <translation>在浏览器中打开题目</translation>
     </message>
+    <message>
+        <source>Set Compile Command</source>
+        <translation>设置编译命令</translation>
+    </message>
+    <message>
+        <source>Set Time Limit</source>
+        <translation>设置时间限制</translation>
+    </message>
 </context>
 <context>
     <name>AppearancePage</name>
@@ -1157,6 +1165,22 @@ Do you want to reload it?</source>
     <message>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>未知的属性: [%1]。请在 %2 检查头部注释的设置。</translation>
+    </message>
+    <message>
+        <source>Set Compile Command</source>
+        <translation>设置编译命令</translation>
+    </message>
+    <message>
+        <source>Custom compile command for this tab:</source>
+        <translation>这个标签页的自定义编译命令：</translation>
+    </message>
+    <message>
+        <source>Set Time Limit</source>
+        <translation>设置时间限制</translation>
+    </message>
+    <message>
+        <source>Custom time limit for this tab:</source>
+        <translation>这个标签页的自定义时间限制：</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1861,16 +1861,6 @@ This will be faster but with a little bit more risk of losing the file (with a v
 这会更快速，但更可能丢失文件（概率极小）。</translation>
     </message>
     <message>
-        <source>Time Limit (ms)</source>
-        <translation>时间限制（毫秒）</translation>
-    </message>
-    <message>
-        <source>The time limit when executing the program.
-The program will be killed if it doesn&apos;t terminate in the time limit.</source>
-        <translation>执行程序的时间限制。
-超时程序将会被终止。</translation>
-    </message>
-    <message>
         <source>Output Length Limit</source>
         <translation>输出长度限制</translation>
     </message>
@@ -2485,6 +2475,16 @@ https://doc.qt.io/qt-5/qtime.html#toString</translation>
 This doesn&apos;t cost you anyting, but helps more people to know CP Editor.</source>
         <translation>在头部注释中添加一行 &quot;Powered By CP Editor&quot;。
 这可以在不花费任何代价的情况下让更多的人知道 CP Editor。</translation>
+    </message>
+    <message>
+        <source>Default Time Limit (ms)</source>
+        <translation>默认时间限制（毫秒）</translation>
+    </message>
+    <message>
+        <source>The default time limit when executing the program.
+The program will be killed if it doesn&apos;t terminate in the time limit.</source>
+        <translation>执行程序的默认时间限制。
+超时的程序会被终止。</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

1.  Now the working directory of the compiler and the document path for the language server are the source file path, and `-I <source file path>` is added in the C++ compile command, so that you can easily include headers and compile with the grader, using relative paths and get the correct linting.
2.  Now you can set custom compile command and time limit for each tab.

## Motivation and Context

I took part in [APIO](https://apio2020.id/) today, and found that it's not very easy to solve grader problems with CP Editor (I used `#ifdef OUUAN` during the contest, and the biggest problem was the language server). So these features are added to make it easier to solve grader problems.

The custom compile command and time limit are also helpful without grader problems. For example, you can use different language standards for different problems, or toggle O2 in a single tab, etc.

## How Has This Been Tested?

On Arch Linux with the problems of APIO2020.

## Type of changes

- [x] New feature (changes which add functionality)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
