### PR TITLE
chore(aur): Remove xterm dependency for detached execution

### DIFF
--- a/.ci/aur/git/.SRCINFO
+++ b/.ci/aur/git/.SRCINFO
@@ -16,7 +16,6 @@ pkgbase = cpeditor-git
 	optdepends = jdk-openjdk: compile Java support
 	optdepends = jre-openjdk: execute Java support
 	optdepends = python: execute Python support
-	optdepends = xterm: detached run support
 	provides = cpeditor
 	conflicts = cpeditor
 	source = git://github.com/cpeditor/cpeditor.git

--- a/.ci/aur/git/PKGBUILD
+++ b/.ci/aur/git/PKGBUILD
@@ -22,7 +22,6 @@ optdepends=(
 	'jdk-openjdk: compile Java support'
 	'jre-openjdk: execute Java support'
 	'python: execute Python support'
-	'xterm: detached run support'
 )
 provides=('cpeditor')
 conflicts=("cpeditor")

--- a/.ci/aur/stable/.SRCINFO
+++ b/.ci/aur/stable/.SRCINFO
@@ -16,7 +16,6 @@ pkgbase = cpeditor
 	optdepends = jdk-openjdk: compile Java support
 	optdepends = jre-openjdk: execute Java support
 	optdepends = python: execute Python support
-	optdepends = xterm: detached run support
 	conflicts = cpeditor-git
 	source = https://github.com/cpeditor/cpeditor/releases/download/@PROJECT_VERSION@/cpeditor-@PROJECT_VERSION@-full-source.tar.gz
 	sha256sums = SKIP

--- a/.ci/aur/stable/PKGBUILD
+++ b/.ci/aur/stable/PKGBUILD
@@ -22,7 +22,6 @@ optdepends=(
 	'jdk-openjdk: compile Java support'
 	'jre-openjdk: execute Java support'
 	'python: execute Python support'
-	'xterm: detached run support'
 )
 conflicts=("cpeditor-git")
 source=("https://github.com/cpeditor/$pkgname/releases/download/$pkgver/cpeditor-$pkgver-full-source.tar.gz")


### PR DESCRIPTION
We now provide user to choose the terminal to perform the detached run. It is not required to have that as an optional dependency.

## Type of changes
- [x] Chore (changes which do not belong to any type above)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] If there are changes of the text displayed in the UI, I have wrapped them in `tr()` or `QCoreApplication::translate()`.
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
