### PR TITLE
ci(release): use the new syntax to set env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           mv build/Release/cpeditor.exe build/out
           ../Qt/*/*/bin/windeployqt.exe build/out/cpeditor.exe --no-translations
           cd "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC"
-          echo ::set-env name=VC_REDIST_VERSION::$(ls -dr *.* | head -n1)
+          echo "VC_REDIST_VERSION=\"$(ls -dr *.* | head -n1)\"" >> $GITHUB_ENV
 
       - name: Pack to installer on Windows
         if: startsWith(matrix.config.os, 'windows') && matrix.config.portable-option == 'Off'


### PR DESCRIPTION
## Description

Use `>> $GITHUB_ENV` to set env.

## Related Issues / Pull Requests

This fixes #654.