### PR TITLE
feat: link to settings in the message, remove diagnostics, improve message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 -   Now you can opt-in non-monospaced fonts when choosing a font in the Preferences. (#217 and #625)
+-   Now you can open the corresponding preferences page via a link when asked to check the setting in the message logger. (#659)
 
 ### Fixed
 
@@ -11,6 +12,7 @@
 ### Changed
 
 -   Font settings are moved to Appearance/Font, everything else remains in Appearance/General. (#625)
+-   You'll no longer receive the warnings about a not-working compiler, etc. at startup. Instead, you'll receive the warning when you try to compile something, etc. (#659)
 
 ### Improved
 

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -127,6 +127,7 @@ void Checker::prepare(const QString &compileCommand)
         connect(compiler, SIGNAL(compilationFinished(const QString &)), this, SLOT(onCompilationFinished()));
         connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
                 SLOT(onCompilationErrorOccurred(const QString &)));
+        connect(compiler, SIGNAL(compilationFailed(const QString &)), this, SLOT(onCompilationFailed(const QString &)));
         connect(compiler, SIGNAL(compilationKilled()), this, SLOT(onCompilationKilled()));
         compiler->start(checkerPath, "", compileCommand, "C++");
     }
@@ -167,6 +168,11 @@ void Checker::onCompilationFinished()
 void Checker::onCompilationErrorOccurred(const QString &error)
 {
     log->error(tr("Checker"), tr("Error occurred while compiling the checker:\n%1").arg(error));
+}
+
+void Checker::onCompilationFailed(const QString &reason)
+{
+    log->error(tr("Checker"), tr("Failed to compile the checker: %1").arg(reason), false);
 }
 
 void Checker::onCompilationKilled()

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -217,7 +217,7 @@ void Checker::onRunFinished(int index, const QString &, const QString &err, int 
 
 void Checker::onFailedToStartRun(int index, const QString &error)
 {
-    log->error(head(index), error);
+    log->error(head(index), error, false);
 }
 
 void Checker::onRunOutputLimitExceeded(int index, const QString &type)
@@ -229,7 +229,8 @@ void Checker::onRunOutputLimitExceeded(int index, const QString &type)
             .arg(type)
             .arg(index + 1)
             .arg(SettingsHelper::getOutputLengthLimit())
-            .arg(SettingsHelper::pathOfOutputLengthLimit()));
+            .arg(SettingsHelper::pathOfOutputLengthLimit()),
+        false);
 }
 
 void Checker::onRunKilled(int index)

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -117,54 +117,22 @@ class Checker : public QObject
     void checkFinished(int index, Widgets::TestCase::Verdict verdict);
 
   private slots:
-    /**
-     * @brief the compilation of the checker started
-     */
     void onCompilationStarted();
 
-    /**
-     * @brief the checker is compiled successfully
-     */
     void onCompilationFinished();
 
-    /**
-     * @brief failed to compile the checker
-     * @param error the error message provided by Core::Compiler
-     */
     void onCompilationErrorOccurred(const QString &error);
 
-    /**
-     * @brief the compile process is killed
-     */
+    void onCompilationFailed(const QString &reason);
+
     void onCompilationKilled();
 
-    /**
-     * @brief the checker process is finished
-     * @param index the index of the testcase
-     * @param err the stderr of the checker process
-     * @param exitCode the exit code of the checker process
-     * @param tle whether the checker process has exceeded the time limit
-     */
     void onRunFinished(int index, const QString &, const QString &err, int exitCode, int, bool tle);
 
-    /**
-     * @brief the checker failed to start
-     * @param index the index of the testcase
-     * @param error the error message provided by Core::Runner
-     */
     void onFailedToStartRun(int index, const QString &error);
 
-    /**
-     * @brief the stdout/stderr of the checker is too long
-     * @param index the index of the testcase
-     * @param type stdout/stderr
-     */
     void onRunOutputLimitExceeded(int index, const QString &type);
 
-    /**
-     * @brief the checker process is killed
-     * @param index the index of the testcase
-     */
     void onRunKilled(int index);
 
   private:

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -165,7 +165,7 @@ void Compiler::onProcessErrorOccurred(QProcess::ProcessError error)
     if (error == QProcess::FailedToStart)
     {
         emit compilationErrorOccurred(
-            tr("Failed to start compilation. Please check %1 or put your compiler in the PATH environment variable.")
+            tr("Failed to start compilation. Please check %1 or add the compiler in the PATH environment variable.")
                 .arg(SettingsManager::getPathText(lang + "/Compile Command")));
     }
 }

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -59,7 +59,7 @@ void Compiler::start(const QString &tmpFilePath, const QString &sourceFilePath, 
     if (!QFile::exists(tmpFilePath))
     {
         // quit with error if the source file is not found
-        emit compilationErrorOccurred(tr("The source file [%1] doesn't exist").arg(tmpFilePath));
+        emit compilationFailed(tr("The source file [%1] doesn't exist").arg(tmpFilePath));
         return;
     }
 
@@ -75,7 +75,7 @@ void Compiler::start(const QString &tmpFilePath, const QString &sourceFilePath, 
 
     if (args.isEmpty())
     {
-        emit compilationErrorOccurred(tr("The compile command for %1 is empty").arg(lang));
+        emit compilationFailed(tr("The compile command for %1 is empty").arg(lang));
         return;
     }
 
@@ -93,7 +93,7 @@ void Compiler::start(const QString &tmpFilePath, const QString &sourceFilePath, 
     }
     else
     {
-        emit compilationErrorOccurred(tr("Unsupported programming language \"%1\"").arg(lang));
+        emit compilationFailed(tr("Unsupported programming language \"%1\"").arg(lang));
         return;
     }
 
@@ -164,8 +164,8 @@ void Compiler::onProcessErrorOccurred(QProcess::ProcessError error)
     LOG_WARN(INFO_OF(error));
     if (error == QProcess::FailedToStart)
     {
-        emit compilationErrorOccurred(
-            tr("Failed to start compilation. Please check %1 or add the compiler in the PATH environment variable.")
+        emit compilationFailed(
+            tr("Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.")
                 .arg(SettingsManager::getPathText(lang + "/Compile Command")));
     }
 }

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -75,7 +75,7 @@ void Compiler::start(const QString &tmpFilePath, const QString &sourceFilePath, 
 
     if (args.isEmpty())
     {
-        emit compilationFailed(tr("The compile command for %1 is empty").arg(lang));
+        emit compilationFailed(tr("%1 is empty").arg(SettingsManager::getPathText(lang + "/Compile Command")));
         return;
     }
 

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -96,6 +96,12 @@ class Compiler : public QObject
     void compilationErrorOccurred(const QString &error);
 
     /**
+     * @brief failed to start compilation
+     * @param reason the reason of the failure
+     */
+    void compilationFailed(const QString &reason);
+
+    /**
      * @brief the compilation process has just been killed
      * @note It's only emitted when the process is killed when destructing the Compiler.
      */

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -61,13 +61,6 @@ class Compiler : public QObject
                const QString &lang);
 
     /**
-     * @brief check whether a compile command is valid or not
-     * @param compilaCommand the command to check
-     * @note this only checks whether the program of the command works
-     */
-    static bool check(const QString &compileCommand);
-
-    /**
      * @brief get the output path (executable file path for C++, class path for Java, tmp file path for Python)
      * @param tmpFilePath the path to the temporary file which is compiled
      * @param sourceFilePath the path to the original source file, if it's empty, tmpFilePath will be used instead of it

--- a/src/Core/MessageLogger.cpp
+++ b/src/Core/MessageLogger.cpp
@@ -17,16 +17,24 @@
 
 #include "Core/MessageLogger.hpp"
 #include "Core/EventLogger.hpp"
+#include "Settings/PreferencesWindow.hpp"
 #include "generated/SettingsHelper.hpp"
 #include <QDateTime>
 
-MessageLogger::MessageLogger(QWidget *parent) : QTextBrowser(parent)
+MessageLogger::MessageLogger(PreferencesWindow *preferences, QWidget *parent)
+    : QTextBrowser(parent), preferencesWindow(preferences)
 {
+    connect(this, SIGNAL(anchorClicked(const QUrl &)), this, SLOT(onAnchorClicked(const QUrl &)));
     setOpenExternalLinks(true);
 }
 
 void MessageLogger::message(const QString &head, const QString &body, const QString &color, bool htmlEscaped)
 {
+    if (htmlEscaped && body.contains("<a href="))
+    {
+        LOG_WARN("The message contains \"<a href=\" but htmlEscaped is enabled. " << INFO_OF(body));
+    }
+
     QString newHead, newBody;
     if (htmlEscaped)
     {
@@ -76,4 +84,12 @@ void MessageLogger::error(const QString &head, const QString &body, bool htmlEsc
 {
     LOG_INFO(INFO_OF(head) << INFO_OF(body));
     message(head, body, "red", htmlEscaped);
+}
+
+void MessageLogger::onAnchorClicked(const QUrl &link)
+{
+    auto url = link.toString();
+    LOG_INFO(INFO_OF(url));
+    if (url.startsWith("#Preferences/"))
+        preferencesWindow->open(url.mid(13));
 }

--- a/src/Core/MessageLogger.cpp
+++ b/src/Core/MessageLogger.cpp
@@ -30,9 +30,10 @@ MessageLogger::MessageLogger(PreferencesWindow *preferences, QWidget *parent)
 
 void MessageLogger::message(const QString &head, const QString &body, const QString &color, bool htmlEscaped)
 {
-    if (htmlEscaped && body.contains("<a href="))
+    if (body.contains("<a href='#Preferences/"))
     {
-        LOG_WARN("The message contains \"<a href=\" but htmlEscaped is enabled. " << INFO_OF(body));
+        LOG_WARN("The message contains \"<a href='#Preferences/\", htmlEscaped is automatically disabled.");
+        htmlEscaped = false;
     }
 
     QString newHead, newBody;

--- a/src/Core/MessageLogger.cpp
+++ b/src/Core/MessageLogger.cpp
@@ -30,11 +30,7 @@ MessageLogger::MessageLogger(PreferencesWindow *preferences, QWidget *parent)
 
 void MessageLogger::message(const QString &head, const QString &body, const QString &color, bool htmlEscaped)
 {
-    if (body.contains("<a href='#Preferences/"))
-    {
-        LOG_WARN("The message contains \"<a href='#Preferences/\", htmlEscaped is automatically disabled.");
-        htmlEscaped = false;
-    }
+    LOG_WARN_IF(body.contains("<a href"), "The message contains \"<a href\", but htmlEscaped is enabled.");
 
     QString newHead, newBody;
     if (htmlEscaped)

--- a/src/Core/MessageLogger.cpp
+++ b/src/Core/MessageLogger.cpp
@@ -17,19 +17,12 @@
 
 #include "Core/MessageLogger.hpp"
 #include "Core/EventLogger.hpp"
+#include "generated/SettingsHelper.hpp"
 #include <QDateTime>
-#include <QTextBrowser>
-#include <generated/SettingsHelper.hpp>
 
-MessageLogger::MessageLogger(QObject *parent) : QObject(parent)
+MessageLogger::MessageLogger(QWidget *parent) : QTextBrowser(parent)
 {
-}
-
-void MessageLogger::setContainer(QTextBrowser *container)
-{
-    box = container;
-    LOG_INFO("MessageLogger container has been initialized");
-    box->setOpenExternalLinks(true);
+    setOpenExternalLinks(true);
 }
 
 void MessageLogger::message(const QString &head, const QString &body, const QString &color, bool htmlEscaped)
@@ -64,29 +57,23 @@ void MessageLogger::message(const QString &head, const QString &body, const QStr
         res += newBody;
     res += "]</span>";
 
-    box->append(res);
+    append(res);
 }
 
 void MessageLogger::info(const QString &head, const QString &body, bool htmlEscaped)
 {
-    LOG_INFO("MessageLogger Information " << INFO_OF(head) << INFO_OF(body));
+    LOG_INFO(INFO_OF(head) << INFO_OF(body));
     message(head, body, "", htmlEscaped);
 }
 
 void MessageLogger::warn(const QString &head, const QString &body, bool htmlEscaped)
 {
-    LOG_INFO("MessageLogger Warning " << INFO_OF(head) << INFO_OF(body));
+    LOG_INFO(INFO_OF(head) << INFO_OF(body));
     message(head, body, "green", htmlEscaped);
 }
 
 void MessageLogger::error(const QString &head, const QString &body, bool htmlEscaped)
 {
-    LOG_INFO("MessageLogger Error " << INFO_OF(head) << INFO_OF(body));
+    LOG_INFO(INFO_OF(head) << INFO_OF(body));
     message(head, body, "red", htmlEscaped);
-}
-
-void MessageLogger::clear()
-{
-    LOG_INFO("MessageLogger box has been cleared");
-    box->clear();
 }

--- a/src/Core/MessageLogger.hpp
+++ b/src/Core/MessageLogger.hpp
@@ -22,16 +22,14 @@
 #ifndef MESSAGELOGGER_HPP
 #define MESSAGELOGGER_HPP
 
-#include <QObject>
+#include <QTextBrowser>
 
-class QTextBrowser;
-
-class MessageLogger : public QObject
+class MessageLogger : public QTextBrowser
 {
     Q_OBJECT
 
   public:
-    explicit MessageLogger(QObject *parent = nullptr);
+    explicit MessageLogger(QWidget *parent = nullptr);
 
     /**
      * @brief show a message
@@ -68,20 +66,6 @@ class MessageLogger : public QObject
      * @note the message is red
      */
     void error(const QString &head, const QString &body, bool htmlEscaped = true);
-
-    /**
-     * @brief clear all messages in the message logger
-     */
-    void clear();
-
-    /**
-     * @brief set the container of the message logger
-     * @param container the container of the message logger
-     */
-    void setContainer(QTextBrowser *container);
-
-  private:
-    QTextBrowser *box = nullptr; // the container of the message logger
 };
 
 #endif // MESSAGELOGGER_HPP

--- a/src/Core/MessageLogger.hpp
+++ b/src/Core/MessageLogger.hpp
@@ -24,12 +24,14 @@
 
 #include <QTextBrowser>
 
+class PreferencesWindow;
+
 class MessageLogger : public QTextBrowser
 {
     Q_OBJECT
 
   public:
-    explicit MessageLogger(QWidget *parent = nullptr);
+    explicit MessageLogger(PreferencesWindow *preferences, QWidget *parent = nullptr);
 
     /**
      * @brief show a message
@@ -66,6 +68,12 @@ class MessageLogger : public QTextBrowser
      * @note the message is red
      */
     void error(const QString &head, const QString &body, bool htmlEscaped = true);
+
+  private slots:
+    void onAnchorClicked(const QUrl &link);
+
+  private:
+    PreferencesWindow *preferencesWindow = nullptr;
 };
 
 #endif // MESSAGELOGGER_HPP

--- a/src/Extensions/ClangFormatter.cpp
+++ b/src/Extensions/ClangFormatter.cpp
@@ -193,11 +193,12 @@ QPair<int, QString> ClangFormatter::getFormatResult(const QStringList &args)
     if (!finished)
     {
         formatProcess.kill();
-        log->warn(
+        log->error(
             tr("Formatter"),
             tr("The format process didn't finish in 2 seconds. This is probably because the clang-format binary is not "
                "found by CP Editor. You can set the path to clang-format at %1.")
-                .arg(SettingsHelper::pathOfClangFormatPath()));
+                .arg(SettingsHelper::pathOfClangFormatPath()),
+            false);
         return QPair<int, QString>(-1, QString());
     }
 

--- a/src/Extensions/LanguageServer.cpp
+++ b/src/Extensions/LanguageServer.cpp
@@ -289,7 +289,8 @@ void LanguageServer::onLSPServerProcessError(QProcess::ProcessError error)
     case QProcess::FailedToStart:
         logger->error(tr("Langauge Server [%1]").arg(language),
                       tr("Failed to start LSP Process. Have you set the path to the Language Server program at %1?")
-                          .arg(SettingsManager::getPathText("LSP/Path " + language)));
+                          .arg(SettingsManager::getPathText("LSP/Path " + language)),
+                      false);
         break;
     case QProcess::Crashed:
         break;

--- a/src/Settings/PathItem.cpp
+++ b/src/Settings/PathItem.cpp
@@ -21,6 +21,7 @@
 #include <QApplication>
 #include <QCoreApplication>
 #include <QFileDialog>
+#include <QFocusEvent>
 #include <QHBoxLayout>
 #include <QLineEdit>
 #include <QStyle>
@@ -88,4 +89,9 @@ QString PathItem::title() const
     default:
         Q_UNREACHABLE();
     }
+}
+
+void PathItem::focusInEvent(QFocusEvent *event)
+{
+    lineEdit->setFocus(event->reason());
 }

--- a/src/Settings/PathItem.hpp
+++ b/src/Settings/PathItem.hpp
@@ -63,6 +63,8 @@ class PathItem : public QWidget
 
     QString title() const;
 
+    void focusInEvent(QFocusEvent *event) override;
+
   private:
     Type fileType;
     QHBoxLayout *layout = nullptr;

--- a/src/Settings/PreferencesGridPage.cpp
+++ b/src/Settings/PreferencesGridPage.cpp
@@ -39,9 +39,10 @@ PreferencesGridPage::PreferencesGridPage(bool alignTop, QWidget *parent) : Prefe
     HLayout->addStretch();
 }
 
-void PreferencesGridPage::addRow(ValueWidget *widget, const QString &tip, const QString &help, const QString &labelText)
+void PreferencesGridPage::addRow(ValueWidget *widget, const QString &key, const QString &tip, const QString &help,
+                                 const QString &labelText)
 {
-    registerWidget(widget);
+    registerWidget(key, widget);
     int row = gridLayout->rowCount();
     if (labelText.isEmpty())
     {

--- a/src/Settings/PreferencesGridPage.cpp
+++ b/src/Settings/PreferencesGridPage.cpp
@@ -39,8 +39,7 @@ PreferencesGridPage::PreferencesGridPage(bool alignTop, QWidget *parent) : Prefe
     HLayout->addStretch();
 }
 
-void PreferencesGridPage::addRow(ValueWidget *widget, const QString &key, const QString &tip, const QString &help,
-                                 const QString &labelText)
+void PreferencesGridPage::addRow(ValueWidget *widget, const QString &key, const QString &tip, const QString &labelText)
 {
     registerWidget(key, widget);
     int row = gridLayout->rowCount();
@@ -48,16 +47,12 @@ void PreferencesGridPage::addRow(ValueWidget *widget, const QString &key, const 
     {
         if (!tip.isEmpty())
             widget->coreWidget()->setToolTip(tr(tip.toUtf8()));
-        if (!help.isEmpty())
-            widget->coreWidget()->setWhatsThis(tr(help.toUtf8()));
     }
     else
     {
         QLabel *label = new QLabel(tr(labelText.toUtf8()), this);
         if (!tip.isEmpty())
             label->setToolTip(tr(tip.toUtf8()));
-        if (!help.isEmpty())
-            label->setWhatsThis(tr(help.toUtf8()));
         gridLayout->addWidget(label, row, 0);
     }
     gridLayout->addWidget(widget->coreWidget(), row, 1);

--- a/src/Settings/PreferencesGridPage.hpp
+++ b/src/Settings/PreferencesGridPage.hpp
@@ -39,11 +39,13 @@ class PreferencesGridPage : public PreferencesPage
     /**
      * @brief add a row
      * @param widget the widget to add
+     * @param key the key of the setting
      * @param tip the tool tip of this item
      * @param help the help (what's this) of this item
      * @param labelText (optional) the label of the row
      */
-    void addRow(ValueWidget *widget, const QString &tip, const QString &help, const QString &labelText = QString());
+    void addRow(ValueWidget *widget, const QString &key, const QString &tip, const QString &help,
+                const QString &labelText = QString());
 
   private:
     QGridLayout *gridLayout = nullptr;

--- a/src/Settings/PreferencesGridPage.hpp
+++ b/src/Settings/PreferencesGridPage.hpp
@@ -41,11 +41,9 @@ class PreferencesGridPage : public PreferencesPage
      * @param widget the widget to add
      * @param key the key of the setting
      * @param tip the tool tip of this item
-     * @param help the help (what's this) of this item
      * @param labelText (optional) the label of the row
      */
-    void addRow(ValueWidget *widget, const QString &key, const QString &tip, const QString &help,
-                const QString &labelText = QString());
+    void addRow(ValueWidget *widget, const QString &key, const QString &tip, const QString &labelText = QString());
 
   private:
     QGridLayout *gridLayout = nullptr;

--- a/src/Settings/PreferencesPage.cpp
+++ b/src/Settings/PreferencesPage.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Settings/PreferencesPage.hpp"
+#include "Settings/SettingsManager.hpp"
 #include "Settings/ValueWrapper.hpp"
 #include <QApplication>
 #include <QFormLayout>
@@ -139,10 +140,12 @@ void PreferencesPage::addItem(QLayoutItem *item)
     settingsLayout->addItem(item);
 }
 
-void PreferencesPage::registerWidget(ValueWidget *widget)
+void PreferencesPage::registerWidget(const QString &key, ValueWidget *widget)
 {
     // PreferencesPageTemplate::PreferencesPageTemplate uses Qt::DirectConnection
     QObject::connect(widget, &ValueWidget::valueChanged, this, &PreferencesPage::updateButtons, Qt::QueuedConnection);
+
+    SettingsManager::setWidget(key, widget->coreWidget());
 }
 
 void PreferencesPage::loadDefault()

--- a/src/Settings/PreferencesPage.cpp
+++ b/src/Settings/PreferencesPage.cpp
@@ -103,9 +103,15 @@ QString PreferencesPage::path() const
     return m_path;
 }
 
-void PreferencesPage::setPath(const QString &path)
+QString PreferencesPage::trPath() const
+{
+    return m_trPath;
+}
+
+void PreferencesPage::setPath(const QString &path, const QString &trPath)
 {
     m_path = path;
+    m_trPath = trPath;
     emit pathChanged(m_path);
 }
 

--- a/src/Settings/PreferencesPage.hpp
+++ b/src/Settings/PreferencesPage.hpp
@@ -144,7 +144,7 @@ class PreferencesPage : public QWidget
      */
     void addItem(QLayoutItem *item);
 
-    void registerWidget(ValueWidget *widget);
+    void registerWidget(const QString &key, ValueWidget *widget);
 
   protected slots:
     /**

--- a/src/Settings/PreferencesPage.hpp
+++ b/src/Settings/PreferencesPage.hpp
@@ -93,9 +93,14 @@ class PreferencesPage : public QWidget
     QString path() const;
 
     /**
+     * @brief get the translation of the path
+     */
+    QString trPath() const;
+
+    /**
      * @brief set the path to this page in the preferences window
      */
-    virtual void setPath(const QString &path);
+    virtual void setPath(const QString &path, const QString &trPath);
 
     /**
      * @brief set the title of the page
@@ -188,7 +193,8 @@ class PreferencesPage : public QWidget
     QPushButton *resetButton = nullptr;    // The button to set the UI to the saved settings
     QPushButton *applyButton = nullptr;    // The button to save the UI to the settings
 
-    QString m_path; // The path to this page in the preferences window
+    QString m_path;   // The path to this page in the preferences window
+    QString m_trPath; // The translation of the path
 };
 
 #endif // PREFERENCESPAGE_HPP

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -32,45 +32,46 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
         if (name != si.name)
             qDebug() << "Unknown option" << name;
 #endif
+        ValueWidget *widget = nullptr;
+
         if (si.type == "QString")
         {
             Wrapper<QString> *wrapper = createStringWrapper(si.ui);
             wrapper->init(this, si.param);
-            addRow(wrapper, si.tip, si.help, si.desc);
-            widgets.push_back(wrapper);
+            widget = wrapper;
         }
         else if (si.type == "bool")
         {
             Wrapper<bool> *wrapper = createBoolWrapper(si.ui);
             wrapper->init(si.desc, this, si.param);
-            addRow(wrapper, si.tip, si.help);
-            widgets.push_back(wrapper);
+            widget = wrapper;
         }
         else if (si.type == "int")
         {
             Wrapper<int> *wrapper = createIntWrapper(si.ui);
             wrapper->init(this, si.param);
-            addRow(wrapper, si.tip, si.help, si.desc);
-            widgets.push_back(wrapper);
+            widget = wrapper;
         }
         else if (si.type == "QFont")
         {
             Wrapper<QFont> *wrapper = createFontWrapper(si.ui);
             wrapper->init(this, si.param);
-            addRow(wrapper, si.tip, si.help, si.desc);
-            widgets.push_back(wrapper);
+            widget = wrapper;
         }
         else if (si.type == "QVariantList")
         {
             Wrapper<QVariantList> *wrapper = createStringListsWrapper(si.ui);
             wrapper->init(this, si.param);
-            addRow(wrapper, si.tip, si.help, si.desc);
-            widgets.push_back(wrapper);
+            widget = wrapper;
         }
         else
         {
             Q_UNREACHABLE();
         }
+
+        Q_ASSERT(widget != nullptr);
+        addRow(widget, name, si.tip, si.help, si.desc);
+        widgets.push_back(widget);
 
         if (si.immediatelyApply)
         {

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -70,7 +70,7 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
         }
 
         Q_ASSERT(widget != nullptr);
-        addRow(widget, name, si.tip, si.help, si.desc);
+        addRow(widget, name, si.tip, si.desc);
         widgets.push_back(widget);
 
         if (si.immediatelyApply)
@@ -112,11 +112,15 @@ QStringList PreferencesPageTemplate::content()
     {
         auto si = SettingsInfo::findSetting(opt);
         if (!si.desc.isEmpty())
+        {
             ret += si.desc;
+            ret += si.untrDesc;
+        }
         if (!si.tip.isEmpty())
+        {
             ret += si.tip;
-        if (!si.help.isEmpty())
-            ret += si.help;
+            ret += si.untrTip;
+        }
     }
     return ret;
 }
@@ -125,7 +129,7 @@ void PreferencesPageTemplate::setPath(const QString &path)
 {
     PreferencesPage::setPath(path);
     for (const QString &name : options)
-        SettingsManager::setPath(name, path + "/" + SettingsInfo::findSetting(name).desc);
+        SettingsManager::setPath(name, path + "/" + SettingsInfo::findSetting(name).untrDesc);
 }
 
 bool PreferencesPageTemplate::areSettingsChanged()

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -125,11 +125,12 @@ QStringList PreferencesPageTemplate::content()
     return ret;
 }
 
-void PreferencesPageTemplate::setPath(const QString &path)
+void PreferencesPageTemplate::setPath(const QString &path, const QString &trPath)
 {
-    PreferencesPage::setPath(path);
+    PreferencesPage::setPath(path, trPath);
     for (const QString &name : options)
-        SettingsManager::setPath(name, path + "/" + SettingsInfo::findSetting(name).untrDesc);
+        SettingsManager::setPath(name, path + "/" + SettingsInfo::findSetting(name).untrDesc,
+                                 trPath + "/" + SettingsInfo::findSetting(name).desc);
 }
 
 bool PreferencesPageTemplate::areSettingsChanged()

--- a/src/Settings/PreferencesPageTemplate.hpp
+++ b/src/Settings/PreferencesPageTemplate.hpp
@@ -29,7 +29,7 @@ class PreferencesPageTemplate : public PreferencesGridPage
 
     virtual QStringList content() override;
 
-    virtual void setPath(const QString &path) override;
+    virtual void setPath(const QString &path, const QString &trPath) override;
 
   private:
     bool areSettingsChanged() override;

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -54,7 +54,7 @@ AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, Pre
     {
         currentItem = new QTreeWidgetItem({trkey});
         tree->addTopLevelItem(currentItem);
-        newpage->setPath(key);
+        newpage->setPath(key, trkey);
         newpage->setTitle(trkey);
         window->addPage(currentItem, newpage, content);
     }
@@ -62,7 +62,7 @@ AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, Pre
     {
         QTreeWidgetItem *item = new QTreeWidgetItem({trkey});
         currentItem->addChild(item);
-        newpage->setPath(currentPath.join('/') + '/' + key);
+        newpage->setPath((currentPath + QStringList(key)).join('/'), (currentTrPath + QStringList(trkey)).join('/'));
         if (key == "@")
             newpage->setTitle(currentItem->text(0));
         else
@@ -87,6 +87,7 @@ AddPageHelper &AddPageHelper::dir(const QString &key, const QString &trkey)
         currentItem = item;
     }
     currentPath.push_back(key);
+    currentTrPath.push_back(trkey);
     return *this;
 }
 
@@ -94,6 +95,7 @@ AddPageHelper &AddPageHelper::end()
 {
     currentItem = currentItem->parent();
     currentPath.pop_back();
+    currentTrPath.pop_back();
     return *this;
 }
 

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -80,6 +80,12 @@ class PreferencesWindow : public QMainWindow
      */
     void display();
 
+    /**
+     * @brief switch to a certain path and show up
+     * @param path the path of the setting to be displayed
+     */
+    void open(const QString &path);
+
   signals:
     /**
      * @brief the settings are applied
@@ -104,8 +110,9 @@ class PreferencesWindow : public QMainWindow
      * @param force if force, user won't be asked whether to save changes or not
      * @note If there are unsaved changes in the current page, the user will be asked whether to save/discard
      *       the changes or stay. If the user chooses to stay, the switch operation will fail.
+     * @returns whether the switch operation suceeded or not, i.e. if the current page is *page*
      */
-    void switchToPage(QWidget *page, bool force = false);
+    bool switchToPage(QWidget *page, bool force = false);
 
     /**
      * @brief get the page widget to the page of the given path

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -59,7 +59,7 @@ class AddPageHelper
     PreferencesWindow *window;
     QTreeWidget *tree;
     QTreeWidgetItem *currentItem;
-    QStringList currentPath;
+    QStringList currentPath, currentTrPath;
 };
 
 class PreferencesWindow : public QMainWindow

--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -31,7 +31,7 @@ class SettingsInfo
   public:
     struct SettingInfo
     {
-        QString name, desc, type, ui, tip, help;
+        QString name, desc, untrDesc, type, ui, tip, untrTip;
         bool requireAllDepends; // false for one of the depends, true for all depends
         bool immediatelyApply;
         std::function<void(SettingInfo *, ValueWidget *, QWidget *)> onApply;

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -30,6 +30,8 @@
 QVariantMap *SettingsManager::cur = nullptr;
 QVariantMap *SettingsManager::def = nullptr;
 QMap<QString, QString> *SettingsManager::settingPath = nullptr;
+QMap<QString, QString> *SettingsManager::pathSetting = nullptr;
+QMap<QString, QWidget *> *SettingsManager::settingWidget = nullptr;
 
 const static QStringList configFileLocations = {
 #ifdef PORTABLE_VERSION
@@ -97,10 +99,16 @@ void SettingsManager::init()
         delete def;
     if (settingPath)
         delete settingPath;
+    if (pathSetting)
+        delete pathSetting;
+    if (settingWidget)
+        delete settingWidget;
 
     cur = new QVariantMap();
     def = new QVariantMap();
     settingPath = new QMap<QString, QString>();
+    pathSetting = new QMap<QString, QString>();
+    settingWidget = new QMap<QString, QWidget *>();
 
     generateDefaultSettings();
 
@@ -202,6 +210,7 @@ void SettingsManager::reset()
 void SettingsManager::setPath(const QString &key, const QString &path)
 {
     settingPath->insert(key, path);
+    pathSetting->insert(path, key);
 }
 
 QString SettingsManager::getPathText(const QString &key, bool parent)
@@ -209,9 +218,9 @@ QString SettingsManager::getPathText(const QString &key, bool parent)
     if (!settingPath->contains(key))
     {
 #ifdef QT_DEBUG
-        qDebug() << "SettingsManager: Getting unknown key path: " << key;
+        qDebug() << "SettingsManager: Getting unknown path: " << key;
 #endif
-        LOG_WARN("Getting unknown key path: " << key);
+        LOG_WARN("Getting unknown path: " << INFO_OF(key));
         return "Unknown";
     }
     auto nodes = QStringList(QCoreApplication::translate("PreferencesWindow", "Preferences")) +
@@ -222,7 +231,32 @@ QString SettingsManager::getPathText(const QString &key, bool parent)
         nodes.pop_back();
     else
         nodes.back() = QCoreApplication::translate("SettingsInfo", nodes.back().toStdString().c_str());
-    return nodes.join("->");
+    return QString("<a href='#Preferences/%1'>%2</a>").arg(settingPath->value(key)).arg(nodes.join("->"));
+}
+
+QString SettingsManager::getKeyOfPath(const QString &path)
+{
+    if (!pathSetting->contains(path))
+    {
+        LOG_WARN("Getting unknown key of path: " << INFO_OF(path));
+        return QString();
+    }
+    return pathSetting->value(path);
+}
+
+void SettingsManager::setWidget(const QString &key, QWidget *widget)
+{
+    settingWidget->insert(key, widget);
+}
+
+QWidget *SettingsManager::getWidget(const QString &key)
+{
+    if (!settingWidget->contains(key))
+    {
+        LOG_WARN("Getting unknown widget: " << INFO_OF(key));
+        return nullptr;
+    }
+    return settingWidget->value(key);
 }
 
 QStringList SettingsManager::keyStartsWith(const QString &head)

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -214,7 +214,8 @@ QString SettingsManager::getPathText(const QString &key, bool parent)
         LOG_WARN("Getting unknown key path: " << key);
         return "Unknown";
     }
-    auto nodes = settingPath->value(key).split('/');
+    auto nodes = QStringList(QCoreApplication::translate("PreferencesWindow", "Preferences")) +
+                 settingPath->value(key).split('/');
     for (int i = 0; i < nodes.count() - 1; ++i)
         nodes[i] = QCoreApplication::translate("PreferencesWindow", nodes[i].toStdString().c_str());
     if (parent)

--- a/src/Settings/SettingsManager.hpp
+++ b/src/Settings/SettingsManager.hpp
@@ -47,8 +47,9 @@ class SettingsManager
      * @breif set the path of a setting in the preferences window
      * @param key the name of the setting
      * @param path The path to the setting, in the form "X/Y/Z/<desc>". The <desc> shouldn't contain slashes.
+     * @param trPath the translation of the path, in the form "X->Y->Z-><trdesc>"
      */
-    static void setPath(const QString &key, const QString &path);
+    static void setPath(const QString &key, const QString &path, const QString &trPath);
     /**
      * @brief get the path of a setting which can be shown in the UI
      * @param key the name of the setting
@@ -67,6 +68,7 @@ class SettingsManager
     static QVariantMap *cur;
     static QVariantMap *def;
     static QMap<QString, QString> *settingPath;
+    static QMap<QString, QString> *settingTrPath;
     static QMap<QString, QString> *pathSetting;
     static QMap<QString, QWidget *> *settingWidget;
 };

--- a/src/Settings/SettingsManager.hpp
+++ b/src/Settings/SettingsManager.hpp
@@ -55,6 +55,10 @@ class SettingsManager
      * @param parent get the path to the parent directory instead of the setting itself
      */
     static QString getPathText(const QString &key, bool parent = false);
+    static QString getKeyOfPath(const QString &path);
+
+    static void setWidget(const QString &key, QWidget *widget);
+    static QWidget *getWidget(const QString &key);
 
     static QStringList keyStartsWith(const QString &head);
     static QStringList itemUnder(const QString &head);
@@ -63,6 +67,8 @@ class SettingsManager
     static QVariantMap *cur;
     static QVariantMap *def;
     static QMap<QString, QString> *settingPath;
+    static QMap<QString, QString> *pathSetting;
+    static QMap<QString, QWidget *> *settingWidget;
 };
 
 #endif // SETTINGSMANAGER_HPP

--- a/src/Widgets/TestCase.cpp
+++ b/src/Widgets/TestCase.cpp
@@ -276,7 +276,8 @@ void TestCase::onToLongForHtml()
               tr("The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change "
                  "the length limit at %2.")
                   .arg(SettingsHelper::getHTMLDiffViewerLengthLimit())
-                  .arg(SettingsHelper::pathOfHTMLDiffViewerLengthLimit()));
+                  .arg(SettingsHelper::pathOfHTMLDiffViewerLengthLimit()),
+              false);
 }
 
 } // namespace Widgets

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -115,13 +115,12 @@ void TestCaseEdit::modifyText(const QString &text, bool keepHistory)
         const QString setLimitPlace = role == Output ? SettingsHelper::pathOfOutputDisplayLengthLimit()
                                                      : SettingsHelper::pathOfDisplayTestCaseLengthLimit();
 
-        log->warn(
-            QString("%1[%2]").arg(name).arg(id + 1),
-            QString("<span title='%1'>%2</span>")
-                .arg(
-                    tr("Now the test case editor is read-only. You can set the length limit at %1.").arg(setLimitPlace))
-                .arg(tr("Only the first %1 characters are shown.").arg(limit)),
-            false);
+        log->warn(QString("%1[%2]").arg(name).arg(id + 1),
+                  QString("Only the first %1 characters are shown. Now the test case editor is read-only. You can set "
+                          "the length limit at %2.")
+                      .arg(limit)
+                      .arg(setLimitPlace),
+                  false);
     }
 
     if (keepHistory)

--- a/src/Widgets/TestCaseEdit.cpp
+++ b/src/Widgets/TestCaseEdit.cpp
@@ -116,8 +116,8 @@ void TestCaseEdit::modifyText(const QString &text, bool keepHistory)
                                                      : SettingsHelper::pathOfDisplayTestCaseLengthLimit();
 
         log->warn(QString("%1[%2]").arg(name).arg(id + 1),
-                  QString("Only the first %1 characters are shown. Now the test case editor is read-only. You can set "
-                          "the length limit at %2.")
+                  tr("Only the first %1 characters are shown. Now the test case editor is read-only. You can set "
+                     "the length limit at %2.")
                       .arg(limit)
                       .arg(setLimitPlace),
                   false);

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -141,7 +141,8 @@ TestCases::TestCases(MessageLogger *logger, QWidget *parent) : QWidget(parent), 
                           tr("The following files are not loaded because they are not matched:%1. You can set the "
                              "matching rules at %2.")
                               .arg(remainPaths.join(", "))
-                              .arg(SettingsHelper::pathOfTestcasesMatchingRules()));
+                              .arg(SettingsHelper::pathOfTestcasesMatchingRules()),
+                          false);
             }
         }
     });

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -409,7 +409,7 @@ void AppWindow::openTab(const QString &path)
         }
     }
 
-    auto newWindow = new MainWindow(path, getNewUntitledIndex(), this);
+    auto newWindow = new MainWindow(path, getNewUntitledIndex(), preferencesWindow, this);
 
     QString lang = SettingsHelper::getDefaultLanguage();
 
@@ -429,7 +429,7 @@ void AppWindow::openTab(const QString &path)
 
 void AppWindow::openTab(const MainWindow::EditorStatus &status, bool duplicate)
 {
-    auto newWindow = new MainWindow(status, duplicate, getNewUntitledIndex(), this);
+    auto newWindow = new MainWindow(status, duplicate, getNewUntitledIndex(), preferencesWindow, this);
     openTab(newWindow);
 }
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1022,7 +1022,7 @@ void AppWindow::onSettingsApplied(const QString &pagePath)
 
     for (int i = 0; i < ui->tabWidget->count(); ++i)
     {
-        windowAt(i)->applySettings(pagePath, i == ui->tabWidget->currentIndex());
+        windowAt(i)->applySettings(pagePath);
         onEditorTextChanged(windowAt(i));
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -133,7 +133,7 @@ void MainWindow::setEditor()
 void MainWindow::setupCore()
 {
     log = new MessageLogger();
-    log->setContainer(ui->compilerEdit);
+    ui->messageLoggerLayout->addWidget(log);
     formatter = new Extensions::ClangFormatter(SettingsHelper::getClangFormatPath(),
                                                SettingsHelper::getClangFormatStyle(), log);
 }
@@ -629,7 +629,7 @@ void MainWindow::applySettings(const QString &pagePath, bool shouldPerformDigoni
 
     if (pageChanged("Appearance/Font"))
     {
-        ui->compilerEdit->setFont(SettingsHelper::getMessageLoggerFont());
+        log->setFont(SettingsHelper::getMessageLoggerFont());
         testcases->setTestCaseEditFont(SettingsHelper::getTestCasesFont());
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -160,6 +160,7 @@ void MainWindow::compile()
     connect(compiler, SIGNAL(compilationFinished(const QString &)), this, SLOT(onCompilationFinished(const QString &)));
     connect(compiler, SIGNAL(compilationErrorOccurred(const QString &)), this,
             SLOT(onCompilationErrorOccurred(const QString &)));
+    connect(compiler, SIGNAL(compilationFailed(const QString &)), this, SLOT(onCompilationFailed(const QString &)));
     connect(compiler, SIGNAL(compilationKilled()), this, SLOT(onCompilationKilled()));
     compiler->start(path, filePath, compileCommand(), language);
 }
@@ -1354,6 +1355,11 @@ void MainWindow::onCompilationErrorOccurred(const QString &error)
                 false);
         }
     }
+}
+
+void MainWindow::onCompilationFailed(const QString &reason)
+{
+    log->error(tr("Compiler"), tr("Failed to start compilation: %1").arg(reason), false);
 }
 
 void MainWindow::onCompilationKilled()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -276,7 +276,7 @@ void MainWindow::setCFToolUI()
         submitToCodeforces->setEnabled(false);
         log->error(tr("CF Tool"),
                    tr("You need to install CF Tool to submit your code to Codeforces. If already installed, you can "
-                      "put it in the PATH environment variable or check your settings at %1.")
+                      "add it in the PATH environment variable or check your settings at %1.")
                        .arg(SettingsHelper::pathOfCFPath()),
                    false);
     }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -143,6 +143,7 @@ class MainWindow : public QMainWindow
     void onCompilationStarted();
     void onCompilationFinished(const QString &warning);
     void onCompilationErrorOccurred(const QString &error);
+    void onCompilationFailed(const QString &reason);
     void onCompilationKilled();
 
     void onRunStarted(int index);

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -21,6 +21,7 @@
 #include <QMainWindow>
 
 class MessageLogger;
+class PreferencesWindow;
 class QCodeEditor;
 class QFileSystemWatcher;
 class QPushButton;
@@ -74,9 +75,10 @@ class MainWindow : public QMainWindow
         QMap<QString, QVariant> toMap() const;
     };
 
-    explicit MainWindow(int index, QWidget *parent);
-    explicit MainWindow(const QString &fileOpen, int index, QWidget *parent);
-    explicit MainWindow(const EditorStatus &status, bool duplicate, int index, QWidget *parent);
+    explicit MainWindow(int index, PreferencesWindow *preferences, QWidget *parent);
+    explicit MainWindow(const QString &fileOpen, int index, PreferencesWindow *preferences, QWidget *parent);
+    explicit MainWindow(const EditorStatus &status, bool duplicate, int index, PreferencesWindow *preferences,
+                        QWidget *parent);
     ~MainWindow() override;
 
     int getUntitledIndex() const;
@@ -228,9 +230,7 @@ class MainWindow : public QMainWindow
     int customTimeLimit = -1;     // the custom time limit for this tab, -1 represents for the same as settings
     QString customCompileCommand; // the custom compile command for this tab, empty represents for the same as settings
 
-    void setTestCases();
     void setEditor();
-    void setupCore();
     void compile();
     void run();
     void run(int index);

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -113,7 +113,7 @@ class MainWindow : public QMainWindow
 
     void setLanguage(const QString &lang);
     QString getLanguage();
-    void applySettings(const QString &pagePath, bool shouldPerformDigonistic);
+    void applySettings(const QString &pagePath);
 
     MessageLogger *getLogger();
     QSplitter *getSplitter();

--- a/tools/genSettings.py
+++ b/tools/genSettings.py
@@ -53,7 +53,6 @@ def writeInfo(f, obj, lst):
         ui = t.get("ui", "")
         tip = t.get("tip", "")
         trtip = t.get("trtip", f"tr({json.dumps(tip)})")
-        hlp = t.get("help", "")
         requireAllDepends = t.get("requireAllDepends", True)
         immediatelyApply = t.get("immediatelyApply", False)
         onApply = f'[](SettingInfo *info, ValueWidget *widget, QWidget *parent){{ {t.get("onApply", "")} }}'
@@ -61,13 +60,11 @@ def writeInfo(f, obj, lst):
         if typename == "Object":
             f.write(f"    QList<SettingInfo> LIST{key};\n")
             writeInfo(f, t["sub"], f"LIST{key}")
-        f.write(f"    {lst}.append(SettingInfo {{{json.dumps(name)}, ")
         if "trdesc" not in t and "notr" not in t:
             for lang in ["C++", "Java", "Python"]:
                 if lang in desc:
                     trdesc = f"tr({json.dumps(desc.replace(lang, '%1'))}).arg(\"{lang}\")"
                     break
-        f.write(trdesc)
         tempname = typename
         if typename == "QMap":
             final = t["final"]
@@ -78,7 +75,7 @@ def writeInfo(f, obj, lst):
         dependsString += "}"
         old = t.get("old", [])
         f.write(
-            f", \"{tempname}\", \"{ui}\", {trtip}, tr({json.dumps(hlp)}), {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, {{{json.dumps(old)[1:-1]}}}, ")
+            f"    {lst}.append(SettingInfo {{{json.dumps(name)}, {trdesc}, {json.dumps(desc)}, \"{tempname}\", \"{ui}\", {trtip}, {json.dumps(tip)}, {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, {{{json.dumps(old)[1:-1]}}}, ")
         if typename != "Object":
             if "default" in t:
                 if typename == "QString":

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -627,6 +627,10 @@ Git commit hash: %3
         <source>The checker is compiled</source>
         <translation>Чекер скомпилирован</translation>
     </message>
+    <message>
+        <source>Failed to compile the checker: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Core::Compiler</name>
@@ -643,7 +647,7 @@ Git commit hash: %3
         <translation>Неподдерживаемый язык программирования &quot;%1&quot;</translation>
     </message>
     <message>
-        <source>Failed to start compilation. Please check %1 or add the compiler in the PATH environment variable.</source>
+        <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1177,6 +1181,10 @@ Do you want to reload it?</source>
     </message>
     <message>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start compilation: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -639,15 +639,15 @@ Git commit hash: %3
         <translation>Файл [%1] не существует</translation>
     </message>
     <message>
-        <source>The compile command for %1 is empty</source>
-        <translation>Команады компиляции для %1 пуста</translation>
-    </message>
-    <message>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Неподдерживаемый язык программирования &quot;%1&quot;</translation>
     </message>
     <message>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 is empty</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -643,8 +643,8 @@ Git commit hash: %3
         <translation>Неподдерживаемый язык программирования &quot;%1&quot;</translation>
     </message>
     <message>
-        <source>Failed to start compilation. Please check the compile command in the settings.</source>
-        <translation>Ошибка при старте компиляции. Пожалуйста, проверьте команды компиляции в настройках.</translation>
+        <source>Failed to start compilation. Please check %1 or add the compiler in the PATH environment variable.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -962,10 +962,6 @@ p, li { white-space: pre-wrap; }
         <translation>Ошибка в сохранении временного файла. Решение не было отправлено.</translation>
     </message>
     <message>
-        <source>You will not be able to submit code to Codeforces because CF Tool is not installed or is not on SYSTEM PATH. You can set it manually in settings.</source>
-        <translation>Вы не можете отправить решение на Codeforces, потому что CF Tool не установлен или не добавлен в переменные окружения. Пожалуйста, установите его вручную в настройках.</translation>
-    </message>
-    <message>
         <source>Untitled-%1</source>
         <translation>Неизвестный-%1</translation>
     </message>
@@ -1050,14 +1046,6 @@ Do you want to reload it?</source>
     <message>
         <source>%1 characters selected</source>
         <translation>Выбрано %1 символов</translation>
-    </message>
-    <message>
-        <source>The compile command for %1 is invalid. Is the compiler in the system PATH?</source>
-        <translation>Команда компиляции %1 неверна. Добавлен ли компилятор в PATH?</translation>
-    </message>
-    <message>
-        <source>The run command for %1 is invalid. Is the runner in the system Path?</source>
-        <translation>Запускающая команда %1 неверна. Находится ли runner в Path?</translation>
     </message>
     <message>
         <source>Compilation has started</source>
@@ -1186,6 +1174,10 @@ Do you want to reload it?</source>
     <message>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Нестандартный лимит времени для этой вкладки: (в мс)</translation>
+    </message>
+    <message>
+        <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2788,20 +2780,16 @@ A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Ожидаемо</translation>
     </message>
     <message>
-        <source>Now the test case editor is read-only. You can set the length limit at %1.</source>
-        <translation>Сейчас тесткейсы доступны только для чтения. Вы можете установить лимит длины в %1.</translation>
-    </message>
-    <message>
-        <source>Only the first %1 characters are shown.</source>
-        <translation>Отображены только первые %1 символов.</translation>
-    </message>
-    <message>
         <source>Save to file</source>
         <translation>Сохранить в файл</translation>
     </message>
     <message>
         <source>Save test case to file</source>
         <translation>Сохранить тесткейс в файл</translation>
+    </message>
+    <message>
+        <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
+        <translation>Отображены только первые %1 символов. Сейчас тесткейсы доступны только для чтения. Вы можете установить лимит длины в %2.</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -627,6 +627,10 @@ git 提交编号: %3
         <source>The checker is compiled</source>
         <translation>评测器编译完成</translation>
     </message>
+    <message>
+        <source>Failed to compile the checker: %1</source>
+        <translation>未能成功编译评测器：%1</translation>
+    </message>
 </context>
 <context>
     <name>Core::Compiler</name>
@@ -643,8 +647,8 @@ git 提交编号: %3
         <translation>编程语言“%1”不受支持</translation>
     </message>
     <message>
-        <source>Failed to start compilation. Please check %1 or add the compiler in the PATH environment variable.</source>
-        <translation>未能成功编译。请检查 %1 或者将编译器添加到 PATH 环境变量中。</translation>
+        <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
+        <translation>未能启动编译器。请检查 %1 或将编译器添加到 PATH 环境变量中。</translation>
     </message>
 </context>
 <context>
@@ -1178,6 +1182,10 @@ Do you want to reload it?</source>
     <message>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>你需要安装 CF Tool 以将代码提交到 Codeforces。如果你已经安装了，你可以将它添加到 PATH 环境变量中，或者检查 %1 处的设置。</translation>
+    </message>
+    <message>
+        <source>Failed to start compilation: %1</source>
+        <translation>未能开始编译：%1</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -643,8 +643,8 @@ git 提交编号: %3
         <translation>编程语言“%1”不受支持</translation>
     </message>
     <message>
-        <source>Failed to start compilation. Please check the compile command in the settings.</source>
-        <translation>未能成功启动编译。请在设置中检查编译命令。</translation>
+        <source>Failed to start compilation. Please check %1 or add the compiler in the PATH environment variable.</source>
+        <translation>未能成功编译。请检查 %1 或者将编译器添加到 PATH 环境变量中。</translation>
     </message>
 </context>
 <context>
@@ -962,10 +962,6 @@ p, li { white-space: pre-wrap; }
         <translation>保存临时文件失败，代码未提交。</translation>
     </message>
     <message>
-        <source>You will not be able to submit code to Codeforces because CF Tool is not installed or is not on SYSTEM PATH. You can set it manually in settings.</source>
-        <translation>你无法将代码提交至 Codeforces，因为 CF Tool 没有安装，或是它不在 PATH 环境变量里。你可以在设置中手动设置 CF Tool 的路径。</translation>
-    </message>
-    <message>
         <source>Untitled-%1</source>
         <translation>未命名-%1</translation>
     </message>
@@ -1050,14 +1046,6 @@ Do you want to reload it?</source>
     <message>
         <source>%1 characters selected</source>
         <translation>共有 %1 个字符被选择</translation>
-    </message>
-    <message>
-        <source>The compile command for %1 is invalid. Is the compiler in the system PATH?</source>
-        <translation>语言 %1 的编译命令不可用。编译器是否在环境变量 PATH 中？</translation>
-    </message>
-    <message>
-        <source>The run command for %1 is invalid. Is the runner in the system Path?</source>
-        <translation>语言 %1 的运行命令不可用。解释器是否在环境变量 PATH 中？</translation>
     </message>
     <message>
         <source>Compilation has started</source>
@@ -1186,6 +1174,10 @@ Do you want to reload it?</source>
     <message>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>这个标签页的自定义时间限制：(毫秒)</translation>
+    </message>
+    <message>
+        <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation>你需要安装 CF Tool 以将代码提交到 Codeforces。如果你已经安装了，你可以将它添加到 PATH 环境变量中，或者检查 %1 处的设置。</translation>
     </message>
 </context>
 <context>
@@ -2780,20 +2772,16 @@ A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>答案</translation>
     </message>
     <message>
-        <source>Now the test case editor is read-only. You can set the length limit at %1.</source>
-        <translation>现在测试用例编辑器是只读的。你可以在 %1 中设置长度限制。</translation>
-    </message>
-    <message>
-        <source>Only the first %1 characters are shown.</source>
-        <translation>只显示了前 %1 个字符。</translation>
-    </message>
-    <message>
         <source>Save to file</source>
         <translation>保存到文件</translation>
     </message>
     <message>
         <source>Save test case to file</source>
         <translation>将测试用例保存到文件</translation>
+    </message>
+    <message>
+        <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
+        <translation>只显示了前 %1 个字符。现在测试用例编辑器是只读的。你可以在 %2 中设置长度限制。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -639,16 +639,16 @@ git 提交编号: %3
         <translation>源文件 [%1] 不存在</translation>
     </message>
     <message>
-        <source>The compile command for %1 is empty</source>
-        <translation>%1 的编译命令为空</translation>
-    </message>
-    <message>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>编程语言“%1”不受支持</translation>
     </message>
     <message>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>未能启动编译器。请检查 %1 或将编译器添加到 PATH 环境变量中。</translation>
+    </message>
+    <message>
+        <source>%1 is empty</source>
+        <translation>%1 为空</translation>
     </message>
 </context>
 <context>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -141,7 +141,9 @@
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
-            <widget class="QTextBrowser" name="compilerEdit"/>
+            <widget class="QWidget" name="messageLoggerWidget">
+             <layout class="QVBoxLayout" name="messageLoggerLayout"/>
+            </widget>
             <widget class="QWidget" name="testCasesWidget">
              <layout class="QVBoxLayout" name="testCasesLayout"/>
             </widget>


### PR DESCRIPTION
## Description

1. Link to the settings in the message logger, in the messages containing the path of the setting.
2. Remove diagnostics (which is not very related, but I decided to do this when trying to modify the messages of it).
3. Improve some messages.
4. Some other refactors.

## Motivation and Context

Make it easy to find the settings you need to change, especially for new users.

## How Has This Been Tested?

On Arch Linux and Windows 10.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30581822/98394472-c6a74900-2095-11eb-97ac-3649ac6a18e7.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text

@IZOBRETATEL777 please update the translations.
