### PR TITLE
refactor: use local variables in the constructor instead of class members

### DIFF
--- a/src/Settings/CodeSnippetsPage.cpp
+++ b/src/Settings/CodeSnippetsPage.cpp
@@ -33,13 +33,13 @@
 
 CodeSnippetsPage::CodeSnippetsPage(const QString &language, QWidget *parent) : PreferencesPage(parent), lang(language)
 {
-    splitter = new QSplitter();
+    auto splitter = new QSplitter();
     addWidget(splitter);
 
-    leftWidget = new QWidget();
+    auto leftWidget = new QWidget();
     splitter->addWidget(leftWidget);
 
-    leftLayout = new QVBoxLayout(leftWidget);
+    auto leftLayout = new QVBoxLayout(leftWidget);
 
     searchEdit = new QLineEdit();
     searchEdit->setPlaceholderText(tr("Search..."));
@@ -52,10 +52,10 @@ CodeSnippetsPage::CodeSnippetsPage(const QString &language, QWidget *parent) : P
     connect(snippetsList, SIGNAL(itemClicked(QListWidgetItem *)), this, SLOT(switchToSnippet(QListWidgetItem *)));
     leftLayout->addWidget(snippetsList);
 
-    buttonsLayout = new QHBoxLayout();
+    auto buttonsLayout = new QHBoxLayout();
     leftLayout->addLayout(buttonsLayout);
 
-    addButton = new QPushButton(tr("Add"));
+    auto addButton = new QPushButton(tr("Add"));
     addButton->setShortcut({"Ctrl+N"});
     connect(addButton, SIGNAL(clicked()), this, SLOT(addSnippet()));
     buttonsLayout->addWidget(addButton);
@@ -82,7 +82,7 @@ CodeSnippetsPage::CodeSnippetsPage(const QString &language, QWidget *parent) : P
     moreMenu->addAction(loadSnippetsFromFilesAction);
     moreMenu->addAction(extractSnippetsToFilesAction);
 
-    moreButton = new QPushButton(tr("More"));
+    auto moreButton = new QPushButton(tr("More"));
     moreButton->setMenu(moreMenu);
     buttonsLayout->addWidget(moreButton);
 
@@ -92,7 +92,7 @@ CodeSnippetsPage::CodeSnippetsPage(const QString &language, QWidget *parent) : P
     snippetWidget = new QWidget();
     rightWidget->addWidget(snippetWidget);
 
-    snippetLayout = new QVBoxLayout(snippetWidget);
+    auto snippetLayout = new QVBoxLayout(snippetWidget);
 
     snippetNameLabel = new QLabel();
     snippetLayout->addWidget(snippetNameLabel);
@@ -105,10 +105,10 @@ CodeSnippetsPage::CodeSnippetsPage(const QString &language, QWidget *parent) : P
     rightWidget->addWidget(noSnippetWidget);
     rightWidget->setCurrentWidget(noSnippetWidget);
 
-    VStretchLayout = new QVBoxLayout(noSnippetWidget);
+    auto VStretchLayout = new QVBoxLayout(noSnippetWidget);
     VStretchLayout->addStretch();
 
-    HStretchLayout = new QHBoxLayout();
+    auto HStretchLayout = new QHBoxLayout();
     VStretchLayout->addLayout(HStretchLayout);
     HStretchLayout->addStretch();
 

--- a/src/Settings/CodeSnippetsPage.hpp
+++ b/src/Settings/CodeSnippetsPage.hpp
@@ -150,27 +150,18 @@ class CodeSnippetsPage : public PreferencesPage
      *         - (stretch)
      */
 
-    QSplitter *splitter = nullptr;
-    QWidget *leftWidget = nullptr;
-    QVBoxLayout *leftLayout = nullptr;
     QLineEdit *searchEdit = nullptr;
     QListWidget *snippetsList = nullptr;
-    QHBoxLayout *buttonsLayout = nullptr;
-    QPushButton *addButton = nullptr;
     QPushButton *deleteButton = nullptr;
-    QPushButton *moreButton = nullptr;
     QMenu *moreMenu = nullptr;
     QAction *renameAction = nullptr;
     QAction *loadSnippetsFromFilesAction = nullptr;
     QAction *extractSnippetsToFilesAction = nullptr;
     QStackedWidget *rightWidget = nullptr;
     QWidget *snippetWidget = nullptr;
-    QVBoxLayout *snippetLayout = nullptr;
     QLabel *snippetNameLabel = nullptr;
     QCodeEditor *editor = nullptr;
     QWidget *noSnippetWidget = nullptr;
-    QVBoxLayout *VStretchLayout = nullptr;
-    QHBoxLayout *HStretchLayout = nullptr;
     QLabel *noSnippetLabel = nullptr;
 
     QString lang;

--- a/src/Settings/ParenthesesPage.cpp
+++ b/src/Settings/ParenthesesPage.cpp
@@ -34,7 +34,7 @@ ParenthesisWidget::ParenthesisWidget(const QString &language, QChar leftParenthe
                                      QWidget *parent)
     : QWidget(parent), lang(language), left(leftParenthesis), right(rightParenthesis)
 {
-    mainLayout = new QVBoxLayout(this);
+    auto mainLayout = new QVBoxLayout(this);
 
     nameLabel = new QLabel(tr("Parenthesis: %1").arg(parenthesis()));
     auto labelFont = font();
@@ -44,15 +44,15 @@ ParenthesisWidget::ParenthesisWidget(const QString &language, QChar leftParenthe
 
     mainLayout->addSpacing(20);
 
-    stretchLayout = new QHBoxLayout();
+    auto stretchLayout = new QHBoxLayout();
     mainLayout->addLayout(stretchLayout);
 
     stretchLayout->addStretch();
 
-    checkBoxesLayout = new QVBoxLayout();
+    auto checkBoxesLayout = new QVBoxLayout();
     stretchLayout->addLayout(checkBoxesLayout);
 
-    auto addOption = [this](QCheckBox *&checkBox, const QString &name, Qt::CheckState state) {
+    auto addOption = [this, &checkBoxesLayout](QCheckBox *&checkBox, const QString &name, Qt::CheckState state) {
         checkBox = new QCheckBox(name);
         checkBox->setTristate(true);
         checkBox->setCheckState(state);
@@ -95,14 +95,14 @@ ParenthesesPage::ParenthesesPage(const QString &language, QWidget *parent) : Pre
     leftWidget = new QWidget();
     splitter->addWidget(leftWidget);
 
-    leftLayout = new QVBoxLayout(leftWidget);
+    auto leftLayout = new QVBoxLayout(leftWidget);
 
     listWidget = new QListWidget();
     connect(listWidget, SIGNAL(itemActivated(QListWidgetItem *)), this, SLOT(switchToParenthesis(QListWidgetItem *)));
     connect(listWidget, SIGNAL(itemClicked(QListWidgetItem *)), this, SLOT(switchToParenthesis(QListWidgetItem *)));
     leftLayout->addWidget(listWidget);
 
-    buttonsLayout = new QHBoxLayout();
+    auto buttonsLayout = new QHBoxLayout();
     leftLayout->addLayout(buttonsLayout);
 
     addButton = new QPushButton(tr("Add"));
@@ -119,20 +119,20 @@ ParenthesesPage::ParenthesesPage(const QString &language, QWidget *parent) : Pre
     stackedWidget = new QStackedWidget();
     splitter->addWidget(stackedWidget);
 
-    noParenthesisWidget = new QWidget();
+    auto noParenthesisWidget = new QWidget();
     stackedWidget->addWidget(noParenthesisWidget);
     stackedWidget->setCurrentWidget(noParenthesisWidget);
 
-    noParenthesisLayout = new QVBoxLayout(noParenthesisWidget);
+    auto noParenthesisLayout = new QVBoxLayout(noParenthesisWidget);
 
     noParenthesisLayout->addStretch();
 
-    noParenthesisStretchLayout = new QHBoxLayout();
+    auto noParenthesisStretchLayout = new QHBoxLayout();
     noParenthesisLayout->addLayout(noParenthesisStretchLayout);
 
     noParenthesisStretchLayout->addStretch();
 
-    noParenthesisLabel = new QLabel(tr("No Parenthesis Selected"));
+    auto noParenthesisLabel = new QLabel(tr("No Parenthesis Selected"));
     noParenthesisStretchLayout->addWidget(noParenthesisLabel);
 
     noParenthesisStretchLayout->addStretch();

--- a/src/Settings/ParenthesesPage.cpp
+++ b/src/Settings/ParenthesesPage.cpp
@@ -52,7 +52,7 @@ ParenthesisWidget::ParenthesisWidget(const QString &language, QChar leftParenthe
     auto checkBoxesLayout = new QVBoxLayout();
     stretchLayout->addLayout(checkBoxesLayout);
 
-    auto addOption = [this, &checkBoxesLayout](QCheckBox *&checkBox, const QString &name, Qt::CheckState state) {
+    auto addOption = [this, checkBoxesLayout](QCheckBox *&checkBox, const QString &name, Qt::CheckState state) {
         checkBox = new QCheckBox(name);
         checkBox->setTristate(true);
         checkBox->setCheckState(state);

--- a/src/Settings/ParenthesesPage.hpp
+++ b/src/Settings/ParenthesesPage.hpp
@@ -67,10 +67,7 @@ class ParenthesisWidget : public QWidget
      *   - (stretch)
      */
 
-    QVBoxLayout *mainLayout = nullptr;
     QLabel *nameLabel = nullptr;
-    QHBoxLayout *stretchLayout = nullptr;
-    QVBoxLayout *checkBoxesLayout = nullptr;
     QCheckBox *autoCompleteCheckBox = nullptr;
     QCheckBox *autoRemoveCheckBox = nullptr;
     QCheckBox *tabJumpOutCheckBox = nullptr;
@@ -181,16 +178,10 @@ class ParenthesesPage : public PreferencesPage
 
     QSplitter *splitter = nullptr;
     QWidget *leftWidget = nullptr;
-    QVBoxLayout *leftLayout = nullptr;
     QListWidget *listWidget = nullptr;
-    QHBoxLayout *buttonsLayout = nullptr;
     QPushButton *addButton = nullptr;
     QPushButton *delButton = nullptr;
     QStackedWidget *stackedWidget = nullptr;
-    QWidget *noParenthesisWidget = nullptr;
-    QVBoxLayout *noParenthesisLayout = nullptr;
-    QHBoxLayout *noParenthesisStretchLayout = nullptr;
-    QLabel *noParenthesisLabel;
 
     QString lang;
 };

--- a/src/Settings/PreferencesGridPage.cpp
+++ b/src/Settings/PreferencesGridPage.cpp
@@ -22,8 +22,8 @@
 
 PreferencesGridPage::PreferencesGridPage(bool alignTop, QWidget *parent) : PreferencesPage(parent)
 {
-    VLayout = new QVBoxLayout();
-    HLayout = new QHBoxLayout();
+    auto VLayout = new QVBoxLayout();
+    auto HLayout = new QHBoxLayout();
     gridLayout = new QGridLayout();
 
     addLayout(VLayout);

--- a/src/Settings/PreferencesGridPage.hpp
+++ b/src/Settings/PreferencesGridPage.hpp
@@ -46,8 +46,6 @@ class PreferencesGridPage : public PreferencesPage
     void addRow(ValueWidget *widget, const QString &tip, const QString &help, const QString &labelText = QString());
 
   private:
-    QVBoxLayout *VLayout = nullptr;
-    QHBoxLayout *HLayout = nullptr;
     QGridLayout *gridLayout = nullptr;
 };
 

--- a/src/Settings/PreferencesHomePage.cpp
+++ b/src/Settings/PreferencesHomePage.cpp
@@ -33,7 +33,7 @@ PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
     // add stretch so that the contents are vertically centered
     layout->addStretch();
 
-    iconLabel = new QLabel();
+    auto iconLabel = new QLabel();
     iconLabel->setPixmap(QPixmap(":/icon.png").scaledToHeight(128, Qt::SmoothTransformation));
     layout->addWidget(iconLabel);
     layout->setAlignment(iconLabel, Qt::AlignCenter);
@@ -42,7 +42,7 @@ PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
     layout->addSpacing(30);
 
     // add welcome label
-    welcomeLabel = new QLabel(tr("Welcome to CP Editor! Let's get started."));
+    auto welcomeLabel = new QLabel(tr("Welcome to CP Editor! Let's get started."));
     layout->addWidget(welcomeLabel);
     layout->setAlignment(welcomeLabel, Qt::AlignCenter);
 
@@ -61,7 +61,7 @@ PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
     layout->addSpacing(20);
 
     // add manual label
-    manualLabel = new QLabel(
+    auto manualLabel = new QLabel(
         tr("You can read the <a href=\"%1\">documentation</a> or go "
            "through the settings for more information.")
             .arg(QUrl(tr("https://cpeditor.org/%1/docs").arg(MINOR_VERSION)).url(QUrl::NormalizePathSegments)));

--- a/src/Settings/PreferencesHomePage.hpp
+++ b/src/Settings/PreferencesHomePage.hpp
@@ -55,9 +55,6 @@ class PreferencesHomePage : public QWidget
     void addButton(const QString &pagePath, const QString &text);
 
     QVBoxLayout *layout = nullptr;  // the main layout
-    QLabel *iconLabel = nullptr;    // the application icon
-    QLabel *welcomeLabel = nullptr; // the welcome QLabel
-    QLabel *manualLabel = nullptr;  // the QLabel that lead people to the Manual
 };
 
 #endif // PREFERENCESHOMEPAGE_HPP

--- a/src/Settings/PreferencesHomePage.hpp
+++ b/src/Settings/PreferencesHomePage.hpp
@@ -54,7 +54,7 @@ class PreferencesHomePage : public QWidget
      */
     void addButton(const QString &pagePath, const QString &text);
 
-    QVBoxLayout *layout = nullptr;  // the main layout
+    QVBoxLayout *layout = nullptr; // the main layout
 };
 
 #endif // PREFERENCESHOMEPAGE_HPP

--- a/src/Settings/PreferencesPage.cpp
+++ b/src/Settings/PreferencesPage.cpp
@@ -29,12 +29,12 @@
 PreferencesPage::PreferencesPage(QWidget *parent) : QWidget(parent)
 {
     // construct widgets
-    mainLayout = new QVBoxLayout(this);
+    auto mainLayout = new QVBoxLayout(this);
     titleLabel = new QLabel();
     scrollArea = new QScrollArea();
     scrollAreaWidget = new QWidget();
     settingsLayout = new QVBoxLayout(scrollAreaWidget);
-    buttonsLayout = new QHBoxLayout();
+    auto buttonsLayout = new QHBoxLayout();
     defaultButton =
         new QPushButton(QApplication::style()->standardIcon(QStyle::SP_FileDialogDetailedView), tr("Default"));
     defaultButton->setShortcut({"Ctrl+D"});

--- a/src/Settings/PreferencesPage.hpp
+++ b/src/Settings/PreferencesPage.hpp
@@ -180,12 +180,10 @@ class PreferencesPage : public QWidget
      *    - applyButton
      */
 
-    QVBoxLayout *mainLayout = nullptr;     // The main layout of the page
     QLabel *titleLabel = nullptr;          // The title of the page
     QScrollArea *scrollArea = nullptr;     // The scroll area to place the settings
     QWidget *scrollAreaWidget = nullptr;   // The widget in the scroll area with settingsLayout as its layout
     QVBoxLayout *settingsLayout = nullptr; // The layout for the settings
-    QHBoxLayout *buttonsLayout = nullptr;  // The layout for the Default, Reset, and Apply buttons
     QPushButton *defaultButton = nullptr;  // The button to set the UI to the default values
     QPushButton *resetButton = nullptr;    // The button to set the UI to the saved settings
     QPushButton *applyButton = nullptr;    // The button to save the UI to the settings

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -108,16 +108,16 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
     setWindowTitle(tr("Preferences"));
 
     // setup UI
-    splitter = new QSplitter();
+    auto splitter = new QSplitter();
     splitter->setChildrenCollapsible(false);
     setCentralWidget(splitter);
 
     leftWidget = new QWidget();
     splitter->addWidget(leftWidget);
 
-    leftLayout = new QVBoxLayout(leftWidget);
+    auto leftLayout = new QVBoxLayout(leftWidget);
 
-    searchLayout = new QHBoxLayout();
+    auto searchLayout = new QHBoxLayout();
     leftLayout->addLayout(searchLayout);
 
     searchEdit = new QLineEdit();

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -165,10 +165,7 @@ class PreferencesWindow : public QMainWindow
      *     - xxx
      */
 
-    QSplitter *splitter = nullptr;
     QWidget *leftWidget = nullptr;
-    QVBoxLayout *leftLayout = nullptr;
-    QHBoxLayout *searchLayout = nullptr;
     QLineEdit *searchEdit = nullptr;
     QPushButton *homeButton = nullptr;
     QTreeWidget *menuTree = nullptr;

--- a/src/Widgets/DiffViewer.cpp
+++ b/src/Widgets/DiffViewer.cpp
@@ -30,14 +30,14 @@ namespace Widgets
 {
 DiffViewer::DiffViewer(QWidget *parent) : QMainWindow(parent)
 {
-    widget = new QWidget(this);
-    layout = new QHBoxLayout();
+    auto widget = new QWidget(this);
+    auto layout = new QHBoxLayout();
     widget->setLayout(layout);
     setCentralWidget(widget);
     setWindowTitle(tr("Diff Viewer"));
     resize(720, 480);
 
-    leftLayout = new QVBoxLayout();
+    auto leftLayout = new QVBoxLayout();
     outputLabel = new QLabel(tr("Output"), widget);
     leftLayout->addWidget(outputLabel);
     outputEdit = new QTextEdit(widget);
@@ -46,7 +46,7 @@ DiffViewer::DiffViewer(QWidget *parent) : QMainWindow(parent)
     leftLayout->addWidget(outputEdit);
     layout->addLayout(leftLayout);
 
-    rightLayout = new QVBoxLayout();
+    auto rightLayout = new QVBoxLayout();
     expectedLabel = new QLabel(tr("Expected"), widget);
     rightLayout->addWidget(expectedLabel);
     expectedEdit = new QTextEdit(widget);

--- a/src/Widgets/DiffViewer.hpp
+++ b/src/Widgets/DiffViewer.hpp
@@ -39,9 +39,6 @@ class DiffViewer : public QMainWindow
     void toLongForHtml();
 
   private:
-    QHBoxLayout *layout = nullptr;
-    QWidget *widget = nullptr;
-    QVBoxLayout *leftLayout = nullptr, *rightLayout = nullptr;
     QLabel *outputLabel = nullptr, *expectedLabel = nullptr;
     QTextEdit *outputEdit = nullptr, *expectedEdit = nullptr;
 };

--- a/src/Widgets/UpdatePresenter.cpp
+++ b/src/Widgets/UpdatePresenter.cpp
@@ -32,11 +32,11 @@ UpdatePresenter::UpdatePresenter()
     textEdit->setReadOnly(true);
 
     hint = new QLabel(this);
-    mainLayout = new QVBoxLayout(this);
-    subLayout = new QHBoxLayout();
+    auto mainLayout = new QVBoxLayout(this);
+    auto subLayout = new QHBoxLayout();
 
-    downloadButton = new QPushButton(tr("Download"), this);
-    cancelButton = new QPushButton(tr("Close"), this);
+    auto downloadButton = new QPushButton(tr("Download"), this);
+    auto cancelButton = new QPushButton(tr("Close"), this);
 
     connect(cancelButton, SIGNAL(clicked()), this, SLOT(close()));
     connect(downloadButton, &QPushButton::clicked, this,

--- a/src/Widgets/UpdatePresenter.hpp
+++ b/src/Widgets/UpdatePresenter.hpp
@@ -38,11 +38,7 @@ class UpdatePresenter : public QDialog
 
   private:
     QLabel *hint = nullptr;
-    QVBoxLayout *mainLayout = nullptr;
-    QHBoxLayout *subLayout = nullptr;
     QTextEdit *textEdit = nullptr;
-    QPushButton *downloadButton = nullptr;
-    QPushButton *cancelButton = nullptr;
 
     QString downloadUrl;
 };

--- a/src/Widgets/UpdateProgressDialog.cpp
+++ b/src/Widgets/UpdateProgressDialog.cpp
@@ -37,7 +37,7 @@ UpdateProgressDialog::UpdateProgressDialog()
     cancelUpdate = new QPushButton(tr("Cancel"), this);
     cancelUpdate->setToolTip(tr("Close this dialog and abort the update check"));
 
-    mainLayout = new QVBoxLayout(this);
+    auto mainLayout = new QVBoxLayout(this);
 
     mainLayout->addWidget(information);
     mainLayout->addWidget(progressBar);

--- a/src/Widgets/UpdateProgressDialog.hpp
+++ b/src/Widgets/UpdateProgressDialog.hpp
@@ -44,7 +44,6 @@ class UpdateProgressDialog : public QDialog
     QPushButton *cancelUpdate = nullptr;
     QLabel *information = nullptr;
     QProgressBar *progressBar = nullptr;
-    QVBoxLayout *mainLayout = nullptr;
 };
 } // namespace Widgets
 


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->
First time working on Qt in a while, and needed a warm-up (big project at work), so a little contribution.
This is only part of #541 , the _easy_ part, just removing useless members. I plan to continue working on #541.

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->
#541

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->
Windows 10 (Qt 5.15 lts w/MinGW toolchain)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
