### PR TITLE
feat: improve on non-Linux UNIX platforms

### DIFF
--- a/src/Core/Runner.cpp
+++ b/src/Core/Runner.cpp
@@ -129,9 +129,9 @@ void Runner::runDetached(const QString &tmpFilePath, const QString &sourceFilePa
                                  getCommand(tmpFilePath, sourceFilePath, lang, runCommand, args).replace("\"", "^\"") +
                                  " ^& pause\""));
     LOG_INFO("CMD Arguemnts " << runProcess->arguments().join(" "));
-#else
+#elif defined(Q_OS_UNIX)
     auto terminal = SettingsHelper::getDetachedRunTerminalProgram();
-    LOG_INFO("Using: " << terminal << " on Linux");
+    LOG_INFO("Using: " << terminal << " on UNIX");
     auto quotedCommand = getCommand(tmpFilePath, sourceFilePath, lang, runCommand, args);
     auto execArgs = QProcess::splitCommand(SettingsHelper::getDetachedRunTerminalArguments()) +
                     QStringList{"/bin/bash", "-c",
@@ -139,6 +139,8 @@ void Runner::runDetached(const QString &tmpFilePath, const QString &sourceFilePa
                                     .arg(quotedCommand)
                                     .arg(tr("Program finished with exit code %1\nPress any key to exit").arg("$?"))};
     runProcess->start(terminal, execArgs);
+#else
+    emit failedToStartRun(runnerIndex, tr("Detached execution is not supported on your platform"));
 #endif
 }
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -217,7 +217,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .dir(TRKEY("Actions"))
             .page(TRKEY("Save"), {"Save Faster", "Save File On Compilation", "Save File On Execution", "Save Tests"})
             .page(TRKEY("Auto Save"), {"Auto Save", "Auto Save Interval", "Auto Save Interval Type"})
-#ifdef Q_OS_UNIX
+#if defined(Q_OS_UNIX) && (!defined(Q_OS_MAC))
             .page(TRKEY("Detached Execution"), {"Detached Run Terminal Program", "Detached Run Terminal Arguments"})
 #endif
             .page(TRKEY("Save Session"), {"Hot Exit/Enable", "Hot Exit/Auto Save", "Hot Exit/Auto Save Interval"})

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -217,7 +217,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .dir(TRKEY("Actions"))
             .page(TRKEY("Save"), {"Save Faster", "Save File On Compilation", "Save File On Execution", "Save Tests"})
             .page(TRKEY("Auto Save"), {"Auto Save", "Auto Save Interval", "Auto Save Interval Type"})
-#ifdef Q_OS_LINUX
+#ifdef Q_OS_UNIX
             .page(TRKEY("Detached Execution"), {"Detached Run Terminal Program", "Detached Run Terminal Arguments"})
 #endif
             .page(TRKEY("Save Session"), {"Hot Exit/Enable", "Hot Exit/Auto Save", "Hot Exit/Auto Save Interval"})

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -140,7 +140,7 @@
     {
         "name": "C++/Compile Command",
         "type": "QString",
-        "default": "g++ -Wall",
+        "default": "c++ -Wall",
         "tip": "The command used to compile C++. It should NOT include the path to the source file or \"-o <output file>\".",
         "old": [
             "compile_cpp"

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -632,6 +632,10 @@ void AppWindow::on_actionBuildInfo_triggered()
                            .arg("Windows")
 #elif defined(Q_OS_MACOS)
                            .arg("macOS")
+#elif defined(Q_OS_FREEBSD)
+                           .arg("FreeBSD")
+#elif defined(Q_OS_UNIX)
+                           .arg("UNIX")
 #else
                            .arg("Unknown")
 #endif

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -665,7 +665,7 @@ Press any key to exit</source>
     </message>
     <message>
         <source>Detached execution is not supported on your platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Отдельный запуск не поддерживается на вашей системе</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -663,6 +663,10 @@ Press any key to exit</source>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Не удалось запустить отдельно. Пожалуйста, проверьте настройки вашего эмулятора терминала в %1.</translation>
     </message>
+    <message>
+        <source>Detached execution is not supported on your platform</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Core::SessionManager</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -663,6 +663,10 @@ Press any key to exit</source>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>未能成功在终端中运行。请在 %1 中检查终端模拟器的设置。</translation>
     </message>
+    <message>
+        <source>Detached execution is not supported on your platform</source>
+        <translation>你的平台上不支持在终端中运行</translation>
+    </message>
 </context>
 <context>
     <name>Core::SessionManager</name>


### PR DESCRIPTION
## Description

Change some `Q_OS_LINUX` to `Q_OS_UNIX`, etc.

## Motivation and Context

Now CP Editor is [in the official repository of FreeBSD 13](https://freebsd.pkgs.org/13/freebsd-amd64/cpeditor-6.6.5.txz.html).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text

@IZOBRETATEL777 Please update the translation.
