### PR TITLE
refactor: validate test case indices

### DIFF
--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -33,6 +33,8 @@
 #include <QSet>
 #include <QVBoxLayout>
 
+#define VALIDATE_INDEX(x) validateIndex(x, __func__)
+
 namespace Widgets
 {
 const int TestCases::MAX_NUMBER_OF_TESTCASES;
@@ -218,17 +220,20 @@ TestCases::TestCases(MessageLogger *logger, QWidget *parent) : QWidget(parent), 
 
 void TestCases::setInput(int index, const QString &input)
 {
-    testcases[index]->setInput(input);
+    if (VALIDATE_INDEX(index))
+        testcases[index]->setInput(input);
 }
 
 void TestCases::setOutput(int index, const QString &output)
 {
-    testcases[index]->setOutput(output);
+    if (VALIDATE_INDEX(index))
+        testcases[index]->setOutput(output);
 }
 
 void TestCases::setExpected(int index, const QString &expected)
 {
-    testcases[index]->setExpected(expected);
+    if (VALIDATE_INDEX(index))
+        testcases[index]->setExpected(expected);
 }
 
 void TestCases::addTestCase(const QString &input, const QString &expected)
@@ -266,23 +271,23 @@ void TestCases::clear()
 
 QString TestCases::input(int index) const
 {
-    return testcases[index]->input();
+    return VALIDATE_INDEX(index) ? testcases[index]->input() : QString();
 }
 
 QString TestCases::output(int index) const
 {
-    return testcases[index]->output();
+    return VALIDATE_INDEX(index) ? testcases[index]->output() : QString();
 }
 
 QString TestCases::expected(int index) const
 {
-    return testcases[index]->expected();
+    return VALIDATE_INDEX(index) ? testcases[index]->expected() : QString();
 }
 
 void TestCases::loadStatus(const QStringList &inputList, const QStringList &expectedList)
 {
     clear();
-    for (int i = 0; i < inputList.length(); ++i)
+    for (int i = 0; i < inputList.length() && i < expectedList.length(); ++i)
         addTestCase(inputList[i], expectedList[i]);
 }
 
@@ -455,18 +460,22 @@ Core::Checker::CheckerType TestCases::checkerType() const
 
 void TestCases::setShow(int index, bool show)
 {
-    testcases[index]->setShow(show);
+    if (VALIDATE_INDEX(index))
+        testcases[index]->setShow(show);
 }
 
 bool TestCases::isShow(int index) const
 {
-    return testcases[index]->isShow();
+    return VALIDATE_INDEX(index) ? testcases[index]->isShow() : false;
 }
 
 void TestCases::setVerdict(int index, TestCase::Verdict verdict)
 {
-    testcases[index]->setVerdict(verdict);
-    updateVerdicts();
+    if (VALIDATE_INDEX(index))
+    {
+        testcases[index]->setVerdict(verdict);
+        updateVerdicts();
+    }
 }
 
 void TestCases::on_addButton_clicked()
@@ -495,6 +504,17 @@ void TestCases::onChildDeleted(TestCase *widget)
     for (int i = 0; i < count(); ++i)
         testcases[i]->setID(i);
     updateVerdicts();
+}
+
+bool TestCases::validateIndex(int index, const QString &funcName) const
+{
+    if (index >= 0 && index < count())
+        return true;
+    else
+    {
+        Core::Log::log("WARN ", funcName, __LINE__, __FILE__) << INFO_OF(index) << INFO_OF(count()) << Qt::endl;
+        return false;
+    }
 }
 
 void TestCases::updateVerdicts()

--- a/src/Widgets/TestCases.cpp
+++ b/src/Widgets/TestCases.cpp
@@ -513,7 +513,7 @@ bool TestCases::validateIndex(int index, const QString &funcName) const
         return true;
     else
     {
-        Core::Log::log("WARN ", funcName, __LINE__, __FILE__) << INFO_OF(index) << INFO_OF(count()) << Qt::endl;
+        LOG_DEV(INFO_OF(index) << INFO_OF(count()) << INFO_OF(funcName));
         return false;
     }
 }

--- a/src/Widgets/TestCases.hpp
+++ b/src/Widgets/TestCases.hpp
@@ -97,6 +97,12 @@ class TestCases : public QWidget
     void onChildDeleted(TestCase *widget);
 
   private:
+    bool validateIndex(int index, const QString &funcName) const;
+    void updateVerdicts();
+    static QString inputFilePath(const QString &filePath, int index);
+    static QString answerFilePath(const QString &filePath, int index);
+    static QString testCaseFilePath(QString rule, const QString &filePath, int index);
+
     static const int MAX_NUMBER_OF_TESTCASES = 100;
     QVBoxLayout *mainLayout = nullptr, *scrollAreaLayout = nullptr;
     QHBoxLayout *titleLayout = nullptr, *checkerLayout = nullptr;
@@ -109,11 +115,6 @@ class TestCases : public QWidget
     QList<TestCase *> testcases;
     MessageLogger *log;
     bool choosingChecker = false;
-
-    void updateVerdicts();
-    QString inputFilePath(const QString &filePath, int index);
-    QString answerFilePath(const QString &filePath, int index);
-    QString testCaseFilePath(QString rule, const QString &filePath, int index);
 };
 } // namespace Widgets
 #endif // TESTCASES_HPP

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -201,6 +201,12 @@ void MainWindow::run()
 
 void MainWindow::run(int index)
 {
+    if (index < 0 || index >= testcases->count())
+    {
+        LOG_WARN(INFO_OF(index) << INFO_OF(testcases->count()));
+        return;
+    }
+
     auto tmp = new Core::Runner(index);
     connect(tmp, SIGNAL(runStarted(int)), this, SLOT(onRunStarted(int)));
     connect(tmp, SIGNAL(runFinished(int, const QString &, const QString &, int, int, bool)), this,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -200,7 +200,7 @@ void MainWindow::run(int index)
 {
     if (index < 0 || index >= testcases->count())
     {
-        LOG_WARN(INFO_OF(index) << INFO_OF(testcases->count()));
+        LOG_DEV(INFO_OF(index) << INFO_OF(testcases->count()));
         return;
     }
 


### PR DESCRIPTION
## Description

Validate test case indices.

## Motivation and Context

Make it safer.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
