### PR TITLE
fix: repaint after the progress dialog

### DIFF
--- a/src/Core/SessionManager.cpp
+++ b/src/Core/SessionManager.cpp
@@ -98,6 +98,7 @@ void SessionManager::restoreSession(const QString &path)
     }
 
     app->setUpdatesEnabled(true);
+    app->repaint();
     app->resize(oldSize);
 
     if (currentIndex >= 0 && currentIndex < app->ui->tabWidget->count())

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -463,6 +463,7 @@ void AppWindow::openTabs(const QStringList &paths)
     }
 
     setUpdatesEnabled(true);
+    repaint();
     resize(oldSize);
 
     progress.setValue(length);


### PR DESCRIPTION
## Description

Repaint after the progress dialog.

## Motivation and Context

The window was sometimes blank after the progress dialog on Windows.

## How Has This Been Tested?

On Windows 10.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).