### PR TITLE
feat: show preferences window for first-time users

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   Now you can use the time limit from Competitive Companion as the time limit for the corresponding tab. (#565)
 -   Now the compiler works in the same directory as the source file, so that you can use relative paths in the compile command. For example, you can add `grader.cpp` to compile the source file with the grader in the same directory. (#565)
 -   TLE and RE verdicts. (#566)
+-   Now the preferences window pops up at the first launch of CP Editor. (#614)
 
 ### Fixed
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -1066,5 +1066,11 @@
         "type": "int",
         "default": 5,
         "notr": true
+    },
+    {
+        "name": "First Time User",
+        "type": "bool",
+        "default": true,
+        "notr": true
     }
 ]

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -129,14 +129,7 @@ AppWindow::AppWindow(int depth, bool cpp, bool java, bool python, bool noHotExit
     : AppWindow(noHotExit, parent)
 {
     openPaths(paths, cpp, java, python, depth);
-    if (ui->tabWidget->count() == 0)
-        openTab("");
-
-#ifdef Q_OS_WIN
-    // This is necessary because of setWindowOpacity(0.99) earlier
-    if (SettingsHelper::getOpacity() == 100)
-        setWindowOpacity(1);
-#endif
+    finishConstruction();
 }
 
 AppWindow::AppWindow(bool cpp, bool java, bool python, bool noHotExit, int number, const QString &path, QWidget *parent)
@@ -150,6 +143,12 @@ AppWindow::AppWindow(bool cpp, bool java, bool python, bool noHotExit, int numbe
     else if (python)
         lang = "Python";
     openContest({path, number, lang});
+
+    finishConstruction();
+}
+
+void AppWindow::finishConstruction()
+{
     if (ui->tabWidget->count() == 0)
         openTab("");
 
@@ -158,6 +157,13 @@ AppWindow::AppWindow(bool cpp, bool java, bool python, bool noHotExit, int numbe
     if (SettingsHelper::getOpacity() == 100)
         setWindowOpacity(1);
 #endif
+
+    if (SettingsHelper::isFirstTimeUser())
+    {
+        LOG_INFO("Is first-time user");
+        preferencesWindow->display();
+        SettingsHelper::setFirstTimeUser(false);
+    }
 }
 
 AppWindow::~AppWindow()

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -58,7 +58,6 @@ class AppWindow : public QMainWindow
     Q_OBJECT
 
   public:
-    explicit AppWindow(bool noHotExit, QWidget *parent = nullptr);
     explicit AppWindow(int depth, bool cpp, bool java, bool python, bool noHotExit, const QStringList &paths,
                        QWidget *parent = nullptr);
     explicit AppWindow(bool cpp, bool java, bool python, bool noHotExit, int number, const QString &path,
@@ -227,6 +226,9 @@ class AppWindow : public QMainWindow
     Extensions::LanguageServer *cppServer = nullptr;
     Extensions::LanguageServer *javaServer = nullptr;
     Extensions::LanguageServer *pythonServer = nullptr;
+
+    explicit AppWindow(bool noHotExit, QWidget *parent = nullptr);
+    void finishConstruction();
 
     void setConnections();
     void allocate();


### PR DESCRIPTION
## Description

Show the preferences window for first-time users.

## Related Issue

This closes #192.

Though this is not a guide, I think a guide is somehow redundant, and the homepage of the preferences window is good enough.

## Motivation and Context

First-time users almost definitely need some configuration. This pop-up can help them find where to configure everything and provides a link to the documentation.

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/doc/CHANGELOG.md), or these changes are not notable.
