### PR TITLE
fix(StyleManager): use palette instead of stylesheet for tooltips

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -24,7 +24,6 @@
 -   Fixed crash when compiling twice in a row with large test cases. (#549 and #550)
 -   Fixed a hypothetical Undefined Behaviour in testlib real number checker. (#586 and #587)
 -   Now you can use CF Tool to submit to Gym problems. (#591 and #592)
--   Fixed an issue where Message Box font was getting reset when using Fusion styles. (#604 and #605)
 
 ### Changed
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   Fixed crash when compiling twice in a row with large test cases. (#549 and #550)
 -   Fixed a hypothetical Undefined Behaviour in testlib real number checker. (#586 and #587)
 -   Now you can use CF Tool to submit to Gym problems. (#591 and #592)
+-   Fixed an issue where Message Box font was getting reset when using Fusion styles. (#604 and #612)
 
 ### Changed
 

--- a/src/Core/StyleManager.cpp
+++ b/src/Core/StyleManager.cpp
@@ -66,7 +66,6 @@ bool StyleManager::setStyle(const QString &styleName)
     }
 #endif
 
-    setStyleSheet(currentStyle);
     setPalette(currentStyle);
 
     if (currentStyle == "default")
@@ -114,18 +113,6 @@ bool StyleManager::isWindowsDarkThemeForApps()
 }
 #endif
 
-void StyleManager::setStyleSheet(const QString &styleName)
-{
-    QString styleSheet;
-
-    if (styleName == "Light Fusion")
-        styleSheet = "QToolTip {color: #000000; background-color: #d57d25 ; border: 1px solid black}";
-    else if (styleName == "Dark Fusion")
-        styleSheet = "QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }";
-
-    qApp->setStyleSheet(styleSheet);
-}
-
 void StyleManager::setPalette(const QString &styleName)
 {
     if (styleName == "Light Fusion")
@@ -147,7 +134,7 @@ QPalette StyleManager::darkFusionPalette()
     darkPalette.setColor(QPalette::WindowText, Qt::white);
     darkPalette.setColor(QPalette::Base, QColor(18, 18, 18));
     darkPalette.setColor(QPalette::AlternateBase, darkColor);
-    darkPalette.setColor(QPalette::ToolTipBase, Qt::white);
+    darkPalette.setColor(QPalette::ToolTipBase, QColor(18, 18, 18));
     darkPalette.setColor(QPalette::ToolTipText, Qt::white);
     darkPalette.setColor(QPalette::Text, Qt::white);
     darkPalette.setColor(QPalette::Disabled, QPalette::Text, disabledColor);
@@ -174,7 +161,7 @@ QPalette StyleManager::lightFusionPalette()
     lightPalette.setColor(QPalette::WindowText, Qt::black);
     lightPalette.setColor(QPalette::Base, QColor(237, 237, 237));
     lightPalette.setColor(QPalette::AlternateBase, lightColor);
-    lightPalette.setColor(QPalette::ToolTipBase, Qt::black);
+    lightPalette.setColor(QPalette::ToolTipBase, QColor(237, 237, 237));
     lightPalette.setColor(QPalette::ToolTipText, Qt::black);
     lightPalette.setColor(QPalette::Text, Qt::black);
     lightPalette.setColor(QPalette::Disabled, QPalette::Text, disabledColor);

--- a/src/Core/StyleManager.hpp
+++ b/src/Core/StyleManager.hpp
@@ -36,8 +36,6 @@ class StyleManager
 
     static void setPalette(const QString &styleName);
 
-    static void setStyleSheet(const QString &styleName);
-
     static QPalette darkFusionPalette();
 
     static QPalette lightFusionPalette();

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1010,6 +1010,12 @@ void AppWindow::onSettingsApplied(const QString &pagePath)
 {
     LOG_INFO("Apply settings for " << INFO_OF(pagePath));
 
+    for (int i = 0; i < ui->tabWidget->count(); ++i)
+    {
+        windowAt(i)->applySettings(pagePath, i == ui->tabWidget->currentIndex());
+        onEditorTextChanged(windowAt(i));
+    }
+
     auto pageChanged = [pagePath](const QString &page) { return pagePath.isEmpty() || pagePath == page; };
 
     if (pageChanged("Key Bindings"))
@@ -1060,12 +1066,6 @@ void AppWindow::onSettingsApplied(const QString &pagePath)
     if (pageChanged("File Path/Default Paths"))
     {
         DefaultPathManager::fromVariantList(SettingsHelper::getDefaultPathNamesAndPaths());
-    }
-
-    for (int i = 0; i < ui->tabWidget->count(); ++i)
-    {
-        windowAt(i)->applySettings(pagePath, i == ui->tabWidget->currentIndex());
-        onEditorTextChanged(windowAt(i));
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,11 +66,8 @@ MainWindow::MainWindow(int index, QWidget *parent)
     connect(
         autoSaveTimer, &QTimer::timeout, autoSaveTimer, [this] { saveFile(AutoSave, tr("Auto Save"), false); },
         Qt::DirectConnection);
-
-    QTimer::singleShot(0, [this] {
-        applySettings("", true); // See issue #604 for more information
-        setLanguage(language);   // See issue #187 for more information
-    });
+    applySettings("", true);
+    QTimer::singleShot(0, [this] { setLanguage(language); }); // See issue #187 for more information
 }
 
 MainWindow::MainWindow(const QString &fileOpen, int index, QWidget *parent) : MainWindow(index, parent)


### PR DESCRIPTION
## Description

Now the color of the tooltips are controlled by the palette, and the stylesheet is not changed.

## Related Issue

This fixes #604 and reverts #606.

## Motivation and Context

1. #604 is caused by unexpected behavior when setting the stylesheet. Instead of changing the order of applying settings, getting rid of the stylesheet has no side effects like #610.
2. I think the new palettes actually seem better than the old stylesheets.

## How Has This Been Tested?

On Arch Linux KDE and Windows, with Dark Fusion and Light Fusion and message logger font changed.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/94340078-81710f80-0031-11eb-8647-b6eadf812a29.png)

![image](https://user-images.githubusercontent.com/30581822/94340085-87ff8700-0031-11eb-9f32-3b47f42bfd6e.png)

## Type of changes

- [x] Bug fix (changes which fix an issue)
- [x] Revert (revert previous changes)

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
