### PR TITLE
chore: add --abbrev=8 for git describe

### DIFF
--- a/.ci/aur/git/PKGBUILD
+++ b/.ci/aur/git/PKGBUILD
@@ -37,7 +37,7 @@ md5sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
 pkgver() {
 	cd "$_pkgname"
-	git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+	git describe --long --tags --abbrev=8 | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {

--- a/.github/workflows/push_aur.yml
+++ b/.github/workflows/push_aur.yml
@@ -32,9 +32,11 @@ jobs:
         run: git clone ssh://aur@aur.archlinux.org/cpeditor-git.git
 
       - name: Update files
+        id: update-files
         run: |
           git fetch --tags
-          VERSION=$(git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g')
+          VERSION=$(git describe --long --tags --abbrev=8 | sed 's/\([^-]*-g\)/r\1/;s/-/./g')
+          echo ::set-output name=VERSION::$VERSION
           cp .ci/aur/git/PKGBUILD cpeditor-git
           cp .ci/aur/git/.SRCINFO cpeditor-git
           sed -i "s/@PROJECT_VERSION@/$VERSION/" cpeditor-git/PKGBUILD cpeditor-git/.SRCINFO
@@ -53,9 +55,8 @@ jobs:
 
       - name: Publish to AUR
         run: |
-          VERSION=$(git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g')
           cd cpeditor-git
           git config --global user.email "ashar786khan@gmail.com"
           git config --global user.name "coder3101"
-          git commit -am "Update from CI: $VERSION"
+          git commit -am "Update from CI: ${ steps.update-files.outputs.VERSION }"
           git push -u origin master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     message(STATUS "Git commit hash: ${GIT_COMMIT_HASH}")
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --long --tags
+      COMMAND ${GIT_EXECUTABLE} describe --long --tags --abbrev=8
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       OUTPUT_VARIABLE "GIT_DESCRIBE"
       OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
## Description

For an unknown reason, the default abbrev for CP Editor is 8 digits now. And somehow it's still 7 digits during CI ([with git 2.28.0](https://github.com/actions/virtual-environments/blame/757f01513062e82bbe8c5670c0b118fafe89e9bc/images/linux/Ubuntu1804-README.md#L183)), so [the CI failed](https://github.com/cpeditor/cpeditor/actions/runs/262574039). This should fix it.

It seems that the reason it is 7 digits during CI is that only the HEAD and its fathers are fetched, and it is 7 digits with only HEAD and its fathers, but 8 digits with all commits.