### PR TITLE
feat(UpdateChecker): update download links

### DIFF
--- a/src/Widgets/UpdateProgressDialog.cpp
+++ b/src/Widgets/UpdateProgressDialog.cpp
@@ -62,7 +62,7 @@ void UpdateProgressDialog::onUpdateFailed(const QString &error)
 {
     information->setText(
         tr("Error: %1<br /><br />Updater failed to check for update. Please manually check for update at<br /><a "
-           "href=\"https://cpeditor.github.io/download\">https://cpeditor.github.io/download</a> or <a "
+           "href=\"https://cpeditor.org/download\">https://cpeditor.org/download</a> or <a "
            "href=\"https://github.com/cpeditor/cpeditor/releases\">https://github.com/cpeditor/cpeditor/releases</a>.")
             .arg(error));
     progressBar->hide();

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2989,8 +2989,8 @@ A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Загружается список релизов...</translation>
     </message>
     <message>
-        <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.github.io/download&quot;&gt;https://cpeditor.github.io/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
-        <translation>Ошибка: %1&lt;br /&gt;&lt;br /&gt;Произошла ошибка при проверке обновления. Пожалуйста, проверьте обновление вручную на &lt;br /&gt;&lt;a href=&quot;https://cpeditor.github.io/download&quot;&gt;https://cpeditor.github.io/download&lt;/a&gt; или &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
+        <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
+        <translation>Ошибка: %1&lt;br /&gt;&lt;br /&gt;Произошла ошибка при проверке обновления. Пожалуйста, проверьте обновление вручную на &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/ru/download&quot;&gt;https://cpeditor.org/ru/download&lt;/a&gt; или &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Close</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2981,8 +2981,8 @@ A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>获取更新列表中...</translation>
     </message>
     <message>
-        <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.github.io/download&quot;&gt;https://cpeditor.github.io/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
-        <translation>错误：%1&lt;br /&gt;&lt;br /&gt;检查更新失败。请前往 &lt;br /&gt;&lt;a href=&quot;https://cpeditor.github.io/download&quot;&gt;https://cpeditor.github.io/download&lt;/a&gt; 或 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt; 手动检查更新。</translation>
+        <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
+        <translation>错误：%1&lt;br /&gt;&lt;br /&gt;检查更新失败。请前往 &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/zh/download&quot;&gt;https://cpeditor.org/zh/download&lt;/a&gt; 或 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt; 手动检查更新。</translation>
     </message>
     <message>
         <source>Close</source>


### PR DESCRIPTION
## Description

Update the download links in the update checker from cpeditor.github.io/download to cpeditor.org/<lang>/download.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
