### PR TITLE
feat(Formatter): Add YAPF Python formatter and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ target_wrapper.*
 CMakeLists.txt.user*
 
 build/
+.clangd/
 
 # Visual Studio
 .vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 -   Now you can opt-in non-monospaced fonts when choosing a font in the Preferences. (#217 and #625)
+-   Now you can format your python code with YAPF Formatter extension. (#640)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ add_executable(cpeditor
     src/Extensions/ClangFormatter.cpp
     src/Extensions/ClangFormatter.hpp
     src/Extensions/CodeFormatter.cpp
-	src/Extensions/CodeFormatter.hpp
+    src/Extensions/CodeFormatter.hpp
     src/Extensions/CompanionServer.cpp
     src/Extensions/CompanionServer.hpp
     src/Extensions/EditorTheme.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ add_executable(cpeditor
     src/Extensions/EditorTheme.hpp
     src/Extensions/LanguageServer.cpp
     src/Extensions/LanguageServer.hpp
+	src/Extensions/YAPFormatter.cpp
+	src/Extensions/YAPFormatter.hpp
 
     src/Settings/CodeSnippetsPage.cpp
     src/Settings/CodeSnippetsPage.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ add_executable(cpeditor
     src/Extensions/CFTool.hpp
     src/Extensions/ClangFormatter.cpp
     src/Extensions/ClangFormatter.hpp
+    src/Extensions/CodeFormatter.cpp
+	src/Extensions/CodeFormatter.hpp
     src/Extensions/CompanionServer.cpp
     src/Extensions/CompanionServer.hpp
     src/Extensions/EditorTheme.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,8 @@ add_executable(cpeditor
     src/Extensions/EditorTheme.hpp
     src/Extensions/LanguageServer.cpp
     src/Extensions/LanguageServer.hpp
-	src/Extensions/YAPFormatter.cpp
-	src/Extensions/YAPFormatter.hpp
+    src/Extensions/YAPFormatter.cpp
+    src/Extensions/YAPFormatter.hpp
 
     src/Settings/CodeSnippetsPage.cpp
     src/Settings/CodeSnippetsPage.hpp

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -128,12 +128,10 @@ void ClangFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
     QTextCursor cursor = editor->textCursor();
     cursor.select(QTextCursor::Document);
     cursor.insertText(formatResult.second);
-    qDebug() << "Setting new cursor position at " << formatResult.first;
     cursor.setPosition(formatResult.first);
 
     if (wasSelection)
     {
-        qDebug() << "There was a selection";
         // if there's a selection, we have to restore not only the cursor, but also the anchor
 
         // get the new position for the anchor
@@ -142,7 +140,6 @@ void ClangFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
         else
             formatArgs[0] = "--cursor=" + QString::number(unformatterEnd);
         auto res2 = parseStdout(runFormatProcess(formatArgs).second);
-        qDebug() << "Returned " << res2;
         if (res2.first == -1)
             return;
 

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -42,6 +42,11 @@ QString ClangFormatter::formatterName()
     return "Clang Formatter";
 }
 
+QString ClangFormatter::formatterSettingPath()
+{
+    return SettingsHelper::pathOfClangFormatPath();
+}
+
 QStringList ClangFormatter::prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
                                                    bool formatCompleteSource)
 {

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -155,4 +155,4 @@ void ClangFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
     editor->setTextCursor(cursor);
     logMessage("Formatting completed");
 }
-} // namespace Extension
+} // namespace Extensions

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -149,8 +149,8 @@ void ClangFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
 
     // apply the cursor changes to the editor
     editor->setTextCursor(cursor);
-	delete tempDir;
-	tempDir = nullptr;
+    delete tempDir;
+    tempDir = nullptr;
     logMessage("Formatting completed");
 }
 } // namespace Extensions

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -42,7 +42,8 @@ QString ClangFormatter::formatterName()
     return "Clang Formatter";
 }
 
-QStringList ClangFormatter::prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource)
+QStringList ClangFormatter::prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
+                                                   bool formatCompleteSource)
 {
 
     LOG_INFO(BOOL_INFO_OF(editor == nullptr) << INFO_OF(filePath));

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -119,7 +119,7 @@ void ClangFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
     auto formatResult = parseStdout(formatStdout);
 
     // get format result with the current cursor
-    if (formatResult.first == -1)
+    if (formatResult.first != 0)
         return;
 
     if (formatResult.second == editor->toPlainText())
@@ -145,7 +145,7 @@ void ClangFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
         else
             formatArgs[0] = "--cursor=" + QString::number(unformatterEnd);
         auto res2 = parseStdout(runFormatProcess(formatArgs).second);
-        if (res2.first == -1)
+        if (res2.first != 0)
             return;
 
         // restore the selection

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -42,7 +42,7 @@ QString ClangFormatter::formatterName()
     return "Clang Formatter";
 }
 
-QStringList ClangFormatter::prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language)
+QStringList ClangFormatter::prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource)
 {
 
     LOG_INFO(BOOL_INFO_OF(editor == nullptr) << INFO_OF(filePath));
@@ -55,7 +55,7 @@ QStringList ClangFormatter::prepareFormatArguments(QCodeEditor *editor, const QS
 
     // get command line arguments related to cursor position
     QStringList args = {"--cursor=" + QString::number(pos), "--style=file"};
-    if (cursor.hasSelection())
+    if (cursor.hasSelection() && !formatCompleteSource)
     {
         args.append("--offset=" + QString::number(start));
         args.append("--length=" + QString::number(end - start));

--- a/src/Extensions/ClangFormatter.hpp
+++ b/src/Extensions/ClangFormatter.hpp
@@ -39,7 +39,7 @@ class ClangFormatter : public CodeFormatter
 
     virtual QStringList supportedLanguages() override;
     virtual QString formatterName() override;
-    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language) override;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource) override;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) override;
 
   private:

--- a/src/Extensions/ClangFormatter.hpp
+++ b/src/Extensions/ClangFormatter.hpp
@@ -45,6 +45,11 @@ class ClangFormatter : public CodeFormatter
 
   private:
     QStringList formatArgs;
+    int unformatterStart;
+    int unformatterEnd;
+    int unformatterPos;
+    
+	bool wasSelection;
 };
 } // namespace Extensions
 #endif

--- a/src/Extensions/ClangFormatter.hpp
+++ b/src/Extensions/ClangFormatter.hpp
@@ -48,8 +48,8 @@ class ClangFormatter : public CodeFormatter
     int unformatterStart;
     int unformatterEnd;
     int unformatterPos;
-    
-	bool wasSelection;
+
+    bool wasSelection;
 };
 } // namespace Extensions
 #endif

--- a/src/Extensions/ClangFormatter.hpp
+++ b/src/Extensions/ClangFormatter.hpp
@@ -39,6 +39,8 @@ class ClangFormatter : public CodeFormatter
 
     virtual QStringList supportedLanguages() override;
     virtual QString formatterName() override;
+    virtual QString formatterSettingPath() override;
+
     virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
                                                bool formatCompleteSource) override;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) override;

--- a/src/Extensions/ClangFormatter.hpp
+++ b/src/Extensions/ClangFormatter.hpp
@@ -39,7 +39,8 @@ class ClangFormatter : public CodeFormatter
 
     virtual QStringList supportedLanguages() override;
     virtual QString formatterName() override;
-    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource) override;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
+                                               bool formatCompleteSource) override;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) override;
 
   private:

--- a/src/Extensions/ClangFormatter.hpp
+++ b/src/Extensions/ClangFormatter.hpp
@@ -24,71 +24,26 @@
 #ifndef CLANG_FORMATTER_HPP
 #define CLANG_FORMATTER_HPP
 
-#include <QObject>
+#include "Extensions/CodeFormatter.hpp"
 
 class MessageLogger;
 class QCodeEditor;
 
 namespace Extensions
 {
-class ClangFormatter : public QObject
+class ClangFormatter : public CodeFormatter
 {
     Q_OBJECT
-
   public:
-    /**
-     * @brief construct a Formatter
-     * @param clangFormatBinary the path to the Clang Format binary used for formatting
-     * @param clangFormatStyle the Clang Format style used for formatting
-     * @param logger the message logger used for displaying messages
-     * @param parent the parent of the QObject
-     */
-    explicit ClangFormatter(const QString &clangFormatBinary, const QString &clangFormatStyle, MessageLogger *logger,
-                            QObject *parent = nullptr);
+    ClangFormatter(QString binary, QString style, QString binaryArgs, MessageLogger *logger, QObject *parent = nullptr);
 
-    /**
-     * @brief format the codes in the given editor
-     * @param editor the editor to be formatted
-     * @param filePath the file path of the file to be formatted
-     * @param lang the language to be formatted
-     * @param selectionOnly whether to format the selection only if there is one, doesn't matter if there is no
-     *        selection
-     * @param verbose if verbose, "Formatting completed" will be logged even if the code is unchanged after formatting
-     */
-    void format(QCodeEditor *editor, const QString &filePath, const QString &lang, bool selectionOnly, bool verbose);
-
-    /**
-     * @brief check whether the given settings are valid
-     * @param checkBinary the Clang Format binary to be checked
-     * @param checkStyle the Clang Format style to be checked
-     */
-    static bool check(const QString &checkBinary, const QString &checkStyle);
-
-    /**
-     * @brief update the Clang Format binary of a checker
-     * @param newBinary the path to the new Clang Format binary to use
-     */
-    void updateBinary(const QString &newBinary);
-
-    /**
-     * @brief update the Clang Format style of a checker
-     * @param newStyle the new Clang Format style to use
-     */
-    void updateStyle(const QString &newStyle);
+    virtual QStringList supportedLanguages() override;
+    virtual QString formatterName() override;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language) override;
+    virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) override;
 
   private:
-    /**
-     * @brief get the format result
-     * @param args the command line arguments passed to Clang Format
-     * @return a QPair, the first element is the new cursor position, the second element is the new text
-     *         if the formatting failed, it will return {-1, QString()}
-     */
-    QPair<int, QString> getFormatResult(const QStringList &args);
-
-    QString binary;     // the path to the Clang Format binary
-    QString style;      // the Clang Format style
-    MessageLogger *log; // the message logger to display messages
+    QStringList formatArgs;
 };
-
 } // namespace Extensions
-#endif // FORMATTER_HPP
+#endif

--- a/src/Extensions/CodeFormatter.cpp
+++ b/src/Extensions/CodeFormatter.cpp
@@ -48,7 +48,7 @@ void CodeFormatter::format(QCodeEditor *editor, const QString &filePath, QString
         return;
     }
 
-    // get the format arguments, if empty is returned. It means some error occured in preparing and bail out.
+    // get the format arguments, if empty is returned. It means some error occurred in preparing and bail out.
     // Error will be logged and reported by the function iteself.
     auto formatArgs = prepareFormatArguments(editor, filePath, language);
     if (formatArgs.isEmpty())

--- a/src/Extensions/CodeFormatter.cpp
+++ b/src/Extensions/CodeFormatter.cpp
@@ -132,7 +132,7 @@ QPair<int, QString> CodeFormatter::runFormatProcess(QStringList const &args)
 
     if (formatProcess.exitCode() != 0)
     {
-        // the format process failed, show the error messages and return {-1, QString()}
+        // the format process failed, show the error messages and return {exitCode(), QString()}
         LOG_WARN("Format process returned exit code " << formatProcess.exitCode());
 
         logWarningMessage(tr("The format command is: %1 %2").arg(binary(), args.join(' ')));

--- a/src/Extensions/CodeFormatter.cpp
+++ b/src/Extensions/CodeFormatter.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+/*
+ * The Formatter is used to format codes.
+ * It runs synchronously, so the event loop is blocked while formatting.
+ * The time limit for formatting is 2 seconds.
+ */
+
+#include "Extensions/CodeFormatter.hpp"
+#include "Core/EventLogger.hpp"
+#include "Core/MessageLogger.hpp"
+#include <QCodeEditor>
+#include <QProcess>
+
+namespace Extensions
+{
+CodeFormatter::CodeFormatter(QString binary, QString style, QString binArgs, MessageLogger *logger, QObject *parent)
+
+    : QObject(parent), m_binary(binary), m_style(style), m_binaryArgs(binArgs), m_logger(logger)
+{
+}
+
+void CodeFormatter::format(QCodeEditor *editor, const QString &filePath, QString language)
+{
+    // Nothing in code editor, bail out.
+    if (editor->toPlainText().isEmpty())
+        return;
+
+    // Sanity check if formatter supports this language
+    if (!supportedLanguages().contains(language))
+    {
+        logErrorMessage(tr("Cannot format %1 code with this formatter").arg(language));
+        return;
+    }
+
+    // get the format arguments, if empty is returned. It means some error occured in preparing and bail out.
+    // Error will be logged and reported by the function iteself.
+    auto formatArgs = prepareFormatArguments(editor, filePath, language);
+    if (formatArgs.isEmpty())
+        return;
+
+    // run the format process with the argument.
+    // error will be reported by the function iteself.
+    auto formatResults = runFormatProcess(formatArgs);
+
+    // exit code 0 but empty output on stdout means that user added -i (inplace) formatting command.
+    // warn him of this disaster.
+    if (formatResults.first == 0 && formatResults.second.isEmpty())
+    {
+        logErrorMessage(tr("Got empty stdout from format process. Did you used -i or inplace formatting argument?"));
+        return;
+    }
+
+    applyFormatting(editor, formatResults.second);
+}
+void CodeFormatter::setBinary(QString const &newBinary)
+{
+    m_binary = newBinary;
+}
+void CodeFormatter::setStyle(QString const &newStyle)
+{
+    m_style = newStyle;
+}
+void CodeFormatter::setArguments(QString const &newArgs)
+{
+    m_binaryArgs = newArgs;
+}
+
+QString CodeFormatter::binary() const
+{
+    return m_binary;
+}
+QString CodeFormatter::style() const
+{
+    return m_style;
+}
+QString CodeFormatter::binaryArgs() const
+{
+    return m_binaryArgs;
+}
+MessageLogger *CodeFormatter::logger() const
+{
+    return m_logger;
+}
+void CodeFormatter::logMessage(QString const &message)
+{
+    if (m_logger)
+        m_logger->info(formatterName(), message);
+}
+void CodeFormatter::logErrorMessage(QString const &message)
+{
+    if (m_logger)
+        m_logger->error(formatterName(), message);
+}
+void CodeFormatter::logWarningMessage(QString const &message)
+{
+    if (m_logger)
+        m_logger->warn(formatterName(), message);
+}
+
+QPair<int, QString> CodeFormatter::runFormatProcess(QStringList const &args)
+{
+    QProcess formatProcess;
+    formatProcess.start(binary(), args);
+    LOG_INFO("Starting format with args : " << args.join(","));
+
+    bool finished = formatProcess.waitForFinished(2000); // BLOCKS main Thread
+    if (!finished)
+    {
+        formatProcess.kill();
+        logWarningMessage(tr("The format process didn't finished in 2 seconds. This is probably because %1 binary is "
+                             "not found by CP Editor. You can set its path in Extensions -> %1 -> Path.")
+                              .arg(formatterName()));
+        return {-1, QString()};
+    }
+
+    if (formatProcess.exitCode() != 0)
+    {
+        // the format process failed, show the error messages and return {-1, QString()}
+        LOG_WARN("Format process returned exit code " << formatProcess.exitCode());
+
+        logWarningMessage(tr("The format command is: %1 %2").arg(binary(), args.join(' ')));
+        auto stdOut = formatProcess.readAllStandardOutput();
+        if (!stdOut.isEmpty() && logger())
+            logger()->warn(tr("Formatter[stdout]"), stdOut);
+        auto stdError = formatProcess.readAllStandardError();
+        if (!stdError.isEmpty() && logger())
+            logger()->error(tr("Formatter[stderr]"), stdError);
+        return {formatProcess.exitCode(), QString()};
+    }
+    return {formatProcess.exitCode(), formatProcess.readAllStandardOutput()};
+}
+} // namespace Extensions

--- a/src/Extensions/CodeFormatter.cpp
+++ b/src/Extensions/CodeFormatter.cpp
@@ -35,7 +35,7 @@ CodeFormatter::CodeFormatter(QString binary, QString style, QString binArgs, Mes
 {
 }
 
-void CodeFormatter::format(QCodeEditor *editor, const QString &filePath, QString language)
+void CodeFormatter::format(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource)
 {
     // Nothing in code editor, bail out.
     if (editor->toPlainText().isEmpty())
@@ -50,7 +50,7 @@ void CodeFormatter::format(QCodeEditor *editor, const QString &filePath, QString
 
     // get the format arguments, if empty is returned. It means some error occurred in preparing and bail out.
     // Error will be logged and reported by the function iteself.
-    auto formatArgs = prepareFormatArguments(editor, filePath, language);
+    auto formatArgs = prepareFormatArguments(editor, filePath, language, formatCompleteSource);
     if (formatArgs.isEmpty())
         return;
 

--- a/src/Extensions/CodeFormatter.cpp
+++ b/src/Extensions/CodeFormatter.cpp
@@ -123,9 +123,10 @@ QPair<int, QString> CodeFormatter::runFormatProcess(QStringList const &args)
     if (!finished)
     {
         formatProcess.kill();
-        logWarningMessage(tr("The format process didn't finished in 2 seconds. This is probably because %1 binary is "
-                             "not found by CP Editor. You can set its path in Extensions -> %1 -> Path.")
-                              .arg(formatterName()));
+        logErrorMessage(tr("The format process didn't finished in 2 seconds. This is probably because %1 binary is "
+                           "not found by CP Editor. You can set its path in %2.")
+                            .arg(formatterName())
+                            .arg(formatterSettingPath()));
         return {-1, QString()};
     }
 

--- a/src/Extensions/CodeFormatter.hpp
+++ b/src/Extensions/CodeFormatter.hpp
@@ -42,14 +42,14 @@ class CodeFormatter : public QObject
   public:
     CodeFormatter(QString binary, QString style, QString binaryArgs, MessageLogger *logger, QObject *parent = nullptr);
 
-    void format(QCodeEditor *editor, const QString &filePath, QString language);
+    void format(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource = false);
     void setBinary(QString const &newBinary);
     void setStyle(QString const &newStyle);
     void setArguments(QString const &newArgs);
 
     virtual QStringList supportedLanguages() = 0;
     virtual QString formatterName() = 0;
-    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language) = 0;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource = false) = 0;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) = 0;
 
     void logMessage(QString const &message);

--- a/src/Extensions/CodeFormatter.hpp
+++ b/src/Extensions/CodeFormatter.hpp
@@ -64,7 +64,6 @@ class CodeFormatter : public QObject
   protected:
     virtual QPair<int, QString> runFormatProcess(const QStringList &args);
 
-    QTemporaryFile *tempFile = nullptr;
     QTemporaryDir *tempDir = nullptr;
 
   private:

--- a/src/Extensions/CodeFormatter.hpp
+++ b/src/Extensions/CodeFormatter.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+/*
+ * The Formatter is used to format codes.
+ * It runs synchronously, so the event loop is blocked while formatting.
+ * The time limit for formatting is 2 seconds.
+ */
+
+#ifndef CODE_FORMATTER_HPP
+#define CODE_FORMATTER_HPP
+
+#include <QObject>
+
+class QString;
+template <class A, class B> class QPair;
+class QStringList;
+class QCodeEditor;
+class MessageLogger;
+class QTemporaryFile;
+class QTemporaryDir;
+
+namespace Extensions
+{
+class CodeFormatter : public QObject
+{
+    Q_OBJECT
+  public:
+    CodeFormatter(QString binary, QString style, QString binaryArgs, MessageLogger *logger, QObject *parent = nullptr);
+
+    void format(QCodeEditor *editor, const QString &filePath, QString language);
+    void setBinary(QString const &newBinary);
+    void setStyle(QString const &newStyle);
+    void setArguments(QString const &newArgs);
+
+    virtual QStringList supportedLanguages() = 0;
+    virtual QString formatterName() = 0;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language) = 0;
+    virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) = 0;
+
+    void logMessage(QString const &message);
+    void logErrorMessage(QString const &message);
+    void logWarningMessage(QString const &message);
+
+    QString binary() const;
+    QString style() const;
+    QString binaryArgs() const;
+    MessageLogger *logger() const;
+
+  protected:
+    virtual QPair<int, QString> runFormatProcess(const QStringList &args);
+
+    QTemporaryFile *tempFile = nullptr;
+    QTemporaryDir *tempDir = nullptr;
+
+  private:
+    QString m_binary;
+    QString m_style;
+    QString m_binaryArgs;
+
+    MessageLogger *m_logger;
+};
+} // namespace Extensions
+#endif

--- a/src/Extensions/CodeFormatter.hpp
+++ b/src/Extensions/CodeFormatter.hpp
@@ -49,6 +49,8 @@ class CodeFormatter : public QObject
 
     virtual QStringList supportedLanguages() = 0;
     virtual QString formatterName() = 0;
+    virtual QString formatterSettingPath() = 0;
+
     virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
                                                bool formatCompleteSource = false) = 0;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) = 0;

--- a/src/Extensions/CodeFormatter.hpp
+++ b/src/Extensions/CodeFormatter.hpp
@@ -49,7 +49,8 @@ class CodeFormatter : public QObject
 
     virtual QStringList supportedLanguages() = 0;
     virtual QString formatterName() = 0;
-    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language, bool formatCompleteSource = false) = 0;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
+                                               bool formatCompleteSource = false) = 0;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) = 0;
 
     void logMessage(QString const &message);

--- a/src/Extensions/YAPFormatter.cpp
+++ b/src/Extensions/YAPFormatter.cpp
@@ -125,8 +125,8 @@ void YAPFormatter::format(QCodeEditor *editor, const QString &filePath, bool sel
 
         cursor.movePosition(QTextCursor::MoveOperation::Start);
         cursor.movePosition(QTextCursor::MoveOperation::Down, QTextCursor::MoveMode::MoveAnchor, firstLine);
-        cursor.movePosition(QTextCursor::MoveOperation::Down, QTextCursor::MoveMode::KeepAnchor, lastLine - firstLine + 1);
-		
+        cursor.movePosition(QTextCursor::MoveOperation::Down, QTextCursor::MoveMode::KeepAnchor,
+                            lastLine - firstLine + 1);
     }
 
     // apply the cursor changes to the editor

--- a/src/Extensions/YAPFormatter.cpp
+++ b/src/Extensions/YAPFormatter.cpp
@@ -56,6 +56,7 @@ QStringList YAPFormatter::prepareFormatArguments(QCodeEditor *editor, const QStr
     if (tempDir)
         delete tempDir;
     tempDir = new QTemporaryDir();
+
     if (!tempDir->isValid())
     {
         logErrorMessage(tr("Failed to create temporary directory"));
@@ -103,6 +104,7 @@ void YAPFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
         logMessage(tr("Formatting completed"));
         return;
     }
+
     QTextCursor cursor = editor->textCursor();
     cursor.select(QTextCursor::Document);
     cursor.insertText(formatStdout);
@@ -116,8 +118,6 @@ void YAPFormatter::applyFormatting(QCodeEditor *editor, QString formatStdout)
     }
 
     editor->setTextCursor(cursor);
-    delete tempDir;
-    tempDir = nullptr;
     logMessage("Formatting completed");
 }
 } // namespace Extensions

--- a/src/Extensions/YAPFormatter.cpp
+++ b/src/Extensions/YAPFormatter.cpp
@@ -42,6 +42,11 @@ QString YAPFormatter::formatterName()
     return "YAPF Formatter";
 }
 
+QString YAPFormatter::formatterSettingPath()
+{
+    return SettingsHelper::pathOfYAPFPath();
+}
+
 QStringList YAPFormatter::prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
                                                  bool formatCompleteSource)
 {

--- a/src/Extensions/YAPFormatter.cpp
+++ b/src/Extensions/YAPFormatter.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#include "Extensions/YAPFormatter.hpp"
+#include "Core/EventLogger.hpp"
+#include "Core/MessageLogger.hpp"
+#include "Util/FileUtil.hpp"
+#include "generated/SettingsHelper.hpp"
+#include <QCodeEditor>
+#include <QProcess>
+#include <QTemporaryDir>
+#include <QTextBlock>
+#include <QTextDocumentFragment>
+
+namespace Extensions
+{
+YAPFormatter::YAPFormatter(const QString &bin, const QString &args, const QString &style, MessageLogger *logger,
+                           QObject *parent)
+    : QObject(parent)
+{
+    log = logger;
+    updateBinary(bin);
+    updateArguments(args);
+    updateStyle(style);
+}
+
+void YAPFormatter::updateBinary(const QString &newBinary)
+{
+    LOG_INFO("Updated yapf format binary to " << newBinary);
+    binary = newBinary;
+}
+
+void YAPFormatter::updateStyle(const QString &newStyle)
+{
+    style = newStyle;
+}
+
+void YAPFormatter::updateArguments(const QString &newArgs)
+{
+    args = newArgs;
+}
+
+void YAPFormatter::format(QCodeEditor *editor, const QString &filePath, bool selectionOnly, bool verbose)
+{
+    LOG_INFO(BOOL_INFO_OF(editor == nullptr) << INFO_OF(filePath) << BOOL_INFO_OF(selectionOnly));
+
+    // get the cursor positions
+    auto cursor = editor->textCursor();
+    int start = cursor.selectionStart();
+    int end = cursor.selectionEnd();
+
+    cursor.setPosition(start);
+    int firstLine = cursor.blockNumber();
+    cursor.setPosition(end, QTextCursor::KeepAnchor);
+    int lastLine = cursor.blockNumber();
+
+    // get command line arguments related to cursor position
+    auto argList = QProcess::splitCommand(args);
+
+    if (selectionOnly && cursor.hasSelection())
+    {
+        argList.append("-l");
+        argList.append(QString::number(firstLine + 1) + "-" + QString::number(lastLine + 1));
+    }
+
+    // get the file name
+    QString tmpName = "tmp.py";
+
+    // create a temporary directory
+    QTemporaryDir tmpDir;
+    if (!tmpDir.isValid())
+    {
+        log->error(tr("Formatter"), tr("Failed to create temporary directory"));
+        return;
+    }
+
+    // save the text to a file
+    if (!Util::saveFile(tmpDir.filePath(tmpName), editor->toPlainText(), tr("Formatter"), true, log))
+        return;
+
+    // save the style to .clang-format
+    if (!Util::saveFile(tmpDir.filePath(".style.yapf"), style, tr("Formatter"), true, log))
+        return;
+
+    // add the file to be formatted in the command line arguments
+    argList.append(tmpDir.filePath(tmpName));
+
+    // get format result with the current cursor
+    auto res = getFormatResult(argList);
+    if (res.isEmpty())
+    {
+        return;
+    }
+
+    if (res == editor->toPlainText())
+    {
+        LOG_INFO("Already formatted");
+        if (verbose)
+            log->info(tr("Formatter"), tr("Formatting completed"));
+        return;
+    }
+
+    // set the formatted text and cursor position
+    cursor.select(QTextCursor::Document);
+    cursor.insertText(res);
+
+    if (start != end)
+    {
+        // if there's a selection, we have to restore the selection.
+        // Since YAPF does not provides --cursor argument, restoring cursor is just selecting the lines [start, end]
+
+        cursor.movePosition(QTextCursor::MoveOperation::Start);
+        cursor.movePosition(QTextCursor::MoveOperation::Down, QTextCursor::MoveMode::MoveAnchor, firstLine);
+        cursor.movePosition(QTextCursor::MoveOperation::Down, QTextCursor::MoveMode::KeepAnchor, lastLine - firstLine + 1);
+		
+    }
+
+    // apply the cursor changes to the editor
+    editor->setTextCursor(cursor);
+
+    log->info(tr("Formatter"), tr("Formatting completed"));
+}
+
+QString YAPFormatter::getFormatResult(const QStringList &args)
+{
+    // run the format porcess
+
+    QProcess formatProcess;
+    formatProcess.start(binary, args);
+    LOG_INFO("Starting format with args : " << args.join(","));
+
+    bool finished = formatProcess.waitForFinished(2000); // BLOCKS main Thread
+    if (!finished)
+    {
+        formatProcess.kill();
+        log->warn(tr("Formatter"),
+                  tr("The format process didn't finish in 2 seconds. This is probably because the python binary is not "
+                     "found by CP Editor. You can set the path to python at %1.")
+                      .arg(SettingsHelper::pathOfYAPFPath()));
+        return QString();
+    }
+
+    if (formatProcess.exitCode() != 0)
+    {
+        // the format process failed, show the error messages and return {-1, QString()}
+        LOG_WARN("Format process returned exit code " << formatProcess.exitCode());
+
+        log->warn(tr("Formatter"), tr("The format command is: %1 %2").arg(binary, args.join(' ')));
+        auto stdOut = formatProcess.readAllStandardOutput();
+        if (!stdOut.isEmpty())
+            log->warn(tr("Formatter[stdout]"), stdOut);
+        auto stdError = formatProcess.readAllStandardError();
+        if (!stdError.isEmpty())
+            log->error(tr("Formatter[stderr]"), stdError);
+        return QString();
+    }
+
+    // get the formatted codes
+    return formatProcess.readAllStandardOutput();
+}
+} // namespace Extensions

--- a/src/Extensions/YAPFormatter.hpp
+++ b/src/Extensions/YAPFormatter.hpp
@@ -45,7 +45,7 @@ class YAPFormatter : public QObject
      * @param parent the parent of the QObject
      */
     YAPFormatter(const QString &yapFormatBinary, const QString &yapArgument, const QString &yapFormatStyle,
-                          MessageLogger *logger, QObject *parent = nullptr);
+                 MessageLogger *logger, QObject *parent = nullptr);
 
     /**
      * @brief format the codes in the given editor
@@ -68,7 +68,7 @@ class YAPFormatter : public QObject
      * @brief update the YAP Format binary of a checker
      * @param newBinary the path to the new YAP Format binary to use
      */
-	void updateArguments(const QString &newArgs);
+    void updateArguments(const QString &newArgs);
 
     /**
      * @brief update the YAP Format style of a checker
@@ -84,9 +84,9 @@ class YAPFormatter : public QObject
      */
     QString getFormatResult(const QStringList &args);
 
-    QString binary;     // the path to the Python binary
-    QString style;      // the YAP Format style
-	QString args;  		// the Argument to start YAP
+    QString binary; // the path to the Python binary
+    QString style;  // the YAP Format style
+    QString args;   // the Argument to start YAP
 
     MessageLogger *log; // the message logger to display messages
 };

--- a/src/Extensions/YAPFormatter.hpp
+++ b/src/Extensions/YAPFormatter.hpp
@@ -21,8 +21,8 @@
  * The time limit for formatting is 2 seconds.
  */
 
-#ifndef CLANG_FORMATTER_HPP
-#define CLANG_FORMATTER_HPP
+#ifndef YAPF_FORMATTER_HPP
+#define YAPF_FORMATTER_HPP
 
 #include <QObject>
 
@@ -31,20 +31,21 @@ class QCodeEditor;
 
 namespace Extensions
 {
-class ClangFormatter : public QObject
+class YAPFormatter : public QObject
 {
     Q_OBJECT
 
   public:
     /**
      * @brief construct a Formatter
-     * @param clangFormatBinary the path to the Clang Format binary used for formatting
-     * @param clangFormatStyle the Clang Format style used for formatting
+     * @param yapFormatBinary the path to the YAP Format binary used for formatting
+     * @param yapArgument the arguments passed to binary to invoke the yapf
+     * @param yapFormatStyle the YAP Format style used for formatting
      * @param logger the message logger used for displaying messages
      * @param parent the parent of the QObject
      */
-    explicit ClangFormatter(const QString &clangFormatBinary, const QString &clangFormatStyle, MessageLogger *logger,
-                            QObject *parent = nullptr);
+    YAPFormatter(const QString &yapFormatBinary, const QString &yapArgument, const QString &yapFormatStyle,
+                          MessageLogger *logger, QObject *parent = nullptr);
 
     /**
      * @brief format the codes in the given editor
@@ -55,38 +56,38 @@ class ClangFormatter : public QObject
      *        selection
      * @param verbose if verbose, "Formatting completed" will be logged even if the code is unchanged after formatting
      */
-    void format(QCodeEditor *editor, const QString &filePath, const QString &lang, bool selectionOnly, bool verbose);
+    void format(QCodeEditor *editor, const QString &filePath, bool selectionOnly, bool verbose);
 
     /**
-     * @brief check whether the given settings are valid
-     * @param checkBinary the Clang Format binary to be checked
-     * @param checkStyle the Clang Format style to be checked
-     */
-    static bool check(const QString &checkBinary, const QString &checkStyle);
-
-    /**
-     * @brief update the Clang Format binary of a checker
-     * @param newBinary the path to the new Clang Format binary to use
+     * @brief update the Python binary of a checker
+     * @param newBinary the path to the new YAP Format binary to use
      */
     void updateBinary(const QString &newBinary);
 
     /**
-     * @brief update the Clang Format style of a checker
-     * @param newStyle the new Clang Format style to use
+     * @brief update the YAP Format binary of a checker
+     * @param newBinary the path to the new YAP Format binary to use
+     */
+	void updateArguments(const QString &newArgs);
+
+    /**
+     * @brief update the YAP Format style of a checker
+     * @param newStyle the new YAP Format style to use
      */
     void updateStyle(const QString &newStyle);
 
   private:
     /**
      * @brief get the format result
-     * @param args the command line arguments passed to Clang Format
-     * @return a QPair, the first element is the new cursor position, the second element is the new text
-     *         if the formatting failed, it will return {-1, QString()}
+     * @param args the command line arguments passed to YAP Format
+     * @return a QString, the new text, if the formatting failed, it will return QString()
      */
-    QPair<int, QString> getFormatResult(const QStringList &args);
+    QString getFormatResult(const QStringList &args);
 
-    QString binary;     // the path to the Clang Format binary
-    QString style;      // the Clang Format style
+    QString binary;     // the path to the Python binary
+    QString style;      // the YAP Format style
+	QString args;  		// the Argument to start YAP
+
     MessageLogger *log; // the message logger to display messages
 };
 

--- a/src/Extensions/YAPFormatter.hpp
+++ b/src/Extensions/YAPFormatter.hpp
@@ -24,72 +24,27 @@
 #ifndef YAPF_FORMATTER_HPP
 #define YAPF_FORMATTER_HPP
 
-#include <QObject>
+#include "Extensions/CodeFormatter.hpp"
 
 class MessageLogger;
 class QCodeEditor;
 
 namespace Extensions
 {
-class YAPFormatter : public QObject
+class YAPFormatter : public CodeFormatter
 {
     Q_OBJECT
-
   public:
-    /**
-     * @brief construct a Formatter
-     * @param yapFormatBinary the path to the YAP Format binary used for formatting
-     * @param yapArgument the arguments passed to binary to invoke the yapf
-     * @param yapFormatStyle the YAP Format style used for formatting
-     * @param logger the message logger used for displaying messages
-     * @param parent the parent of the QObject
-     */
-    YAPFormatter(const QString &yapFormatBinary, const QString &yapArgument, const QString &yapFormatStyle,
-                 MessageLogger *logger, QObject *parent = nullptr);
+    YAPFormatter(QString binary, QString style, QString binaryArgs, MessageLogger *logger, QObject *parent = nullptr);
 
-    /**
-     * @brief format the codes in the given editor
-     * @param editor the editor to be formatted
-     * @param filePath the file path of the file to be formatted
-     * @param lang the language to be formatted
-     * @param selectionOnly whether to format the selection only if there is one, doesn't matter if there is no
-     *        selection
-     * @param verbose if verbose, "Formatting completed" will be logged even if the code is unchanged after formatting
-     */
-    void format(QCodeEditor *editor, const QString &filePath, bool selectionOnly, bool verbose);
-
-    /**
-     * @brief update the Python binary of a checker
-     * @param newBinary the path to the new YAP Format binary to use
-     */
-    void updateBinary(const QString &newBinary);
-
-    /**
-     * @brief update the YAP Format binary of a checker
-     * @param newBinary the path to the new YAP Format binary to use
-     */
-    void updateArguments(const QString &newArgs);
-
-    /**
-     * @brief update the YAP Format style of a checker
-     * @param newStyle the new YAP Format style to use
-     */
-    void updateStyle(const QString &newStyle);
+    virtual QStringList supportedLanguages() override;
+    virtual QString formatterName() override;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language) override;
+    virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) override;
 
   private:
-    /**
-     * @brief get the format result
-     * @param args the command line arguments passed to YAP Format
-     * @return a QString, the new text, if the formatting failed, it will return QString()
-     */
-    QString getFormatResult(const QStringList &args);
-
-    QString binary; // the path to the Python binary
-    QString style;  // the YAP Format style
-    QString args;   // the Argument to start YAP
-
-    MessageLogger *log; // the message logger to display messages
+    int firstLine;
+    int lastLine;
 };
-
 } // namespace Extensions
-#endif // FORMATTER_HPP
+#endif

--- a/src/Extensions/YAPFormatter.hpp
+++ b/src/Extensions/YAPFormatter.hpp
@@ -39,6 +39,8 @@ class YAPFormatter : public CodeFormatter
 
     virtual QStringList supportedLanguages() override;
     virtual QString formatterName() override;
+    virtual QString formatterSettingPath() override;
+
     virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
                                                bool formatCompleteSource) override;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) override;

--- a/src/Extensions/YAPFormatter.hpp
+++ b/src/Extensions/YAPFormatter.hpp
@@ -39,12 +39,15 @@ class YAPFormatter : public CodeFormatter
 
     virtual QStringList supportedLanguages() override;
     virtual QString formatterName() override;
-    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language) override;
+    virtual QStringList prepareFormatArguments(QCodeEditor *editor, const QString &filePath, QString language,
+                                               bool formatCompleteSource) override;
     virtual void applyFormatting(QCodeEditor *editor, QString formatStdout) override;
 
   private:
     int firstLine;
     int lastLine;
+
+    bool wasSelection;
 };
 } // namespace Extensions
 #endif

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -228,6 +228,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .dir(TRKEY("Extensions"))
             .page(TRKEY("Clang Format"), new PreferencesPageTemplate({"Clang Format/Path", "Clang Format/Format On Manual Save",
                                          "Clang Format/Format On Auto Save", "Clang Format/Style"}, false))
+            .page(TRKEY("YAPF Format"), new PreferencesPageTemplate({"YAPF/Path", "YAPF/Arguments", "YAPF/Format On Manual Save",
+                                         "YAPF/Format On Auto Save", "YAPF/Style"}, false))
             .dir(TRKEY("Language Server"))
                 .page("C++ Server", tr("%1 Server").arg(tr("C++")), {"LSP/Use Linting C++", "LSP/Delay C++", "LSP/Path C++", "LSP/Args C++"})
                 .page("Java Server", tr("%1 Server").arg(tr("Java")), {"LSP/Use Linting Java", "LSP/Delay Java", "LSP/Path Java", "LSP/Args Java"})

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -89,6 +89,42 @@
         "tip": "Use Clang Format to format the code when auto-saving it."
     },
     {
+        "name": "YAPF/Path",
+        "desc": "Path",
+        "type": "QString",
+        "default": "python",
+        "ui": "PathItem",
+        "param": "PathItem::Executable",
+        "tip": "The path of python interpreter."
+    },
+    {
+        "name": "YAPF/Arguments",
+        "desc": "Arguments",
+        "type": "QString",
+        "default": "-m yapf",
+        "tip": "The argument for the interpreter to invoke yapf module."
+    },
+    {
+        "name": "YAPF/Style",
+        "desc": "Style",
+        "type": "QString",
+        "ui": "QPlainTextEdit",
+		"default": "[style]\nbased_on_style = pep8",
+        "tip": "The YAPF Format style options, which are often saved in a .style.yapf or setup.conf configuration file. \nYou can check all possible configuration by running `yapf --style-help`"
+    },
+    {
+        "name": "YAPF/Format On Manual Save",
+        "desc": "Format code on manual save",
+        "type": "bool",
+        "tip": "Use YAPF Formatter to format the code when saving it manually."
+    },
+    {
+        "name": "YAPF/Format On Auto Save",
+        "desc": "Format code on auto-save",
+        "type": "bool",
+        "tip": "Use YAPF Formatter to format the code when auto-saving it."
+    },
+    {
         "name": "C++/Template Path",
         "type": "QString",
         "ui": "PathItem",

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -954,11 +954,11 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
 
     if (language != "Python" && ((mode != AutoSave && SettingsHelper::isClangFormatFormatOnManualSave()) ||
                                  (mode == AutoSave && SettingsHelper::isClangFormatFormatOnAutoSave())))
-        formatter->format(editor, filePath, language);
+        formatter->format(editor, filePath, language, true); // format complete file even if cursor has selection
 
     if (language == "Python" && ((mode != AutoSave && SettingsHelper::isYAPFFormatOnManualSave()) ||
                                  (mode == AutoSave && SettingsHelper::isYAPFFormatOnAutoSave())))
-        formatter->format(editor, filePath, language);
+        formatter->format(editor, filePath, language, true);
 
     if (mode == SaveAs || (isUntitled() && mode == AlwaysSave))
     {

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -200,7 +200,7 @@ class MainWindow : public QMainWindow
     bool isLanguageSet = false;
 
     Extensions::ClangFormatter *formatterClang = nullptr;
-	Extensions::YAPFormatter *formatterYapf = nullptr;
+    Extensions::YAPFormatter *formatterYapf = nullptr;
     Core::Compiler *compiler = nullptr;
     QVector<Core::Runner *> runner;
     Core::Checker *checker = nullptr;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -44,6 +44,7 @@ namespace Extensions
 {
 class CFTool;
 class ClangFormatter;
+class YAPFormatter;
 struct CompanionData;
 } // namespace Extensions
 
@@ -198,7 +199,8 @@ class MainWindow : public QMainWindow
     QString language;
     bool isLanguageSet = false;
 
-    Extensions::ClangFormatter *formatter = nullptr;
+    Extensions::ClangFormatter *formatterClang = nullptr;
+	Extensions::YAPFormatter *formatterYapf = nullptr;
     Core::Compiler *compiler = nullptr;
     QVector<Core::Runner *> runner;
     Core::Checker *checker = nullptr;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -43,8 +43,7 @@ class Runner;
 namespace Extensions
 {
 class CFTool;
-class ClangFormatter;
-class YAPFormatter;
+class CodeFormatter;
 struct CompanionData;
 } // namespace Extensions
 
@@ -199,8 +198,7 @@ class MainWindow : public QMainWindow
     QString language;
     bool isLanguageSet = false;
 
-    Extensions::ClangFormatter *formatterClang = nullptr;
-    Extensions::YAPFormatter *formatterYapf = nullptr;
+    Extensions::CodeFormatter* formatter = nullptr;
     Core::Compiler *compiler = nullptr;
     QVector<Core::Runner *> runner;
     Core::Checker *checker = nullptr;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -198,7 +198,7 @@ class MainWindow : public QMainWindow
     QString language;
     bool isLanguageSet = false;
 
-    Extensions::CodeFormatter* formatter = nullptr;
+    Extensions::CodeFormatter *formatter = nullptr;
     Core::Compiler *compiler = nullptr;
     QVector<Core::Runner *> runner;
     Core::Checker *checker = nullptr;

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -469,6 +469,33 @@ Git commit hash: %3
     </message>
 </context>
 <context>
+    <name>CodeFormatter</name>
+    <message>
+        <source>Cannot format %1 code with this formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Got empty stdout from format process. Did you used -i or inplace formatting argument?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finished in 2 seconds. This is probably because %1 binary is not found by CP Editor. You can set its path in Extensions -&gt; %1 -&gt; Path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The format command is: %1 %2</source>
+        <translation type="unfinished">Команды форматирования: %1 %2</translation>
+    </message>
+    <message>
+        <source>Formatter[stdout]</source>
+        <translation type="unfinished">Форматирование[stdout]</translation>
+    </message>
+    <message>
+        <source>Formatter[stderr]</source>
+        <translation type="unfinished">Форматирование[stderr]</translation>
+    </message>
+</context>
+<context>
     <name>CodeSnippetsPage</name>
     <message>
         <source>Search...</source>
@@ -721,10 +748,6 @@ Press any key to exit</source>
 <context>
     <name>Extensions::ClangFormatter</name>
     <message>
-        <source>Formatter/check</source>
-        <translation>Форматирование/Проверка</translation>
-    </message>
-    <message>
         <source>Formatter</source>
         <translation>Форматирование</translation>
     </message>
@@ -735,22 +758,6 @@ Press any key to exit</source>
     <message>
         <source>Formatting completed</source>
         <translation>Форматирование завершено</translation>
-    </message>
-    <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format at %1.</source>
-        <translation>Процесс форматировния не завершился за 2 секунды. Возможно исполняемый файл clang-format не найден CP Editor&apos;ом. Вы можете установить путь к clang-format в %1.</translation>
-    </message>
-    <message>
-        <source>The format command is: %1 %2</source>
-        <translation>Команды форматирования: %1 %2</translation>
-    </message>
-    <message>
-        <source>Formatter[stdout]</source>
-        <translation>Форматирование[stdout]</translation>
-    </message>
-    <message>
-        <source>Formatter[stderr]</source>
-        <translation>Форматирование[stderr]</translation>
     </message>
 </context>
 <context>
@@ -830,22 +837,6 @@ Press any key to exit</source>
     <message>
         <source>Formatting completed</source>
         <translation type="unfinished">Форматирование завершено</translation>
-    </message>
-    <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the python binary is not found by CP Editor. You can set the path to python at %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The format command is: %1 %2</source>
-        <translation type="unfinished">Команды форматирования: %1 %2</translation>
-    </message>
-    <message>
-        <source>Formatter[stdout]</source>
-        <translation type="unfinished">Форматирование[stdout]</translation>
-    </message>
-    <message>
-        <source>Formatter[stderr]</source>
-        <translation type="unfinished">Форматирование[stderr]</translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -479,10 +479,6 @@ Git commit hash: %3
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The format process didn&apos;t finished in 2 seconds. This is probably because %1 binary is not found by CP Editor. You can set its path in Extensions -&gt; %1 -&gt; Path.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The format command is: %1 %2</source>
         <translation type="unfinished">Команды форматирования: %1 %2</translation>
     </message>
@@ -493,6 +489,10 @@ Git commit hash: %3
     <message>
         <source>Formatter[stderr]</source>
         <translation type="unfinished">Форматирование[stderr]</translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finished in 2 seconds. This is probably because %1 binary is not found by CP Editor. You can set its path in %2.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -818,6 +818,37 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::YAPFormatter</name>
+    <message>
+        <source>Formatter</source>
+        <translation type="unfinished">Форматирование</translation>
+    </message>
+    <message>
+        <source>Failed to create temporary directory</source>
+        <translation type="unfinished">Ошибка при создании временной директории</translation>
+    </message>
+    <message>
+        <source>Formatting completed</source>
+        <translation type="unfinished">Форматирование завершено</translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the python binary is not found by CP Editor. You can set the path to python at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The format command is: %1 %2</source>
+        <translation type="unfinished">Команды форматирования: %1 %2</translation>
+    </message>
+    <message>
+        <source>Formatter[stdout]</source>
+        <translation type="unfinished">Форматирование[stdout]</translation>
+    </message>
+    <message>
+        <source>Formatter[stderr]</source>
+        <translation type="unfinished">Форматирование[stderr]</translation>
+    </message>
+</context>
+<context>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
@@ -1495,6 +1526,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     <message>
         <source>Font</source>
         <translation>Шрифт</translation>
+    </message>
+    <message>
+        <source>YAPF Format</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2518,6 +2553,31 @@ The program will be killed if it doesn&apos;t terminate in the time limit.</sour
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Максимальное отображаемое число символов в тесткейсе.
 Если тесткейс будет слишком большой, он будет пропущен и доступен только для чтения.</translation>
+    </message>
+    <message>
+        <source>The path of python interpreter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The argument for the interpreter to invoke yapf module.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The YAPF Format style options, which are often saved in a .style.yapf or setup.conf configuration file. 
+You can check all possible configuration by running `yapf --style-help`</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use YAPF Formatter to format the code when saving it manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use YAPF Formatter to format the code when auto-saving it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -479,10 +479,6 @@ git 提交编号: %3
         <translation>格式化程序未产生任何输出。你是否使用了 -i 或其他的就地格式化参数？</translation>
     </message>
     <message>
-        <source>The format process didn&apos;t finished in 2 seconds. This is probably because %1 binary is not found by CP Editor. You can set its path in Extensions -&gt; %1 -&gt; Path.</source>
-        <translation>格式化过程未能在 2 秒内完成，这可能是因为 %1 程序未被 CP Editor 找到。你可以在扩展 -&gt; %1 -&gt; 路径中设置其路径。</translation>
-    </message>
-    <message>
         <source>The format command is: %1 %2</source>
         <translation>格式化指令为: %1 %2</translation>
     </message>
@@ -493,6 +489,10 @@ git 提交编号: %3
     <message>
         <source>Formatter[stderr]</source>
         <translation>格式化工具[stderr]</translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finished in 2 seconds. This is probably because %1 binary is not found by CP Editor. You can set its path in %2.</source>
+        <translation>格式化进程没有在 2 秒内结束。这可能是由于 CP Editor 没有找到 %1 的可执行文件。你可以在 %2 设置其路径。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -469,6 +469,33 @@ git 提交编号: %3
     </message>
 </context>
 <context>
+    <name>CodeFormatter</name>
+    <message>
+        <source>Cannot format %1 code with this formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Got empty stdout from format process. Did you used -i or inplace formatting argument?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finished in 2 seconds. This is probably because %1 binary is not found by CP Editor. You can set its path in Extensions -&gt; %1 -&gt; Path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The format command is: %1 %2</source>
+        <translation type="unfinished">格式化指令为: %1 %2</translation>
+    </message>
+    <message>
+        <source>Formatter[stdout]</source>
+        <translation type="unfinished">格式化工具[stdout]</translation>
+    </message>
+    <message>
+        <source>Formatter[stderr]</source>
+        <translation type="unfinished">格式化工具[stderr]</translation>
+    </message>
+</context>
+<context>
     <name>CodeSnippetsPage</name>
     <message>
         <source>Search...</source>
@@ -721,10 +748,6 @@ Press any key to exit</source>
 <context>
     <name>Extensions::ClangFormatter</name>
     <message>
-        <source>Formatter/check</source>
-        <translation>格式化工具/检查</translation>
-    </message>
-    <message>
         <source>Formatter</source>
         <translation>格式化工具</translation>
     </message>
@@ -735,22 +758,6 @@ Press any key to exit</source>
     <message>
         <source>Formatting completed</source>
         <translation>格式化完毕</translation>
-    </message>
-    <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format at %1.</source>
-        <translation>格式化进程未能在 2 秒内结束。这可能是因为 CP Editor 未能找到 clang-format 的可执行文件。你可以在 %1 设置 clang-format 可执行文件的路径。</translation>
-    </message>
-    <message>
-        <source>The format command is: %1 %2</source>
-        <translation>格式化指令为: %1 %2</translation>
-    </message>
-    <message>
-        <source>Formatter[stdout]</source>
-        <translation>格式化工具[stdout]</translation>
-    </message>
-    <message>
-        <source>Formatter[stderr]</source>
-        <translation>格式化工具[stderr]</translation>
     </message>
 </context>
 <context>
@@ -830,22 +837,6 @@ Press any key to exit</source>
     <message>
         <source>Formatting completed</source>
         <translation type="unfinished">格式化完毕</translation>
-    </message>
-    <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the python binary is not found by CP Editor. You can set the path to python at %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The format command is: %1 %2</source>
-        <translation type="unfinished">格式化指令为: %1 %2</translation>
-    </message>
-    <message>
-        <source>Formatter[stdout]</source>
-        <translation type="unfinished">格式化工具[stdout]</translation>
-    </message>
-    <message>
-        <source>Formatter[stderr]</source>
-        <translation type="unfinished">格式化工具[stderr]</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -818,6 +818,37 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::YAPFormatter</name>
+    <message>
+        <source>Formatter</source>
+        <translation type="unfinished">格式化工具</translation>
+    </message>
+    <message>
+        <source>Failed to create temporary directory</source>
+        <translation type="unfinished">未能成功创建临时目录</translation>
+    </message>
+    <message>
+        <source>Formatting completed</source>
+        <translation type="unfinished">格式化完毕</translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the python binary is not found by CP Editor. You can set the path to python at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The format command is: %1 %2</source>
+        <translation type="unfinished">格式化指令为: %1 %2</translation>
+    </message>
+    <message>
+        <source>Formatter[stdout]</source>
+        <translation type="unfinished">格式化工具[stdout]</translation>
+    </message>
+    <message>
+        <source>Formatter[stderr]</source>
+        <translation type="unfinished">格式化工具[stderr]</translation>
+    </message>
+</context>
+<context>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
@@ -1495,6 +1526,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     <message>
         <source>Font</source>
         <translation>字体</translation>
+    </message>
+    <message>
+        <source>YAPF Format</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2510,6 +2545,31 @@ The program will be killed if it doesn&apos;t terminate in the time limit.</sour
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>会显示出来的测试用例的最大字符数。如果测试用例过长，超长部分会被省略，且测试用例会变得只读。</translation>
+    </message>
+    <message>
+        <source>The path of python interpreter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The argument for the interpreter to invoke yapf module.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The YAPF Format style options, which are often saved in a .style.yapf or setup.conf configuration file. 
+You can check all possible configuration by running `yapf --style-help`</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use YAPF Formatter to format the code when saving it manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use YAPF Formatter to format the code when auto-saving it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -472,27 +472,27 @@ git 提交编号: %3
     <name>CodeFormatter</name>
     <message>
         <source>Cannot format %1 code with this formatter</source>
-        <translation type="unfinished"></translation>
+        <translation>无法用格式化程序格式化 %1 代码</translation>
     </message>
     <message>
         <source>Got empty stdout from format process. Did you used -i or inplace formatting argument?</source>
-        <translation type="unfinished"></translation>
+        <translation>格式化程序未产生任何输出。你是否使用了 -i 或其他的就地格式化参数？</translation>
     </message>
     <message>
         <source>The format process didn&apos;t finished in 2 seconds. This is probably because %1 binary is not found by CP Editor. You can set its path in Extensions -&gt; %1 -&gt; Path.</source>
-        <translation type="unfinished"></translation>
+        <translation>格式化过程未能在 2 秒内完成，这可能是因为 %1 程序未被 CP Editor 找到。你可以在扩展 -&gt; %1 -&gt; 路径中设置其路径。</translation>
     </message>
     <message>
         <source>The format command is: %1 %2</source>
-        <translation type="unfinished">格式化指令为: %1 %2</translation>
+        <translation>格式化指令为: %1 %2</translation>
     </message>
     <message>
         <source>Formatter[stdout]</source>
-        <translation type="unfinished">格式化工具[stdout]</translation>
+        <translation>格式化工具[stdout]</translation>
     </message>
     <message>
         <source>Formatter[stderr]</source>
-        <translation type="unfinished">格式化工具[stderr]</translation>
+        <translation>格式化工具[stderr]</translation>
     </message>
 </context>
 <context>
@@ -828,15 +828,15 @@ Press any key to exit</source>
     <name>Extensions::YAPFormatter</name>
     <message>
         <source>Formatter</source>
-        <translation type="unfinished">格式化工具</translation>
+        <translation>格式化工具</translation>
     </message>
     <message>
         <source>Failed to create temporary directory</source>
-        <translation type="unfinished">未能成功创建临时目录</translation>
+        <translation>未能成功创建临时目录</translation>
     </message>
     <message>
         <source>Formatting completed</source>
-        <translation type="unfinished">格式化完毕</translation>
+        <translation>格式化完毕</translation>
     </message>
 </context>
 <context>
@@ -1520,7 +1520,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
     <message>
         <source>YAPF Format</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2539,28 +2539,29 @@ A test case will be elided and read-only if it&apos;s too long.</source>
     </message>
     <message>
         <source>The path of python interpreter.</source>
-        <translation type="unfinished"></translation>
+        <translation>Python 解释器的路径。</translation>
     </message>
     <message>
         <source>Arguments</source>
-        <translation type="unfinished"></translation>
+        <translation>参数</translation>
     </message>
     <message>
         <source>The argument for the interpreter to invoke yapf module.</source>
-        <translation type="unfinished"></translation>
+        <translation>解释器调用 yapf 模块时使用的参数。</translation>
     </message>
     <message>
         <source>The YAPF Format style options, which are often saved in a .style.yapf or setup.conf configuration file. 
 You can check all possible configuration by running `yapf --style-help`</source>
-        <translation type="unfinished"></translation>
+        <translation>YAPF 格式化选项，通常保存在 .style.yapf 或 setup.conf 配置文件中。
+你可以通过 yapf --style-help 命令来获取所有配置选项。</translation>
     </message>
     <message>
         <source>Use YAPF Formatter to format the code when saving it manually.</source>
-        <translation type="unfinished"></translation>
+        <translation>在手动保存时调用 YAPF 格式化工具来格式化代码。</translation>
     </message>
     <message>
         <source>Use YAPF Formatter to format the code when auto-saving it.</source>
-        <translation type="unfinished"></translation>
+        <translation>在自动保存时调用 YAPF 格式化工具来格式化代码。</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->
The clang-formatter is able to format code in C/C++/Java but there was
no formatter support for python language. In this commit we add a new
Extensions YAPF Format that can format any valid python code. It also
accepts many configuration that can be set up by user in style.

In addition to this new formatter, the complete formatter code has been refactored. 
Notable ideas included in refactoring are as follow:

- Add a generic code-formatter abstract class that can be used to add new formatters for other languages.
- Reuse code across formatters.
- Purge `XXXXFormatter::check()`, We report error at execution in formatters if any.

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To correctly format python codes

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->
Arch linux

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
Documentation PR at https://github.com/cpeditor/cpeditor.github.io/pull/101
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
