### PR TITLE
refactor(Checker): use TResult in testlib.h instead of a list of numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ include_directories("third_party/lsp-cpp/include")
 include_directories("third_party/QCodeEditor/include")
 include_directories("third_party/QtFindReplaceDialog")
 include_directories("third_party/qhttp/src")
+include_directories("third_party/testlib")
 
 target_link_libraries(cpeditor PRIVATE LSPClient)
 target_link_libraries(cpeditor PRIVATE QCodeEditor)

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -601,11 +601,11 @@ git 提交编号: %3
     </message>
     <message>
         <source>Checker exited with exit code %1</source>
-        <translation>评测器退出，返回值: %1</translation>
+        <translation>评测器以返回值 %1 退出</translation>
     </message>
     <message>
         <source>Checker exited with unknown exit code %1</source>
-        <translation>评测器退出，未知返回值: %1</translation>
+        <translation>评测器以未知返回值 %1 退出</translation>
     </message>
     <message>
         <source>Time Limit Exceeded</source>


### PR DESCRIPTION
## Description

Use TResult in `testlib.h` instead of a list of numbers.

## Motivation and Context

Use `-Wswitch` to generate a compilation warning when there are unhandled items in TResult.

## How Has This Been Tested?

On Arch Linux with testlib.h checkers and a fake checker which returns an unknown value.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
