### PR TITLE
refactor(Settings): move old to JSON and rename Test Case Length Limit

### DIFF
--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -36,6 +36,7 @@ class SettingsInfo
         bool immediatelyApply;
         std::function<void(SettingInfo *, ValueWidget *, QWidget *)> onApply;
         QList<QPair<QString, std::function<bool(const QVariant &)>>> depends;
+        QList<QString> old; // the old names for this setting
         QVariant def;
         QVariant param;
         QList<SettingInfo> child;
@@ -63,6 +64,8 @@ class SettingsInfo
 
   private:
     static QList<SettingInfo> settings;
+
+    friend class SettingsUpdater;
 };
 
 #endif // SETTINGSINFO_HPP

--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -36,7 +36,7 @@ class SettingsInfo
         bool immediatelyApply;
         std::function<void(SettingInfo *, ValueWidget *, QWidget *)> onApply;
         QList<QPair<QString, std::function<bool(const QVariant &)>>> depends;
-        QList<QString> old; // the old names for this setting
+        QList<QString> old; // the old keys of this setting
         QVariant def;
         QVariant param;
         QList<SettingInfo> child;

--- a/src/Settings/SettingsUpdater.cpp
+++ b/src/Settings/SettingsUpdater.cpp
@@ -19,63 +19,41 @@
 #include "Core/SessionManager.hpp"
 #include "Settings/SettingsManager.hpp"
 #include "generated/SettingsHelper.hpp"
+#include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QMap>
 #include <QSettings>
-
-const static QMap<QString, QString> updateInfo = {
-    {"tab_stop", "Tab Width"},
-    {"font", "Editor Font"},
-    {"clang_format_binary", "Clang Format/Path"},
-    {"clang_format_style", "Clang Format/Style"},
-    {"template_cpp", "C++/Template Path"},
-    {"compile_cpp", "C++/Compile Command"},
-    {"runtime_cpp", "C++/Run Arguments"},
-    {"template_java", "Java/Template Path"},
-    {"compile_java", "Java/Compile Command"},
-    {"runtime_java", "Java/Run Arguments"},
-    {"run_java", "Java/Run Command"},
-    {"template_java", "Python/Template Path"},
-    {"runtime_python", "Python/Run Arguments"},
-    {"run_python", "Python/Run Command"},
-    {"auto_parenthesis", "Auto Complete Parentheses"},
-    {"auto_remove_parentheses", "Auto Remove Parentheses"},
-    {"autosave", "Auto Save"},
-    {"win_max", "Maximized Window"},
-    {"update_start_check", "Check Update"},
-    {"format_on_save", "Clang Format/Format On Manual Save"},
-    {"auto_format", "Clang Format/Format On Manual Save"},
-    {"transparency", "Opacity"},
-    {"splitter_sizes", "Splitter Size"},
-    {"right_splitter_sizes", "Right Splitter Size"},
-    {"competitive_use", "Competitive Companion/Enable"},
-    {"connection_port", "Competitive Companion/Connection Port"},
-    {"companion_new_tab", "Competitive Companion/Open New Tab"},
-    {"hotkey_format", "Hotkey/Format"},
-    {"hotkey_kill", "Hotkey/Kill"},
-    {"hotkey_compile_run", "Hotkey/Compile Run"},
-    {"hotkey_run", "Hotkey/Run"},
-    {"hotkey_compile", "Hotkey/Compile"},
-    {"hotkey_mode_toggle", "Hotkey/Change View Mode"},
-    {"hotkey_snippets", "Hotkey/Snippets"},
-    {"use_hot_exit", "Hot Exit/Enable"},
-    {"cf_path", "CF/Path"},
-    {"compile_and_run_only", "Show Compile And Run Only"},
-    {"language", "Locale"},
-    {"load_test_case_file_length_limit", "Load Test Case Length Limit"},
-    {"time_limit", "Default Time Limit"},
-};
 
 void SettingsUpdater::updateSetting(QSettings &setting)
 {
-    for (const auto &old : updateInfo.keys())
+#ifdef QT_DEBUG
+    // Check for key conflicts
+    QSet<QString> keys;
+    for (const auto &si : qAsConst(SettingsInfo::settings))
     {
-        QString nw = updateInfo[old];
-        if (!SettingsManager::contains(nw) && setting.contains(old))
+        auto addKey = [&](const QString &key) {
+            if (keys.contains(key))
+                qFatal("Duplicate key in the settings: %s", key.toStdString().c_str());
+            keys.insert(key);
+        };
+        addKey(si.key());
+        std::for_each(si.old.begin(), si.old.end(), addKey);
+    }
+#endif
+
+    for (const auto &si : qAsConst(SettingsInfo::settings))
+    {
+        if (!SettingsManager::contains(si.name))
         {
-            SettingsManager::set(nw, setting.value(old));
+            for (const auto &old : qAsConst(si.old))
+            {
+                if (setting.contains(old))
+                {
+                    SettingsManager::set(si.name, setting.value(old));
+                    break;
+                }
+            }
         }
     }
 

--- a/src/Settings/SettingsUpdater.cpp
+++ b/src/Settings/SettingsUpdater.cpp
@@ -30,13 +30,15 @@ void SettingsUpdater::updateSetting(QSettings &setting)
 #ifdef QT_DEBUG
     // Check for key conflicts
     QSet<QString> keys;
+
+    auto addKey = [&](const QString &key) {
+        if (keys.contains(key))
+            qFatal("Duplicate key in the settings: %s", key.toStdString().c_str());
+        keys.insert(key);
+    };
+
     for (const auto &si : qAsConst(SettingsInfo::settings))
     {
-        auto addKey = [&](const QString &key) {
-            if (keys.contains(key))
-                qFatal("Duplicate key in the settings: %s", key.toStdString().c_str());
-            keys.insert(key);
-        };
         addKey(si.key());
         std::for_each(si.old.begin(), si.old.end(), addKey);
     }

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -4,7 +4,10 @@
         "type": "int",
         "default": 4,
         "param": "QVariantList {1,16}",
-        "tip": "The width of the tab character, or the number of spaces of an indent"
+        "tip": "The width of the tab character, or the number of spaces of an indent",
+        "old": [
+            "tab_stop"
+        ]
     },
     {
         "name": "Geometry",
@@ -16,7 +19,10 @@
         "type": "QFont",
         "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
         "param": "true",
-        "tip": "The font of the code editor"
+        "tip": "The font of the code editor",
+        "old": [
+            "font"
+        ]
     },
     {
         "name": "Use Custom Application Font",
@@ -50,7 +56,10 @@
         "default": "clang-format",
         "ui": "PathItem",
         "param": "PathItem::Executable",
-        "tip": "The path to the Clang Format executable file"
+        "tip": "The path to the Clang Format executable file",
+        "old": [
+            "clang_format_binary"
+        ]
     },
     {
         "name": "Clang Format/Style",
@@ -58,13 +67,20 @@
         "type": "QString",
         "default": "BasedOnStyle: Google",
         "ui": "QPlainTextEdit",
-        "tip": "The Clang Format style options, which are often saved in a .clang-format configuration file.\nYou can learn about it at <https://clang.llvm.org/docs/ClangFormatStyleOptions.html>."
+        "tip": "The Clang Format style options, which are often saved in a .clang-format configuration file.\nYou can learn about it at <https://clang.llvm.org/docs/ClangFormatStyleOptions.html>.",
+        "old": [
+            "clang_format_style"
+        ]
     },
     {
         "name": "Clang Format/Format On Manual Save",
         "desc": "Format code on manual save",
         "type": "bool",
-        "tip": "Use Clang Format to format the code when saving it manually."
+        "tip": "Use Clang Format to format the code when saving it manually.",
+        "old": [
+            "format_on_save",
+            "auto_format"
+        ]
     },
     {
         "name": "Clang Format/Format On Auto Save",
@@ -77,7 +93,10 @@
         "type": "QString",
         "ui": "PathItem",
         "param": "PathItem::CppSource",
-        "tip": "The template used when creating a new C++ file"
+        "tip": "The template used when creating a new C++ file",
+        "old": [
+            "template_cpp"
+        ]
     },
     {
         "name": "C++/Template Cursor Position Regex",
@@ -122,7 +141,10 @@
         "name": "C++/Compile Command",
         "type": "QString",
         "default": "g++ -Wall",
-        "tip": "The command used to compile C++. It should NOT include the path to the source file or \"-o <output file>\"."
+        "tip": "The command used to compile C++. It should NOT include the path to the source file or \"-o <output file>\".",
+        "old": [
+            "compile_cpp"
+        ]
     },
     {
         "name": "C++/Output Path",
@@ -134,7 +156,10 @@
     {
         "name": "C++/Run Arguments",
         "type": "QString",
-        "tip": "The runtime arguments when executing a C++ program"
+        "tip": "The runtime arguments when executing a C++ program",
+        "old": [
+            "runtime_cpp"
+        ]
     },
     {
         "name": "C++/Parentheses",
@@ -147,25 +172,37 @@
         "type": "QString",
         "ui": "PathItem",
         "param": "PathItem::JavaSource",
-        "tip": "The template used when creating a new Java file"
+        "tip": "The template used when creating a new Java file",
+        "old": [
+            "template_java"
+        ]
     },
     {
         "name": "Java/Compile Command",
         "type": "QString",
         "default": "javac",
-        "tip": "The command used to compile Java.\nIt should NOT include the path to the source file or the path of the compiled class file."
+        "tip": "The command used to compile Java.\nIt should NOT include the path to the source file or the path of the compiled class file.",
+        "old": [
+            "compile_java"
+        ]
     },
     {
         "name": "Java/Run Arguments",
         "type": "QString",
         "default": "",
-        "tip": "The runtime arguments when executing a Java program"
+        "tip": "The runtime arguments when executing a Java program",
+        "old": [
+            "runtime_java"
+        ]
     },
     {
         "name": "Java/Run Command",
         "type": "QString",
         "default": "java",
-        "tip": "The command to start a Java program. It should NOT include \"-classpath <path> <class name>\"."
+        "tip": "The command to start a Java program. It should NOT include \"-classpath <path> <class name>\".",
+        "old": [
+            "run_java"
+        ]
     },
     {
         "name": "Java/Class Name",
@@ -228,7 +265,10 @@
         "type": "QString",
         "ui": "PathItem",
         "param": "PathItem::PythonSource",
-        "tip": "The template used when creating a new Python file"
+        "tip": "The template used when creating a new Python file",
+        "old": [
+            "template_python"
+        ]
     },
     {
         "name": "Python/Template Cursor Position Regex",
@@ -270,13 +310,19 @@
     {
         "name": "Python/Run Arguments",
         "type": "QString",
-        "tip": "The runtime arguments when executing a Python program"
+        "tip": "The runtime arguments when executing a Python program",
+        "old": [
+            "runtime_python"
+        ]
     },
     {
         "name": "Python/Run Command",
         "type": "QString",
         "default": "python",
-        "tip": "The command to start a Python program. It should NOT include the path to the source file."
+        "tip": "The command to start a Python program. It should NOT include the path to the source file.",
+        "old": [
+            "run_python"
+        ]
     },
     {
         "name": "Python/Parentheses",
@@ -310,7 +356,10 @@
         "name": "Auto Complete Parentheses",
         "type": "bool",
         "default": true,
-        "tip": "Automatically complete a pair of parentheses when typing the left element of it,\nand move out of it when typing the right element of it.\nThis can be overridden for each parenthesis in each language."
+        "tip": "Automatically complete a pair of parentheses when typing the left element of it,\nand move out of it when typing the right element of it.\nThis can be overridden for each parenthesis in each language.",
+        "old": [
+            "auto_parenthesis"
+        ]
     },
     {
         "name": "Auto Remove Parentheses",
@@ -334,7 +383,10 @@
         "name": "Auto Save",
         "desc": "Enable Auto Save",
         "type": "bool",
-        "tip": "Automatically save the file every 3 seconds."
+        "tip": "Automatically save the file every 3 seconds.",
+        "old": [
+            "autosave"
+        ]
     },
     {
         "name": "Auto Save Interval",
@@ -387,14 +439,21 @@
     },
     {
         "name": "Maximized Window",
-        "type": "bool"
+        "type": "bool",
+        "notr": true,
+        "old": [
+            "win_max"
+        ]
     },
     {
         "name": "Check Update",
         "desc": "Check for updates on startup",
         "type": "bool",
         "default": true,
-        "tip": "Check whether there's a new version of CP Editor when starting CP Editor."
+        "tip": "Check whether there's a new version of CP Editor when starting CP Editor.",
+        "old": [
+            "update_start_check"
+        ]
     },
     {
         "name": "Opacity",
@@ -402,7 +461,10 @@
         "default": 100,
         "param": "QVariantList {60,100}",
         "ui": "QSlider",
-        "tip": "The opacity of the main window"
+        "tip": "The opacity of the main window",
+        "old": [
+            "transparency"
+        ]
     },
     {
         "name": "View Mode",
@@ -413,19 +475,28 @@
     {
         "name": "Splitter Size",
         "type": "QByteArray",
-        "notr": true
+        "notr": true,
+        "old": [
+            "splitter_sizes"
+        ]
     },
     {
         "name": "Right Splitter Size",
         "type": "QByteArray",
-        "notr": true
+        "notr": true,
+        "old": [
+            "right_splitter_sizes"
+        ]
     },
     {
         "name": "Competitive Companion/Enable",
         "desc": "Enable Competitive Companion",
         "type": "bool",
         "default": true,
-        "tip": "Receive data sent by Competitive Companion and load the example testcases."
+        "tip": "Receive data sent by Competitive Companion and load the example testcases.",
+        "old": [
+            "competitive_use"
+        ]
     },
     {
         "name": "Competitive Companion/Connection Port",
@@ -438,7 +509,10 @@
                 "name": "Competitive Companion/Enable"
             }
         ],
-        "tip": "The port used to receive data from Competitive Companion"
+        "tip": "The port used to receive data from Competitive Companion",
+        "old": [
+            "connection_port"
+        ]
     },
     {
         "name": "Competitive Companion/Open New Tab",
@@ -450,7 +524,10 @@
                 "name": "Competitive Companion/Enable"
             }
         ],
-        "tip": "Open a new tab for each problem parsed by Competitive Companion."
+        "tip": "Open a new tab for each problem parsed by Competitive Companion.",
+        "old": [
+            "companion_new_tab"
+        ]
     },
     {
         "name": "Competitive Companion/Set Time Limit For Tab",
@@ -504,50 +581,74 @@
         "name": "Hotkey/Format",
         "desc": "Format Codes",
         "type": "QString",
-        "ui": "ShortcutItem"
+        "ui": "ShortcutItem",
+        "old": [
+            "hotkey_format"
+        ]
     },
     {
         "name": "Hotkey/Kill",
         "desc": "Kill All Processes",
         "type": "QString",
-        "ui": "ShortcutItem"
+        "ui": "ShortcutItem",
+        "old": [
+            "hotkey_kill"
+        ]
     },
     {
         "name": "Hotkey/Compile Run",
         "desc": "Compile and Run",
         "type": "QString",
-        "ui": "ShortcutItem"
+        "ui": "ShortcutItem",
+        "old": [
+            "hotkey_compile_run"
+        ]
     },
     {
         "name": "Hotkey/Run",
         "desc": "Run Only",
         "type": "QString",
-        "ui": "ShortcutItem"
+        "ui": "ShortcutItem",
+        "old": [
+            "hotkey_run"
+        ]
     },
     {
         "name": "Hotkey/Compile",
         "desc": "Compile Only",
         "type": "QString",
-        "ui": "ShortcutItem"
+        "ui": "ShortcutItem",
+        "old": [
+            "hotkey_compile"
+        ]
     },
     {
         "name": "Hotkey/Change View Mode",
         "desc": "Change View Mode",
         "type": "QString",
-        "ui": "ShortcutItem"
+        "ui": "ShortcutItem",
+        "old": [
+            "hotkey_mode_toggle"
+        ]
     },
     {
         "name": "Hotkey/Snippets",
         "desc": "Use Snippets",
         "type": "QString",
-        "ui": "ShortcutItem"
+        "ui": "ShortcutItem",
+        "old": [
+            "hotkey_snippets"
+        ]
     },
     {
         "name": "Hot Exit/Enable",
         "desc": "Restore last session at startup",
         "type": "bool",
         "default": true,
-        "tip": "Restore the last session when the application starts.\nWhen this is enabled, you won't be asked whether to save unsaved files when exiting."
+        "tip": "Restore the last session when the application starts.\nWhen this is enabled, you won't be asked whether to save unsaved files when exiting.",
+        "old": [
+            "use_hot_exit"
+        ]
     },
     {
         "name": "Hot Exit/Auto Save",
@@ -588,7 +689,10 @@
         "default": "cf",
         "ui": "PathItem",
         "param": "PathItem::Executable",
-        "tip": "The path to the CF Tool executable file"
+        "tip": "The path to the CF Tool executable file",
+        "old": [
+            "cf_path"
+        ]
     },
     {
         "name": "CF/Show Toast Messages",
@@ -600,7 +704,10 @@
     {
         "name": "Show Compile And Run Only",
         "type": "bool",
-        "tip": "Hide the Compile Only button and the Run Only button under the code editor in the main window."
+        "tip": "Hide the Compile Only button and the Run Only button under the code editor in the main window.",
+        "old": [
+            "compile_and_run_only"
+        ]
     },
     {
         "name": "Display EOLN In Diff",
@@ -619,7 +726,10 @@
         "type": "int",
         "default": 5000,
         "param": "QVariantList {1,3600000,1000}",
-        "tip": "The default time limit when executing the program.\nThe program will be killed if it doesn't terminate in the time limit."
+        "tip": "The default time limit when executing the program.\nThe program will be killed if it doesn't terminate in the time limit.",
+        "old": [
+            "time_limit"
+        ]
     },
     {
         "name": "Output Length Limit",
@@ -661,7 +771,10 @@
         "type": "int",
         "default": 500000,
         "param": "QVariantList {2,1000000000}",
-        "tip": "The maximum number of characters in a test case to be loaded.\nA loaded test case will be elided and read-only if it's too long."
+        "tip": "The maximum number of characters in a test case to be loaded.\nA loaded test case will be elided and read-only if it's too long.",
+        "old": [
+            "load_test_case_file_length_limit"
+        ]
     },
     {
         "name": "LSP/Path C++",

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -767,13 +767,14 @@
         "tip": "The maximum number of characters in a source file to open.\nA source file won't be opened if it's too long."
     },
     {
-        "name": "Load Test Case Length Limit",
+        "name": "Display Test Case Length Limit",
         "type": "int",
         "default": 500000,
         "param": "QVariantList {2,1000000000}",
-        "tip": "The maximum number of characters in a test case to be loaded.\nA loaded test case will be elided and read-only if it's too long.",
+        "tip": "The maximum number of characters in a test case to be displayed.\nA test case will be elided and read-only if it's too long.",
         "old": [
-            "load_test_case_file_length_limit"
+            "load_test_case_file_length_limit",
+            "load_test_case_length_limit"
         ]
     },
     {

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -92,8 +92,8 @@ void TestCaseEdit::modifyText(const QString &text, bool keepHistory)
 {
     this->text = text;
 
-    const int limit =
-        role == Output ? SettingsHelper::getOutputDisplayLengthLimit() : SettingsHelper::getLoadTestCaseLengthLimit();
+    const int limit = role == Output ? SettingsHelper::getOutputDisplayLengthLimit()
+                                     : SettingsHelper::getDisplayTestCaseLengthLimit();
 
     QString displayText;
 
@@ -113,7 +113,7 @@ void TestCaseEdit::modifyText(const QString &text, bool keepHistory)
 
         const QString name = role == Input ? tr("Input") : (role == Output ? tr("Output") : tr("Expected"));
         const QString setLimitPlace = role == Output ? SettingsHelper::pathOfOutputDisplayLengthLimit()
-                                                     : SettingsHelper::pathOfLoadTestCaseLengthLimit();
+                                                     : SettingsHelper::pathOfDisplayTestCaseLengthLimit();
 
         log->warn(
             QString("%1[%2]").arg(name).arg(id + 1),

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -76,8 +76,9 @@ def writeInfo(f, obj, lst):
         for depend in depends:
             dependsString += f"{{{json.dumps(depend.get('name', ''))}, [](const QVariant &var) {{ {depend.get('check', 'return var.toBool();')} }}}}, "
         dependsString += "}"
+        old = t.get("old", [])
         f.write(
-            f", \"{tempname}\", \"{ui}\", {trtip}, tr({json.dumps(hlp)}), {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, ")
+            f", \"{tempname}\", \"{ui}\", {trtip}, tr({json.dumps(hlp)}), {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, {{{json.dumps(old)[1:-1]}}}, ")
         if typename != "Object":
             if "default" in t:
                 if typename == "QString":

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2511,12 +2511,13 @@ The program will be killed if it doesn&apos;t terminate in the time limit.</sour
     </message>
     <message>
         <source>Display Test Case Length Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать лимит длины тесткейса</translation>
     </message>
     <message>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
-        <translation type="unfinished"></translation>
+        <translation>Максимальное отображаемое число символов в тесткейсе.
+Если тесткейс будет слишком большой, он будет пропущен и доступен только для чтения.</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1768,10 +1768,6 @@ This can be overridden for each parenthesis in each language.</source>
         <translation>Сохраните тесткейсы на диске при сохранении файла и загрузите сохраненные тескейсы при открытии файла.</translation>
     </message>
     <message>
-        <source>Maximized Window</source>
-        <translation>Развернуть окно</translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation>Проверять обновления при запуске программы</translation>
     </message>
@@ -1908,10 +1904,6 @@ The Diff Viewer will fall back to plain text if either of the output or the expe
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>Максимальное количество символов в исходном файле для открытия.
 Исходный файл не будет открыт, если он слишком длинный.</translation>
-    </message>
-    <message>
-        <source>Load Test Case Length Limit</source>
-        <translation>Лмимт длины загружаемых тесткейсов</translation>
     </message>
     <message>
         <source>Path to LSP executable</source>
@@ -2410,12 +2402,6 @@ If the output is too long, it will be elided.</source>
 Если вывод очень большой, то он будет опущен.</translation>
     </message>
     <message>
-        <source>The maximum number of characters in a test case to be loaded.
-A loaded test case will be elided and read-only if it&apos;s too long.</source>
-        <translation>Максимальное число символов, в загруженном тесткейсе.
-Если тесткейс большой, то он будет опущен и досупен только для чтения.</translation>
-    </message>
-    <message>
         <source>Show toast messages for submission verdicts</source>
         <translation>Показывать всплывающие уведомления для вердиктов отправок</translation>
     </message>
@@ -2522,6 +2508,15 @@ The program will be killed if it doesn&apos;t terminate in the time limit.</sour
     <message>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Показывать только моноширинные шрифты при выборе</translation>
+    </message>
+    <message>
+        <source>Display Test Case Length Limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in a test case to be displayed.
+A test case will be elided and read-only if it&apos;s too long.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1764,10 +1764,6 @@ This can be overridden for each parenthesis in each language.</source>
         <translation>在保存文件时一并保存测试用例，在加载时一并加载。</translation>
     </message>
     <message>
-        <source>Maximized Window</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Check for updates on startup</source>
         <translation>启动时检查更新</translation>
     </message>
@@ -1904,10 +1900,6 @@ The Diff Viewer will fall back to plain text if either of the output or the expe
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>允许打开的文件的最大字符数。
 如果超长，将不会打开。</translation>
-    </message>
-    <message>
-        <source>Load Test Case Length Limit</source>
-        <translation>加载测试用例长度限制</translation>
     </message>
     <message>
         <source>Path to LSP executable</source>
@@ -2403,11 +2395,6 @@ If the output is too long, it will be elided.</source>
         <translation>会显示出来的程序输出的最大字符数。如果输出过长，超长部分会被省略。</translation>
     </message>
     <message>
-        <source>The maximum number of characters in a test case to be loaded.
-A loaded test case will be elided and read-only if it&apos;s too long.</source>
-        <translation>一个被加载的测试用例中最大的字符数量。一个被加载的测试用例如果过长，超长部分会被省略。</translation>
-    </message>
-    <message>
         <source>Show toast messages for submission verdicts</source>
         <translation>为评测结果显示气泡消息</translation>
     </message>
@@ -2514,6 +2501,15 @@ The program will be killed if it doesn&apos;t terminate in the time limit.</sour
     <message>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>在选择字体时只显示等宽字体</translation>
+    </message>
+    <message>
+        <source>Display Test Case Length Limit</source>
+        <translation>显示测试用例长度限制</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in a test case to be displayed.
+A test case will be elided and read-only if it&apos;s too long.</source>
+        <translation>会显示出来的测试用例的最大字符数。如果测试用例过长，超长部分会被省略，且测试用例会变得只读。</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. The old settings keys are moved from SettingsUpdater to settings.json. It reduces the modification when changing the name of a setting, especially when a setting has multiple old names.
2. Rename "Load Test Case Length Limit" to "Display Test Case Length Limit", which is a better name since #491.

