### PR TITLE
fix(InnoSetup): use the "/norestart" option when installing vcredist

### DIFF
--- a/.ci/win/win-setup.iss
+++ b/.ci/win/win-setup.iss
@@ -61,7 +61,7 @@ Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#MyAppName}"; Fil
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-Filename: "{tmp}\vc_redist.x64.exe"; StatusMsg: "Installing VC2019 redist..."; Parameters: "/quiet"; Check: VC2019RedistNeedsInstall ; Flags: waituntilterminated
+Filename: "{tmp}\vc_redist.x64.exe"; StatusMsg: "Installing VC2019 redist..."; Parameters: "/quiet /norestart"; Check: VC2019RedistNeedsInstall ; Flags: waituntilterminated
 
 [Code]
 function VC2019RedistNeedsInstall: Boolean;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   Fixed a hypothetical Undefined Behaviour in testlib real number checker. (#586 and #587)
 -   Now you can use CF Tool to submit to Gym problems. (#591 and #592)
 -   Fixed an issue where Message Box font was getting reset when using Fusion styles. (#604 and #612)
+-   Fixed Windows sometimes restarts during the setup. (#545 and #619)
 
 ### Changed
 


### PR DESCRIPTION
## Description

Use the "/norestart" option when installing vcredist,

## Related Issue

This fixes #545.

## Checklist

- [x] I have documented these changes in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md), or these changes are not notable.
