### PR TITLE
fix(Head Comments): Improve format and handle edge cases

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   Fixed crash when compiling twice in a row with large test cases. (#549 and #550)
 -   Fixed a hypothetical Undefined Behaviour in testlib real number checker. (#586 and #587)
 -   Now you can use CF Tool to submit to Gym problems. (#591 and #592)
+-   Now Header comments starts from line 1 with correct formatting in edge cases. (#607 and #609)
 
 ### Changed
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -24,7 +24,6 @@
 -   Fixed crash when compiling twice in a row with large test cases. (#549 and #550)
 -   Fixed a hypothetical Undefined Behaviour in testlib real number checker. (#586 and #587)
 -   Now you can use CF Tool to submit to Gym problems. (#591 and #592)
--   Now Header comments starts from line 1 with correct formatting in edge cases. (#607 and #609)
 
 ### Changed
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -552,7 +552,7 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
             finalComments = "# " + finalComments;
             finalComments.replace('\n', "\n# ");
         }
-        else if(!finalComments.isEmpty())
+        else if (!finalComments.isEmpty())
         {
             finalComments = "// " + finalComments;
             finalComments.replace('\n', "\n// ");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -509,7 +509,7 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
 
         auto it = QRegularExpression(R"(\$\{json\..+?\})").globalMatch(comments);
 
-        QString finalComments = "\n";
+        QString finalComments;
         int lastEnd = 0;
 
         while (it.hasNext())
@@ -541,14 +541,24 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
         finalComments += comments.mid(lastEnd);
 
         if (SettingsHelper::isCompetitiveCompanionHeadCommentsPoweredByCPEditor())
-            finalComments += "\n\nPowered by CP Editor (https://cpeditor.org)";
+        {
+            if (!finalComments.isEmpty())
+                finalComments += "\n\n";
+            finalComments += "Powered by CP Editor (https://cpeditor.org)";
+        }
 
-        if (language == "Python")
+        if (language == "Python" && !finalComments.isEmpty())
+        {
+            finalComments = "# " + finalComments;
             finalComments.replace('\n', "\n# ");
-        else
+        }
+        else if(!finalComments.isEmpty())
+        {
+            finalComments = "// " + finalComments;
             finalComments.replace('\n', "\n// ");
-
-        finalComments += "\n\n";
+        }
+        if (!finalComments.isEmpty())
+            finalComments += "\n\n";
 
         auto cursor = editor->textCursor();
         int cursorPos = cursor.position(); // keep Template Cursor Position

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -547,18 +547,12 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
             finalComments += "Powered by CP Editor (https://cpeditor.org)";
         }
 
-        if (language == "Python" && !finalComments.isEmpty())
-        {
-            finalComments = "# " + finalComments;
-            finalComments.replace('\n', "\n# ");
-        }
-        else if (!finalComments.isEmpty())
-        {
-            finalComments = "// " + finalComments;
-            finalComments.replace('\n', "\n// ");
-        }
         if (!finalComments.isEmpty())
+        {
+            finalComments.replace(QRegularExpression("^", QRegularExpression::MultilineOption),
+                                  language == "Python" ? "# " : "// ");
             finalComments += "\n\n";
+        }
 
         auto cursor = editor->textCursor();
         int cursorPos = cursor.position(); // keep Template Cursor Position


### PR DESCRIPTION
Header comments are now correctly formatted and displayed as mentioned in the linked issue.

## Description
See #607

## Related Issue
Fixes #607 

## Motivation and Context
For better formatting of code

## How Has This Been Tested?
Arch on KDE

## Screenshots (if appropriate)
- Header comment starts at first line 
![image](https://user-images.githubusercontent.com/22212259/94009859-ae6bbb00-fdc2-11ea-81d4-093c6d399cfb.png)
- If header comment is empty 
![image](https://user-images.githubusercontent.com/22212259/94009977-e541d100-fdc2-11ea-9c38-ad1d18b082f8.png)
- A custom header comment with "Powered by CP Editor" 
![image](https://user-images.githubusercontent.com/22212259/94010731-f3dcb800-fdc3-11ea-9cde-554373e15c1d.png)
- A custom header comment without "Powered by CP Editor" 
![image](https://user-images.githubusercontent.com/22212259/94010884-2a1a3780-fdc4-11ea-80d8-28435a920076.png)

- Disabled header comment 
![image](https://user-images.githubusercontent.com/22212259/94010394-8466c880-fdc3-11ea-9ca6-698230ea64c6.png)





## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [x] Bug fix (changes which fix an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] If there are changes of the text displayed in the UI, I have wrapped them in `tr()` or `QCoreApplication::translate()`.
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
