### PR TITLE
fix(Settings): emit settingsApplied for immediatelyApply

### DIFF
--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -76,7 +76,11 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
         {
             auto widget = widgets.back();
             connect(
-                widget, &ValueWidget::valueChanged, this, [=] { SettingsManager::set(si.name, widget->getVariant()); },
+                widget, &ValueWidget::valueChanged, this,
+                [=] {
+                    SettingsManager::set(si.name, widget->getVariant());
+                    emit settingsApplied(path());
+                },
                 Qt::DirectConnection); // PreferencesPage::registerWidget uses Qt::QueuedConnection
         }
     }


### PR DESCRIPTION
## Description

Emit settingsApplied for immediatelyApply.

## Motivation and Context

SettingsApplied is expected to be emitted in immediatelyApply. If not, we may meet unexpected errors when using immediatelyApply in the future.

## How Has This Been Tested?

On Arch Linux with "Opacity" set to immediatelyApply.

I was thinking of making "Opacity" immediately applied, but when immediately applied it was very slow when draging the slider.

## Checklist

- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
