### PR TITLE
fix(cftool): Check for CF Tool

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -277,15 +277,6 @@ void MainWindow::setCFToolUI()
             }
         });
     }
-    if (!Extensions::CFTool::check(SettingsHelper::getCFPath()))
-    {
-        qDebug() << "CF tool was not found";
-
-        submitToCodeforces->setEnabled(false);
-        log->error(tr("CF Tool"),
-                   tr("You will not be able to submit code to Codeforces because CF Tool is not installed or is "
-                      "not on SYSTEM PATH. You can set it manually in settings."));
-    }
 }
 
 int MainWindow::getUntitledIndex() const
@@ -592,6 +583,7 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
 
     if ((pagePath.isEmpty() || pagePath == "Extensions/CF Tool") && submitToCodeforces)
     {
+        log->clear();
 
         if (Extensions::CFTool::check(SettingsHelper::getCFPath()))
         {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -249,7 +249,7 @@ void MainWindow::setCFToolUI()
     if (submitToCodeforces == nullptr)
     {
         submitToCodeforces = new QPushButton(tr("Submit"), this);
-        cftool = new Extensions::CFTool(cftoolPath, log);
+        cftool = new Extensions::CFTool(SettingsHelper::getCFPath(), log);
         connect(cftool, SIGNAL(requestToastMessage(const QString &, const QString &)), this,
                 SIGNAL(requestToastMessage(const QString &, const QString &)));
         ui->compileAndRunButtons->addWidget(submitToCodeforces);
@@ -277,8 +277,10 @@ void MainWindow::setCFToolUI()
             }
         });
     }
-    if (!Extensions::CFTool::check(cftoolPath))
+    if (!Extensions::CFTool::check(SettingsHelper::getCFPath()))
     {
+        qDebug() << "CF tool was not found";
+
         submitToCodeforces->setEnabled(false);
         log->error(tr("CF Tool"),
                    tr("You will not be able to submit code to Codeforces because CF Tool is not installed or is "
@@ -587,11 +589,10 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
 
     if (pagePath.isEmpty() || pagePath == "Extensions/CF Tool")
     {
-        cftoolPath = SettingsHelper::getCFPath();
 
-        if (cftool != nullptr && Extensions::CFTool::check(cftoolPath))
+        if (cftool != nullptr && Extensions::CFTool::check(SettingsHelper::getCFPath()))
         {
-            cftool->updatePath(cftoolPath);
+            cftool->updatePath(SettingsHelper::getCFPath());
             if (submitToCodeforces != nullptr)
                 submitToCodeforces->setEnabled(true);
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -382,7 +382,10 @@ void MainWindow::setProblemURL(const QString &url)
     problemURL = url;
     FileProblemBinder::set(filePath, url);
     if (problemURL.contains("codeforces.com"))
+    {
         setCFToolUI();
+        applySettings("Extensions/CF Tool", false);
+    }
     emit editorFileChanged();
 }
 
@@ -587,14 +590,20 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
         formatter->updateStyle(SettingsHelper::getClangFormatStyle());
     }
 
-    if (pagePath.isEmpty() || pagePath == "Extensions/CF Tool")
+    if ((pagePath.isEmpty() || pagePath == "Extensions/CF Tool") && submitToCodeforces)
     {
 
-        if (cftool != nullptr && Extensions::CFTool::check(SettingsHelper::getCFPath()))
+        if (Extensions::CFTool::check(SettingsHelper::getCFPath()))
         {
             cftool->updatePath(SettingsHelper::getCFPath());
-            if (submitToCodeforces != nullptr)
-                submitToCodeforces->setEnabled(true);
+            submitToCodeforces->setEnabled(true);
+        }
+        else
+        {
+            submitToCodeforces->setEnabled(false);
+            log->error(tr("CF Tool"),
+                       tr("You will not be able to submit code to Codeforces because CF Tool is not installed or is "
+                          "not on SYSTEM PATH. You can set it manually in settings."));
         }
     }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -212,7 +212,6 @@ class MainWindow : public QMainWindow
     QString problemURL;
     QString filePath;
     QString savedText;
-    QString cftoolPath;
     QFileSystemWatcher *fileWatcher;
 
     std::atomic<bool> reloading;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Since #606 the settings are being applied later. Due to this, the variable named cftoolpath was empty when it was used to check the cf tool availability and a false error of no cf tool was being shown. With this PR we use SettingsHelper and let applySettings check and warn the availability of CF Tool

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [x] Bug fix (changes which fix an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/cpeditor/cpeditor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] The settings file in the old version can be used in the new version after this change.
- [x] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [x] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
- [x] If there are changes of the text displayed in the UI, I have wrapped them in `tr()` or `QCoreApplication::translate()`.
- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
