### PR TITLE
feat(Checker): add logs for compilation and improve log for killed

### DIFF
--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -126,6 +126,7 @@ void Checker::prepare(const QString &compileCommand)
 
         // start the compilation of the checker
         compiler = new Compiler();
+        connect(compiler, SIGNAL(compilationStarted()), this, SLOT(onCompilationStarted()));
         connect(compiler, SIGNAL(compilationFinished(const QString &)), this, SLOT(onCompilationFinished()));
         connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
                 SLOT(onCompilationErrorOccurred(const QString &)));
@@ -143,9 +144,16 @@ void Checker::reqeustCheck(int index, const QString &input, const QString &outpu
         pendingTasks.push_back({index, input, output, expected}); // otherwise push it into the pending tasks list
 }
 
+void Checker::onCompilationStarted()
+{
+    log->info(tr("Checker"), tr("Started compiling the checker"));
+}
+
 void Checker::onCompilationFinished()
 {
     compiled = true; // mark that the checker is compiled
+    if (checkerType >= Ncmp)
+        log->info(tr("Checker"), tr("The checker is compiled"));
     for (auto t : pendingTasks)
         check(t.index, t.input, t.output, t.expected); // solve the pending tasks
     pendingTasks.clear();
@@ -168,42 +176,42 @@ void Checker::onCompilationKilled()
 void Checker::onRunFinished(int index, const QString &, const QString &err, int exitCode, int, bool tle)
 {
     if (tle)
-        log->warn(tr("Checker[%1]").arg(index + 1), tr("Time Limit Exceeded"));
+        log->warn(head(index), tr("Time Limit Exceeded"));
 
     if (exitCode == 0)
     {
         // the check process succeeded
         if (!err.isEmpty())
-            log->message(tr("Checker[%1]").arg(index + 1), err, "green");
+            log->message(head(index), err, "green");
         emit checkFinished(index, Widgets::TestCase::AC);
     }
     else if (QList<int>({1, 2, 3, 4, 5, 8, 16}).contains(exitCode)) // this list is from testlib.h::TResult
     {
         // This exit code is a normal exit code of a testlib checker, means WA or something else
         if (err.isEmpty())
-            log->error(tr("Checker[%1]").arg(index + 1), tr("Checker exited with exit code %1").arg(exitCode));
+            log->error(head(index), tr("Checker exited with exit code %1").arg(exitCode));
         else
-            log->error(tr("Checker[%1]").arg(index + 1), err);
+            log->error(head(index), err);
         emit checkFinished(index, Widgets::TestCase::WA);
     }
     else
     {
         // This exit code is not one of the normal exit codes of a testlib checker, maybe the checker crashed
-        log->error(tr("Checker[%1]").arg(index + 1), tr("Checker exited with unknown exit code %1").arg(exitCode));
+        log->error(head(index), tr("Checker exited with unknown exit code %1").arg(exitCode));
         if (!err.isEmpty())
-            log->error(tr("Checker[%1]").arg(index + 1), err);
+            log->error(head(index), err);
     }
 }
 
 void Checker::onFailedToStartRun(int index, const QString &error)
 {
-    log->error(tr("Checker[%1]").arg(index + 1), error);
+    log->error(head(index), error);
 }
 
 void Checker::onRunOutputLimitExceeded(int index, const QString &type)
 {
     log->warn(
-        tr("Checker[%1]").arg(index + 1),
+        head(index),
         tr("The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer "
            "than the output length limit, so the process is killed. You can change the output length limit at %4.")
             .arg(type)
@@ -214,7 +222,7 @@ void Checker::onRunOutputLimitExceeded(int index, const QString &type)
 
 void Checker::onRunKilled(int index)
 {
-    log->error(tr("Checker[%1]").arg(index + 1), tr("Killed"));
+    log->error(head(index), tr("The checker is killed"));
 }
 
 bool Checker::checkIgnoreTrailingSpaces(const QString &output, const QString &expected)
@@ -305,6 +313,11 @@ void Checker::check(int index, const QString &input, const QString &output, cons
         }
         break;
     }
+}
+
+QString Checker::head(int index) const
+{
+    return tr("Checker[%1]").arg(index + 1);
 }
 
 } // namespace Core

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -51,6 +51,7 @@ class Checker : public QObject
         IgnoreTrailingSpaces, // Ignore blank characters at the end of lines and blank lines at the end.
         Strict,               // White space differences matters, except the differences between \n, \r and \r\n
         /* testlib checkers */
+        /* Ncmp should be the first one in the testlib checkers */
         Ncmp,   // ncmp.cpp in testlib, compare ordered sequences of signed int64 numbers
         Rcmp4,  // rcmp4.cpp in testlib, compare two sequences of doubles, max absolute or relative error = 1e-4
         Rcmp6,  // rcmp6.cpp in testlib, compare two sequences of doubles, max absolute or relative error = 1e-6
@@ -111,6 +112,11 @@ class Checker : public QObject
     void checkFinished(int index, Widgets::TestCase::Verdict verdict);
 
   private slots:
+    /**
+     * @brief the compilation of the checker started
+     */
+    void onCompilationStarted();
+
     /**
      * @brief the checker is compiled successfully
      */
@@ -181,6 +187,12 @@ class Checker : public QObject
      * @note this should only be called when the checker is compiled
      */
     void check(int index, const QString &input, const QString &output, const QString &expected);
+
+    /**
+     * @param index the index of the testcase
+     * @returns "Checker[*index*]"
+     */
+    QString head(int index) const;
 
     // a struct with the info of a testcase, or called a check task, used to save check requests
     struct Task

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -616,8 +616,16 @@ Git commit hash: %3
         <translation>%1 из процессов при работе на тесткейсе #%2 содержит более чем %3 символов и превосходит лимит. Процесс убит. Вы можете изменить этот лимит в %4.</translation>
     </message>
     <message>
-        <source>Killed</source>
-        <translation>Убито</translation>
+        <source>The checker is killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Started compiling the checker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The checker is compiled</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -617,15 +617,15 @@ Git commit hash: %3
     </message>
     <message>
         <source>The checker is killed</source>
-        <translation type="unfinished"></translation>
+        <translation>Чекер убит</translation>
     </message>
     <message>
         <source>Started compiling the checker</source>
-        <translation type="unfinished"></translation>
+        <translation>Начата компиляция чекера</translation>
     </message>
     <message>
         <source>The checker is compiled</source>
-        <translation type="unfinished"></translation>
+        <translation>Чекер скомпилирован</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -616,8 +616,16 @@ git 提交编号: %3
         <translation>测试点 #%2 的 %1 超过 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在 %4 更改限制大小。</translation>
     </message>
     <message>
-        <source>Killed</source>
-        <translation>被终止</translation>
+        <source>The checker is killed</source>
+        <translation>评测器已被终止运行</translation>
+    </message>
+    <message>
+        <source>Started compiling the checker</source>
+        <translation>开始编译评测器</translation>
+    </message>
+    <message>
+        <source>The checker is compiled</source>
+        <translation>评测器编译完成</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

Add logs for compilation and improve log for killed.

## Motivation and Context

When I was designing the checker, I thought logs for the compilation of the checkers are redundant. But it turns out that it can be very confusing to wait for the checker to be compiled.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text

@IZOBRETATEL777 Please update the translations.
