### PR TITLE
feat(formatter): add YAPF and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ target_wrapper.*
 CMakeLists.txt.user*
 
 build/
+.clangd/
 
 # Visual Studio
 .vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 -   Now you can opt-in non-monospaced fonts when choosing a font in the Preferences. (#217 and #625)
+-   Format python codes by YAPF. (#652)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,10 @@ add_executable(cpeditor
     src/Extensions/CFTool.hpp
     src/Extensions/ClangFormatter.cpp
     src/Extensions/ClangFormatter.hpp
+    src/Extensions/CodeFormatter.cpp
+    src/Extensions/CodeFormatter.hpp
+    src/Extensions/YAPFormatter.cpp
+    src/Extensions/YAPFormatter.hpp
     src/Extensions/CompanionServer.cpp
     src/Extensions/CompanionServer.hpp
     src/Extensions/EditorTheme.cpp

--- a/src/Extensions/CodeFormatter.cpp
+++ b/src/Extensions/CodeFormatter.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#include "Extensions/CodeFormatter.hpp"
+#include "Core/EventLogger.hpp"
+#include "Core/MessageLogger.hpp"
+#include "Settings/SettingsManager.hpp"
+#include "Util/FileUtil.hpp"
+#include <QCodeEditor>
+#include <QProcess>
+#include <QTemporaryDir>
+
+namespace Extensions
+{
+
+CodeFormatter::CodeFormatter(QCodeEditor *editor, const QString &lang, bool selectionOnly, bool logOnNoChange,
+                             MessageLogger *log, QObject *parent)
+    : QObject(parent), editor(editor), lang(lang), selectionOnly(selectionOnly), logOnNoChange(logOnNoChange), log(log)
+{
+    LOG_INFO(INFO_OF(lang) << INFO_OF(selectionOnly) << INFO_OF(logOnNoChange));
+
+    auto cursor = editor->textCursor();
+    cursorPos = cursor.position();
+    cursorLine = cursor.blockNumber();
+    cursorCol = cursor.columnNumber();
+    anchorPos = cursor.anchor();
+    cursor.setPosition(anchorPos);
+    anchorLine = cursor.blockNumber();
+    anchorCol = cursor.columnNumber();
+
+    LOG_INFO(INFO_OF(cursorPos) << INFO_OF(cursorLine) << INFO_OF(anchorPos) << INFO_OF(anchorLine));
+}
+
+void CodeFormatter::format() const
+{
+    QStringList args = arguments() << QProcess::splitCommand(getSetting("Arguments").toString());
+
+    if (formatSelectionOnly())
+        args.append(rangeArgs());
+
+    QTemporaryDir tmpDir;
+    if (!tmpDir.isValid())
+    {
+        log->error(tr("Formatter"), tr("Failed to create temporary directory"));
+        return;
+    }
+
+    auto tmpPath = tmpDir.filePath(Util::fileNameWithSuffix("tmp", lang));
+    args.append(tmpPath);
+
+    if (!Util::saveFile(tmpPath, editor->toPlainText(), tr("Formatter"), true, log))
+        return;
+
+    if (!Util::saveFile(tmpDir.filePath(styleFileName()), getSetting("Style").toString(), tr("Formatter"), true, log))
+        return;
+
+    auto res = runProcess(args);
+    if (res.isEmpty())
+        return;
+
+    auto source = newSource(res);
+
+    if (source == editor->toPlainText())
+    {
+        if (logOnNoChange)
+            log->info(tr("Formatter"), tr("Formatting completed"));
+        return;
+    }
+
+    auto cursor = editor->textCursor();
+    cursor.select(QTextCursor::Document);
+    cursor.insertText(source);
+
+    editor->setTextCursor(newCursor(res, args));
+
+    log->info(tr("Formatter"), tr("Formatting completed"));
+}
+
+QString CodeFormatter::runProcess(const QStringList &args) const
+{
+    QProcess formatProcess;
+    formatProcess.start(getSetting("Program").toString(), args);
+    LOG_INFO(INFO_OF(formatProcess.program()) << INFO_OF(formatProcess.arguments().join(' ')));
+
+    bool finished = formatProcess.waitForFinished(2000); // blocks main Thread
+    if (!finished)
+    {
+        formatProcess.kill();
+        log->warn(tr("Formatter"),
+                  tr("The format process didn't finish in 2 seconds. This is probably because the %1 program is not "
+                     "found by CP Editor. You can set the path to the program at %2.")
+                      .arg(settingKey())
+                      .arg(SettingsManager::getPathText(settingKey() + "/Program")));
+        return QString();
+    }
+
+    auto exitCode = formatProcess.exitCode();
+
+    if (exitCode != 0)
+    {
+        LOG_WARN(INFO_OF(exitCode));
+
+        log->warn(tr("Formatter"), tr("The format command [%1 %2] finished with exit code %3.")
+                                       .arg(formatProcess.program())
+                                       .arg(formatProcess.arguments().join(' '))
+                                       .arg(exitCode));
+        auto stdOut = formatProcess.readAllStandardOutput();
+        if (!stdOut.isEmpty())
+            log->warn(tr("Formatter[stdout]"), stdOut);
+        auto stdError = formatProcess.readAllStandardError();
+        if (!stdError.isEmpty())
+            log->error(tr("Formatter[stderr]"), stdError);
+        return QString();
+    }
+
+    auto out = formatProcess.readAllStandardOutput();
+
+    if (out.isEmpty())
+    {
+        LOG_WARN("Output is empty");
+        log->warn(tr("Formatter"), tr("The output of the format process is empty. Please ensure there is no in-place "
+                                      "modification option in the formatting arguments."));
+    }
+
+    return out;
+}
+
+bool CodeFormatter::formatSelectionOnly() const
+{
+    return selectionOnly && cursorPos != anchorPos;
+}
+
+QVariant CodeFormatter::getSetting(const QString &key) const
+{
+    return SettingsManager::get(settingKey() + "/" + key);
+}
+
+} // namespace Extensions

--- a/src/Extensions/CodeFormatter.hpp
+++ b/src/Extensions/CodeFormatter.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#ifndef CODEFORMATTER_HPP
+#define CODEFORMATTER_HPP
+
+#include <QObject>
+
+class MessageLogger;
+class QCodeEditor;
+class QTextCursor;
+
+namespace Extensions
+{
+class CodeFormatter : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit CodeFormatter(QCodeEditor *editor, const QString &lang, bool selectionOnly, bool logOnNoChange,
+                           MessageLogger *log, QObject *parent = nullptr);
+
+    void format() const;
+
+  protected:
+    /**
+     * @brief the key of the formatter in the settings, e.g. Clang Format
+     * @note there should be these settings: settingKey()/Program, settingKey()/Arguments, settingKey()/Style
+     */
+    virtual QString settingKey() const = 0;
+
+    /**
+     * @brief the arguments of the formatter, except args for formatting a range and args set by the user
+     */
+    virtual QStringList arguments() const = 0;
+
+    /**
+     * @brief the arguments used to format selection only
+     * @note you can use cursorPos, cursorLine, cursorCol, anchorPos, anchorLine, anchorCol in this function
+     */
+    virtual QStringList rangeArgs() const = 0;
+
+    /**
+     * @brief the name of the style file, e.g. .clang-format
+     */
+    virtual QString styleFileName() const = 0;
+
+    /**
+     * @brief the new source code after formatting
+     * @param out the stdout of the format process
+     */
+    virtual QString newSource(const QString &out) const = 0;
+
+    /**
+     * @brief the new text cursor after formatting
+     * @param out the stdout of the format process
+     * @param args the arguments used when formatting
+     */
+    virtual QTextCursor newCursor(const QString &out, const QStringList &args) const = 0;
+
+    /**
+     * @brief run the format process and get the result
+     * @param args the arguments of the format process
+     * @returns the stdout of the format process, or an empty QString if error occurred
+     */
+    QString runProcess(const QStringList &args) const;
+
+    /**
+     * @brief check whether only the selection is formatted
+     */
+    bool formatSelectionOnly() const;
+
+  private:
+    /**
+     * @brief get settingKey()/key
+     */
+    QVariant getSetting(const QString &key) const;
+
+  protected:
+    QCodeEditor *editor;
+    QString lang;
+    bool selectionOnly;
+    bool logOnNoChange;
+    int cursorPos, cursorLine, cursorCol, anchorPos, anchorLine, anchorCol;
+
+  private:
+    MessageLogger *log = nullptr;
+};
+} // namespace Extensions
+
+#endif // CODEFORMATTER_HPP

--- a/src/Extensions/YAPFormatter.cpp
+++ b/src/Extensions/YAPFormatter.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+#include "Extensions/YAPFormatter.hpp"
+#include <QCodeEditor>
+#include <QTextBlock>
+#include <QTextCursor>
+#include <QTextDocument>
+
+namespace Extensions
+{
+
+YAPFormatter::YAPFormatter(QCodeEditor *editor, const QString &lang, bool selectionOnly, bool logOnNoChange,
+                           MessageLogger *log, QObject *parent)
+    : CodeFormatter(editor, lang, selectionOnly, logOnNoChange, log, parent)
+{
+}
+
+QString YAPFormatter::settingKey() const
+{
+    return "YAPF";
+}
+
+QStringList YAPFormatter::arguments() const
+{
+    return {};
+}
+
+QStringList YAPFormatter::rangeArgs() const
+{
+    return {QString("-l %1-%2").arg(qMin(cursorLine, anchorLine) + 1).arg(qMax(cursorLine, anchorLine) + 1)};
+}
+
+QString YAPFormatter::styleFileName() const
+{
+    return ".style.yapf";
+}
+
+QString YAPFormatter::newSource(const QString &out) const
+{
+    return out;
+}
+
+QTextCursor YAPFormatter::newCursor(const QString &out, const QStringList &) const
+{
+    auto cursor = editor->textCursor();
+
+    auto setCol = [this, &cursor](QTextCursor::MoveMode mode, int col) {
+        cursor.movePosition(QTextCursor::NextCharacter, mode,
+                            qMin(col, editor->document()->findBlockByNumber(cursor.blockNumber()).length() - 1));
+    };
+
+    cursor.movePosition(QTextCursor::Start);
+    cursor.movePosition(QTextCursor::NextBlock, QTextCursor::MoveAnchor, anchorLine);
+    setCol(QTextCursor::MoveAnchor, anchorCol);
+
+    if (cursorPos == anchorPos)
+        return cursor;
+
+    if (anchorLine <= cursorLine)
+    {
+        cursor.movePosition(QTextCursor::NextBlock, QTextCursor::KeepAnchor, cursorLine - anchorLine);
+    }
+    else
+    {
+        cursor.movePosition(QTextCursor::PreviousBlock, QTextCursor::KeepAnchor, anchorLine - cursorLine);
+        cursor.movePosition(QTextCursor::StartOfBlock, QTextCursor::KeepAnchor);
+    }
+
+    setCol(QTextCursor::KeepAnchor, cursorCol);
+
+    return cursor;
+}
+
+} // namespace Extensions

--- a/src/Extensions/YAPFormatter.hpp
+++ b/src/Extensions/YAPFormatter.hpp
@@ -15,26 +15,20 @@
  *
  */
 
-/*
- * The Formatter is used to format codes.
- * It runs synchronously, so the event loop is blocked while formatting.
- * The time limit for formatting is 2 seconds.
- */
-
-#ifndef FORMATTER_HPP
-#define FORMATTER_HPP
+#ifndef YAPFORMATTER_HPP
+#define YAPFORMATTER_HPP
 
 #include "Extensions/CodeFormatter.hpp"
 
 namespace Extensions
 {
-class ClangFormatter : public CodeFormatter
+class YAPFormatter : public CodeFormatter
 {
     Q_OBJECT
 
   public:
-    explicit ClangFormatter(QCodeEditor *editor, const QString &lang, bool selectionOnly, bool logOnNoChange,
-                            MessageLogger *log, QObject *parent = nullptr);
+    explicit YAPFormatter(QCodeEditor *editor, const QString &lang, bool selectionOnly, bool logOnNoChange,
+                          MessageLogger *log, QObject *parent = nullptr);
 
   protected:
     virtual QString settingKey() const override;
@@ -47,12 +41,9 @@ class ClangFormatter : public CodeFormatter
 
     virtual QString newSource(const QString &out) const override;
 
-    virtual QTextCursor newCursor(const QString &out, const QStringList &args) const override;
-
-  private:
-    int newCursorPos(const QString &out) const;
+    virtual QTextCursor newCursor(const QString &out, const QStringList &) const override;
 };
 
 } // namespace Extensions
 
-#endif // FORMATTER_HPP
+#endif // YAPFORMATTER_HPP

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -50,7 +50,7 @@ AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, Pre
                                    const QStringList &content)
 {
     window->registerName(key, trkey);
-    if (currentPath.size() == 0)
+    if (atTop())
     {
         currentItem = new QTreeWidgetItem({trkey});
         tree->addTopLevelItem(currentItem);
@@ -75,7 +75,7 @@ AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, Pre
 AddPageHelper &AddPageHelper::dir(const QString &key, const QString &trkey)
 {
     window->registerName(key, trkey);
-    if (currentPath.size() == 0)
+    if (atTop())
     {
         currentItem = new QTreeWidgetItem({trkey});
         tree->addTopLevelItem(currentItem);
@@ -95,6 +95,16 @@ AddPageHelper &AddPageHelper::end()
     currentItem = currentItem->parent();
     currentPath.pop_back();
     return *this;
+}
+
+void AddPageHelper::ensureAtTop() const
+{
+    Q_ASSERT(atTop());
+}
+
+bool AddPageHelper::atTop() const
+{
+    return currentPath.isEmpty();
 }
 
 AddPageHelper::AddPageHelper(PreferencesWindow *w) : window(w), tree(window->menuTree)
@@ -226,8 +236,11 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
             .page(TRKEY("Load External File Changes"), {"Auto Load External Changes If No Unsaved Modification", "Ask For Loading External Changes"})
         .end()
         .dir(TRKEY("Extensions"))
-            .page(TRKEY("Clang Format"), new PreferencesPageTemplate({"Clang Format/Path", "Clang Format/Format On Manual Save",
-                                         "Clang Format/Format On Auto Save", "Clang Format/Style"}, false))
+            .dir(TRKEY("Code Formatting"))
+                .page(TRKEY("General"), {"Format On Manual Save", "Format On Auto Save"})
+                .page(TRKEY("Clang Format"), new PreferencesPageTemplate({"Clang Format/Program", "Clang Format/Arguments", "Clang Format/Style"}, false))
+                .page(TRKEY("YAPF"), new PreferencesPageTemplate({"YAPF/Program", "YAPF/Arguments", "YAPF/Style"}, false))
+            .end()
             .dir(TRKEY("Language Server"))
                 .page("C++ Server", tr("%1 Server").arg(tr("C++")), {"LSP/Use Linting C++", "LSP/Delay C++", "LSP/Path C++", "LSP/Args C++"})
                 .page("Java Server", tr("%1 Server").arg(tr("Java")), {"LSP/Use Linting Java", "LSP/Delay Java", "LSP/Path Java", "LSP/Args Java"})
@@ -252,7 +265,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
             .page(TRKEY("Limits"), {"Default Time Limit", "Output Length Limit", "Output Display Length Limit", "Message Length Limit",
                                     "HTML Diff Viewer Length Limit", "Open File Length Limit", "Display Test Case Length Limit"})
             .page(TRKEY("Network Proxy"), {"Proxy/Enabled", "Proxy/Type", "Proxy/Host Name", "Proxy/Port", "Proxy/User", "Proxy/Password"})
-        .end();
+        .end()
+    .ensureAtTop();
 
 #undef TRKEY
 

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -55,7 +55,11 @@ class AddPageHelper
 
     AddPageHelper &end();
 
+    void ensureAtTop() const;
+
   private:
+    bool atTop() const;
+
     PreferencesWindow *window;
     QTreeWidget *tree;
     QTreeWidgetItem *currentItem;

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -50,43 +50,72 @@
         "tip": "The default language used when opening new tabs"
     },
     {
-        "name": "Clang Format/Path",
-        "desc": "Path",
+        "name": "Clang Format/Program",
         "type": "QString",
         "default": "clang-format",
         "ui": "PathItem",
         "param": "PathItem::Executable",
         "tip": "The path to the Clang Format executable file",
         "old": [
-            "clang_format_binary"
+            "clang_format_binary",
+            "clang_format/path"
         ]
     },
     {
+        "name": "Clang Format/Arguments",
+        "type": "QString",
+        "tip": "The arguments passed to clang-format. It should NOT contain \"-i\"."
+    },
+    {
         "name": "Clang Format/Style",
-        "desc": "Style",
         "type": "QString",
         "default": "BasedOnStyle: Google",
         "ui": "QPlainTextEdit",
-        "tip": "The Clang Format style options, which are often saved in a .clang-format configuration file.\nYou can learn about it at <https://clang.llvm.org/docs/ClangFormatStyleOptions.html>.",
+        "tip": "The Clang Format style options, which are usually saved in a .clang-format configuration file.\nYou can learn about it at <https://clang.llvm.org/docs/ClangFormatStyleOptions.html>.",
         "old": [
             "clang_format_style"
         ]
     },
     {
-        "name": "Clang Format/Format On Manual Save",
+        "name": "YAPF/Program",
+        "type": "QString",
+        "default": "python",
+        "ui": "PathItem",
+        "param": "PathItem::Executable",
+        "tip": "The program of YAPF. It could be `yapf` (which doesn't need arguments) or `python` (which needs `-m yapf` as the arguments)."
+    },
+    {
+        "name": "YAPF/Arguments",
+        "type": "QString",
+        "default": "-m yapf",
+        "tip": "The arguments passed to the YAPF program. It should NOT contain \"-i\"."
+    },
+    {
+        "name": "YAPF/Style",
+        "type": "QString",
+        "default": "[style]\nbased_on_style = pep8",
+        "ui": "QPlainTextEdit",
+        "tip": "The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.\nYou can learn about it by running `yapf --style-help`."
+    },
+    {
+        "name": "Format On Manual Save",
         "desc": "Format code on manual save",
         "type": "bool",
-        "tip": "Use Clang Format to format the code when saving it manually.",
+        "tip": "Format the code when saving it manually.",
         "old": [
             "format_on_save",
-            "auto_format"
+            "auto_format",
+            "clang_format/format_on_manual_save"
         ]
     },
     {
-        "name": "Clang Format/Format On Auto Save",
+        "name": "Format On Auto Save",
         "desc": "Format code on auto-save",
         "type": "bool",
-        "tip": "Use Clang Format to format the code when auto-saving it."
+        "tip": "Format the code when auto-saving it.",
+        "old": [
+            "clang_format/format_on_auto_save"
+        ]
     },
     {
         "name": "C++/Template Path",

--- a/src/Util/FileUtil.cpp
+++ b/src/Util/FileUtil.cpp
@@ -54,6 +54,20 @@ QString fileNameFilter(bool cpp, bool java, bool python)
     return QCoreApplication::translate("Util::FileUtil", "%1Source Files (%2)").arg(name, filter.trimmed());
 }
 
+QString fileNameWithSuffix(const QString &name, const QString &lang)
+{
+    QString result = name + ".";
+    if (lang == "C++")
+        result += cppSuffix[0];
+    else if (lang == "Java")
+        result += javaSuffix[0];
+    else if (lang == "Python")
+        result += pythonSuffix[0];
+    else
+        LOG_WTF("Unknown language: " << lang);
+    return result;
+}
+
 bool saveFile(const QString &path, const QString &content, const QString &head, bool safe, MessageLogger *log,
               bool createDirectory)
 {

--- a/src/Util/FileUtil.hpp
+++ b/src/Util/FileUtil.hpp
@@ -33,6 +33,8 @@ const static QString exeSuffix = ".exe";
 const static QString exeSuffix = "";
 #endif
 
+QString fileNameWithSuffix(const QString &name, const QString &lang);
+
 QString fileNameFilter(bool cpp, bool java, bool python);
 
 bool saveFile(const QString &path, const QString &content, const QString &head = "Save File", bool safe = true,

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -518,16 +518,7 @@ void AppWindow::openContest(Widgets::ContestDialog::ContestData const &data)
     QStringList tabs;
 
     for (int i = 0; i < number; ++i)
-    {
-        QString name('A' + i);
-        if (language == "C++")
-            name += ".cpp";
-        else if (language == "Java")
-            name += ".java";
-        else if (language == "Python")
-            name += ".py";
-        tabs.append(QDir(path).filePath(name));
-    }
+        tabs.append(QDir(path).filePath(Util::fileNameWithSuffix(QChar('A' + i), lang)));
 
     openTabs(tabs);
 }
@@ -1182,7 +1173,7 @@ void AppWindow::on_actionFormatCode_triggered()
 {
     if (currentWindow() != nullptr)
     {
-        currentWindow()->formatSource();
+        currentWindow()->formatSource(true, true);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -700,13 +700,10 @@ void MainWindow::compileAndRun()
 void MainWindow::formatSource(bool selectionOnly, bool logOnNoChange)
 {
     LOG_INFO("Requested code format");
-    Extensions::CodeFormatter *formatter;
     if (language == "Python")
-        formatter = new Extensions::YAPFormatter(editor, language, selectionOnly, logOnNoChange, log, this);
+        Extensions::YAPFormatter(editor, language, selectionOnly, logOnNoChange, log, this).format();
     else
-        formatter = new Extensions::ClangFormatter(editor, language, selectionOnly, logOnNoChange, log, this);
-    formatter->format();
-    delete formatter;
+        Extensions::ClangFormatter(editor, language, selectionOnly, logOnNoChange, log, this).format();
 }
 
 void MainWindow::setLanguage(const QString &lang)

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -43,7 +43,6 @@ class Runner;
 namespace Extensions
 {
 class CFTool;
-class ClangFormatter;
 struct CompanionData;
 } // namespace Extensions
 
@@ -105,7 +104,7 @@ class MainWindow : public QMainWindow
     void compileOnly();
     void runOnly();
     void compileAndRun();
-    void formatSource();
+    void formatSource(bool selectionOnly, bool logOnNoChange);
 
     void applyCompanion(const Extensions::CompanionData &data);
 
@@ -198,7 +197,6 @@ class MainWindow : public QMainWindow
     QString language;
     bool isLanguageSet = false;
 
-    Extensions::ClangFormatter *formatter = nullptr;
     Core::Compiler *compiler = nullptr;
     QVector<Core::Runner *> runner;
     Core::Checker *checker = nullptr;

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -731,11 +731,7 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
-    <name>Extensions::ClangFormatter</name>
-    <message>
-        <source>Formatter/check</source>
-        <translation>Форматирование/Проверка</translation>
-    </message>
+    <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
         <translation>Форматирование</translation>
@@ -749,20 +745,24 @@ Press any key to exit</source>
         <translation>Форматирование завершено</translation>
     </message>
     <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format at %1.</source>
-        <translation>Процесс форматировния не завершился за 2 секунды. Возможно исполняемый файл clang-format не найден CP Editor&apos;ом. Вы можете установить путь к clang-format в %1.</translation>
-    </message>
-    <message>
-        <source>The format command is: %1 %2</source>
-        <translation>Команды форматирования: %1 %2</translation>
-    </message>
-    <message>
         <source>Formatter[stdout]</source>
         <translation>Форматирование[stdout]</translation>
     </message>
     <message>
         <source>Formatter[stderr]</source>
         <translation>Форматирование[stderr]</translation>
+    </message>
+    <message>
+        <source>The format command [%1 %2] finished with exit code %3.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1508,6 +1508,14 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
+    <message>
+        <source>YAPF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Code Formatting</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1544,11 +1552,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <translation>Путь до исполняемых файлов Clang Format</translation>
     </message>
     <message>
-        <source>Style</source>
-        <translation>Стиль</translation>
-    </message>
-    <message>
-        <source>The Clang Format style options, which are often saved in a .clang-format configuration file.
+        <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Опции Clang Format style, который обычно сохраняются в файле .clang-format.
 Больше информации на &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
@@ -2366,16 +2370,8 @@ It is a list of &lt;default path name&gt;s, separated by commas, and can be empt
         <translation>Может быть перезаписан %1.</translation>
     </message>
     <message>
-        <source>Use Clang Format to format the code when auto-saving it.</source>
-        <translation>Использовать Clang Format для форматирования кода при его автоматическом сохранении.</translation>
-    </message>
-    <message>
         <source>Format code on manual save</source>
         <translation>Форматировать код при ручном сохранении</translation>
-    </message>
-    <message>
-        <source>Use Clang Format to format the code when saving it manually.</source>
-        <translation>Использовать Clang Format для форматирования кода при его ручном сохранении.</translation>
     </message>
     <message>
         <source>Format code on auto-save</source>
@@ -2530,6 +2526,55 @@ The program will be killed if it doesn&apos;t terminate in the time limit.</sour
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Максимальное отображаемое число символов в тесткейсе.
 Если тесткейс будет слишком большой, он будет пропущен и доступен только для чтения.</translation>
+    </message>
+    <message>
+        <source>Clang Format Program</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clang Format Arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clang Format Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>YAPF Program</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>YAPF Arguments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>YAPF Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
+You can learn about it by running `yapf --style-help`.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Format the code when saving it manually.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Format the code when auto-saving it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -731,11 +731,7 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
-    <name>Extensions::ClangFormatter</name>
-    <message>
-        <source>Formatter/check</source>
-        <translation>格式化工具/检查</translation>
-    </message>
+    <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
         <translation>格式化工具</translation>
@@ -749,20 +745,24 @@ Press any key to exit</source>
         <translation>格式化完毕</translation>
     </message>
     <message>
-        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the clang-format binary is not found by CP Editor. You can set the path to clang-format at %1.</source>
-        <translation>格式化进程未能在 2 秒内结束。这可能是因为 CP Editor 未能找到 clang-format 的可执行文件。你可以在 %1 设置 clang-format 可执行文件的路径。</translation>
-    </message>
-    <message>
-        <source>The format command is: %1 %2</source>
-        <translation>格式化指令为: %1 %2</translation>
-    </message>
-    <message>
         <source>Formatter[stdout]</source>
         <translation>格式化工具[stdout]</translation>
     </message>
     <message>
         <source>Formatter[stderr]</source>
         <translation>格式化工具[stderr]</translation>
+    </message>
+    <message>
+        <source>The format command [%1 %2] finished with exit code %3.</source>
+        <translation>格式化命令 [%1 %2] 以返回值 %3 结束了。</translation>
+    </message>
+    <message>
+        <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
+        <translation>格式化进程未能在 2 秒内结束。这很可能是因为 CP Editor 没有找到 %1 程序。你可以在 %2 设置程序的路径。</translation>
+    </message>
+    <message>
+        <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
+        <translation>格式化进程的输出为空。请确保格式化命令中没有就地修改选项。</translation>
     </message>
 </context>
 <context>
@@ -1508,6 +1508,14 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Font</source>
         <translation>字体</translation>
     </message>
+    <message>
+        <source>YAPF</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Code Formatting</source>
+        <translation>代码格式化</translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1544,11 +1552,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <translation>Clang Format 可执行文件的路径</translation>
     </message>
     <message>
-        <source>Style</source>
-        <translation>风格</translation>
-    </message>
-    <message>
-        <source>The Clang Format style options, which are often saved in a .clang-format configuration file.
+        <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Clang Format 格式化所用风格，通常存储为 .clang-format。
 你可以在 &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt; 上了解更多。</translation>
@@ -2362,16 +2366,8 @@ It is a list of &lt;default path name&gt;s, separated by commas, and can be empt
         <translation>它可以被 %1 覆盖。</translation>
     </message>
     <message>
-        <source>Use Clang Format to format the code when auto-saving it.</source>
-        <translation>自动保存代码时使用 Clang Format 进行格式化。</translation>
-    </message>
-    <message>
         <source>Format code on manual save</source>
         <translation>手动保存时格式化代码</translation>
-    </message>
-    <message>
-        <source>Use Clang Format to format the code when saving it manually.</source>
-        <translation>手动保存代码时使用 Clang Format 进行格式化。</translation>
     </message>
     <message>
         <source>Format code on auto-save</source>
@@ -2522,6 +2518,56 @@ The program will be killed if it doesn&apos;t terminate in the time limit.</sour
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>会显示出来的测试用例的最大字符数。如果测试用例过长，超长部分会被省略，且测试用例会变得只读。</translation>
+    </message>
+    <message>
+        <source>Clang Format Program</source>
+        <translation>Clang Format 程序</translation>
+    </message>
+    <message>
+        <source>Clang Format Arguments</source>
+        <translation>Clang Format 参数</translation>
+    </message>
+    <message>
+        <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
+        <translation>传递给 clang-format 的参数。它不应包含 &quot;-i&quot;。</translation>
+    </message>
+    <message>
+        <source>Clang Format Style</source>
+        <translation>Clang Format 风格</translation>
+    </message>
+    <message>
+        <source>YAPF Program</source>
+        <translation>YAPF 程序</translation>
+    </message>
+    <message>
+        <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
+        <translation>YAPF 的程序。它可以是 `yapf`（无需额外设置参数）或 `python`（需要 `-m yapf` 作为参数）。</translation>
+    </message>
+    <message>
+        <source>YAPF Arguments</source>
+        <translation>YAPF 参数</translation>
+    </message>
+    <message>
+        <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
+        <translation>传递给 YAPF 程序的参数。它不应包含 &quot;-i&quot;。</translation>
+    </message>
+    <message>
+        <source>YAPF Style</source>
+        <translation>YAPF 风格</translation>
+    </message>
+    <message>
+        <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
+You can learn about it by running `yapf --style-help`.</source>
+        <translation>YAPF 格式化所用风格，通常存储为 .style.yapf 或 setup.conf。
+你可以运行 `yapf --style-help` 以了解更多。</translation>
+    </message>
+    <message>
+        <source>Format the code when saving it manually.</source>
+        <translation>手动保存时格式化代码。</translation>
+    </message>
+    <message>
+        <source>Format the code when auto-saving it.</source>
+        <translation>自动保存时格式化代码。</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

Better logic and code reuse than #640.

## Related Issues / Pull Requests

This closes #640.

## Motivation and Context

There are many duplicate codes in #640 and some logics including the `verbose` option are changed. There are also duplicate `format code on save` settings in #640.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text

@IZOBRETATEL777 please update the translations.
