### PR TITLE
feat(Window): Toggle Fullscreen with F11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 -   Now you can opt-in non-monospaced fonts when choosing a font in the Preferences. (#217 and #625)
+- 	Now you can Toggle window Full Screen by Pressing F11. (#642 and #660)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 -   Now you can opt-in non-monospaced fonts when choosing a font in the Preferences. (#217 and #625)
-- 	Now you can toggle fullscreen mode by pressing F11. (#642 and #660)
+-   Now you can toggle fullscreen mode by pressing F11. (#642 and #660)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 -   Now you can opt-in non-monospaced fonts when choosing a font in the Preferences. (#217 and #625)
-- 	Now you can Toggle window Full Screen by Pressing F11. (#642 and #660)
+- 	Now you can toggle fullscreen mode by pressing F11. (#642 and #660)
 
 ### Fixed
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -349,6 +349,13 @@ void AppWindow::maybeSetHotkeys()
         hotkeyObjects.push_back(
             new QShortcut(SettingsHelper::getHotkeySnippets(), this, SLOT(on_actionUseSnippets_triggered())));
     }
+
+    hotkeyObjects.push_back(new QShortcut(Qt::Key_F11, this, [this] {
+        if (!isFullScreen())
+            showFullScreen();
+        else
+            showNormal();
+    }));
 }
 
 bool AppWindow::closeTab(int index)

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -350,20 +350,8 @@ void AppWindow::maybeSetHotkeys()
             new QShortcut(SettingsHelper::getHotkeySnippets(), this, SLOT(on_actionUseSnippets_triggered())));
     }
 
-    hotkeyObjects.push_back(new QShortcut(Qt::Key_F11, this, [this] {
-        if (!isFullScreen())
-        {
-            wasMaximized = isMaximized();
-            showFullScreen();
-        }
-        else
-        {
-            if (wasMaximized)
-                showMaximized();
-            else
-                showNormal();
-        }
-    }));
+    hotkeyObjects.push_back(
+        new QShortcut(Qt::Key_F11, this, [this] { setWindowState(windowState() ^ Qt::WindowFullScreen); }));
 }
 
 bool AppWindow::closeTab(int index)

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -352,9 +352,17 @@ void AppWindow::maybeSetHotkeys()
 
     hotkeyObjects.push_back(new QShortcut(Qt::Key_F11, this, [this] {
         if (!isFullScreen())
+        {
+            wasMaximized = isMaximized();
             showFullScreen();
+        }
         else
-            showNormal();
+        {
+            if (wasMaximized)
+                showMaximized();
+            else
+                showNormal();
+        }
     }));
 }
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -352,6 +352,9 @@ void AppWindow::maybeSetHotkeys()
 
     hotkeyObjects.push_back(
         new QShortcut(Qt::Key_F11, this, [this] { setWindowState(windowState() ^ Qt::WindowFullScreen); }));
+
+    hotkeyObjects.push_back(
+        new QShortcut(Qt::Key_Escape, this, [this] { setWindowState(windowState() & ~Qt::WindowFullScreen); }));
 }
 
 bool AppWindow::closeTab(int index)

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -222,6 +222,7 @@ class AppWindow : public QMainWindow
     QSystemTrayIcon *trayIcon = nullptr;
     QMenu *trayIconMenu = nullptr;
     QMenu *tabMenu = nullptr;
+    bool wasMaximized;
 
     Extensions::LanguageServer *cppServer = nullptr;
     Extensions::LanguageServer *javaServer = nullptr;

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -222,7 +222,6 @@ class AppWindow : public QMainWindow
     QSystemTrayIcon *trayIcon = nullptr;
     QMenu *trayIconMenu = nullptr;
     QMenu *tabMenu = nullptr;
-    bool wasMaximized;
 
     Extensions::LanguageServer *cppServer = nullptr;
     Extensions::LanguageServer *javaServer = nullptr;


### PR DESCRIPTION
Toggle full screen by Pressing <kbd>F11</kbd> 

## Description
<!--- Describe your changes in detail -->

## Related Issues / Pull Requests
Fixes #642 

## Motivation and Context
Better editing on Smaller screens

## How Has This Been Tested?
Arch on KDE [works]
Windows 10 [Animation to restore to maximized state is bad]

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
N/A
