### PR TITLE
fix(Checker): clear tasks when starting a new execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 -   Font settings are moved to Appearance/Font, everything else remains in Appearance/General. (#625)
 
+### Improved
+
+-   Now unfinished checks will be cancelled at the new execution. (#635)
+
 ## v6.7
 
 ### Added

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -102,6 +102,11 @@ class Checker : public QObject
      */
     void reqeustCheck(int index, const QString &input, const QString &output, const QString &expected);
 
+    /**
+     * @brief clear the pending tasks and kill executing tasks
+     */
+    void clearTasks();
+
   signals:
     /**
      * @brief return the check result
@@ -195,7 +200,7 @@ class Checker : public QObject
                                      // It's not needed by built-in checkers
     MessageLogger *log = nullptr;    // the message logger to show messages to the user
     Compiler *compiler = nullptr;    // the compiler used to compile the checker
-    QVector<Runner *> runner;        // the runners used to run the check processes
+    QVector<Runner *> runners;        // the runners used to run the check processes
     QVector<Task> pendingTasks;      // the unsolved check requests
     bool compiled = false;           // whether the testlib checker is compiled or not
                                      // It should be true for built-in checkers.

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -200,7 +200,7 @@ class Checker : public QObject
                                      // It's not needed by built-in checkers
     MessageLogger *log = nullptr;    // the message logger to show messages to the user
     Compiler *compiler = nullptr;    // the compiler used to compile the checker
-    QVector<Runner *> runners;        // the runners used to run the check processes
+    QVector<Runner *> runners;       // the runners used to run the check processes
     QVector<Task> pendingTasks;      // the unsolved check requests
     bool compiled = false;           // whether the testlib checker is compiled or not
                                      // It should be true for built-in checkers.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -184,6 +184,8 @@ void MainWindow::run()
         return;
     }
 
+    checker->clearTasks();
+
     for (int i = 0; i < testcases->count(); ++i)
     {
         if ((!testcases->input(i).trimmed().isEmpty() || SettingsHelper::isRunOnEmptyTestcase()) &&


### PR DESCRIPTION
## Description

Clear check tasks when starting a new execution.

## Motivation and Context

Otherwise, there can be many unfinished tasks, especially when there are many executions before the checker is compiled.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
