### PR TITLE
feat: add LOG_DEV and some warnings

### DIFF
--- a/src/Core/EventLogger.cpp
+++ b/src/Core/EventLogger.cpp
@@ -35,7 +35,7 @@ QTextStream Log::logStream;
 
 int Log::NUMBER_OF_LOGS_TO_KEEP = 50;
 int Log::MAXIMUM_FUNCTION_NAME_SIZE = 30;
-int Log::MAXIMUM_FILE_NAME_SIZE = 20;
+int Log::MAXIMUM_FILE_NAME_SIZE = 30;
 QString Log::LOG_DIR_NAME = "cpeditorLogFiles";
 QString Log::LOG_FILE_NAME = "cpeditor";
 

--- a/src/Core/EventLogger.hpp
+++ b/src/Core/EventLogger.hpp
@@ -23,6 +23,9 @@
 #ifndef EVENTLOGGER_HPP
 #define EVENTLOGGER_HPP
 
+#ifdef QT_DEBUG
+#include <QDebug>
+#endif
 #include <QTextStream>
 
 class QFile;
@@ -63,6 +66,16 @@ class QFile;
     {                                                                                                                  \
         LOG_WTF(stream)                                                                                                \
     }
+
+#ifdef QT_DEBUG
+#define LOG_DEV(stream)                                                                                                \
+    {                                                                                                                  \
+        qDebug() << "File: [" __FILE__ "] Func: [" << __func__ << "] Line: [" << __LINE__ << "] " << stream;           \
+        LOG_WARN(stream);                                                                                              \
+    }
+#else
+#define LOG_DEV LOG_WARN
+#endif
 
 #define INFO_OF(variable) "<" #variable ">: [" << (variable) << "], "
 #define BOOL_INFO_OF(variable) "<" #variable ">: [" << ((variable) ? "true" : "false") << "], "

--- a/src/Settings/DefaultPathManager.cpp
+++ b/src/Settings/DefaultPathManager.cpp
@@ -19,7 +19,6 @@
 #include "Core/EventLogger.hpp"
 #include "Settings/SettingsManager.hpp"
 #include "generated/SettingsHelper.hpp"
-#include <QDebug>
 #include <QFileInfo>
 #include <QRegularExpression>
 
@@ -41,8 +40,7 @@ void DefaultPathManager::setDefaultPathForAction(const QString &action, const QS
 
     if (!SettingsManager::contains(settingsKey, true))
     {
-        qDebug() << "Unknown Action:" << action;
-        LOG_ERR("Unknown Action");
+        LOG_DEV("Unknown Action: " << action);
         return;
     }
 

--- a/src/Settings/PreferencesHomePage.cpp
+++ b/src/Settings/PreferencesHomePage.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "Settings/PreferencesHomePage.hpp"
+#include "Core/EventLogger.hpp"
+#include "Settings/PreferencesWindow.hpp"
 #include "generated/version.hpp"
 #include <QLabel>
 #include <QPixmap>
@@ -23,9 +25,12 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
-PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
+PreferencesHomePage::PreferencesHomePage(PreferencesWindow *parent) : QWidget(parent), preferencesWindow(parent)
 {
-    // construct the layout
+}
+
+void PreferencesHomePage::init()
+{
     layout = new QVBoxLayout(this);
 
     layout->addSpacing(20);
@@ -77,6 +82,8 @@ PreferencesHomePage::PreferencesHomePage(QWidget *parent) : QWidget(parent)
 
 void PreferencesHomePage::addButton(const QString &page, const QString &text)
 {
+    if (!preferencesWindow->pathExists(page))
+        LOG_DEV("Unknown path: " << page);
     auto button = new QPushButton(text, this);
     connect(button, &QPushButton::clicked, [this, page]() { emit requestPage(page); });
     layout->addWidget(button);

--- a/src/Settings/PreferencesHomePage.hpp
+++ b/src/Settings/PreferencesHomePage.hpp
@@ -25,6 +25,7 @@
 
 #include <QWidget>
 
+class PreferencesWindow;
 class QLabel;
 class QPushButton;
 class QVBoxLayout;
@@ -37,7 +38,9 @@ class PreferencesHomePage : public QWidget
     /**
      * @brief construct a PreferencesHomePage
      */
-    explicit PreferencesHomePage(QWidget *parent = nullptr);
+    explicit PreferencesHomePage(PreferencesWindow *parent);
+
+    void init();
 
   signals:
     /**
@@ -54,7 +57,8 @@ class PreferencesHomePage : public QWidget
      */
     void addButton(const QString &pagePath, const QString &text);
 
-    QVBoxLayout *layout = nullptr; // the main layout
+    QVBoxLayout *layout = nullptr;
+    PreferencesWindow *preferencesWindow = nullptr;
 };
 
 #endif // PREFERENCESHOMEPAGE_HPP

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -16,11 +16,11 @@
  */
 
 #include "Settings/PreferencesPageTemplate.hpp"
+#include "Core/EventLogger.hpp"
 #include "Settings/SettingsInfo.hpp"
 #include "Settings/SettingsManager.hpp"
 #include "Settings/ValueWrapper.hpp"
 #include <QCheckBox>
-#include <QDebug>
 
 PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop, QWidget *parent)
     : PreferencesGridPage(alignTop, parent), options(opts)
@@ -28,10 +28,8 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
     for (const QString &name : options)
     {
         auto si = SettingsInfo::findSetting(name);
-#ifdef QT_DEBUG
         if (name != si.name)
-            qDebug() << "Unknown option" << name;
-#endif
+            LOG_DEV("Unknown option: " << name);
         if (si.type == "QString")
         {
             Wrapper<QString> *wrapper = createStringWrapper(si.ui);
@@ -94,7 +92,7 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, bool alignTop
         {
             if (!options.contains(depend.first))
             {
-                qDebug() << name << " depends on unknown option " << depend.first;
+                LOG_DEV(name << " depends on unknown option " << depend.first);
                 continue;
             }
             auto dependWidget = widgets[options.indexOf(depend.first)];

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -143,7 +143,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
     stackedWidget = new QStackedWidget();
     splitter->addWidget(stackedWidget);
 
-    homePage = new PreferencesHomePage();
+    homePage = new PreferencesHomePage(this);
     connect(homePage, &PreferencesHomePage::requestPage,
             [this](const QString &path) { switchToPage(getPageWidget(path)); });
     stackedWidget->addWidget(homePage);
@@ -257,6 +257,13 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 #undef TRKEY
 
     // clang-format on
+
+    homePage->init();
+}
+
+bool PreferencesWindow::pathExists(const QString &pagePath) const
+{
+    return getPageWidget(pagePath) != nullptr;
 }
 
 void PreferencesWindow::display()
@@ -334,11 +341,20 @@ void PreferencesWindow::addPage(QTreeWidgetItem *item, PreferencesPage *page, co
     connect(page, SIGNAL(settingsApplied(const QString &)), this, SIGNAL(settingsApplied(const QString &)));
 }
 
-PreferencesPage *PreferencesWindow::getPageWidget(const QString &pagePath)
+PreferencesPage *PreferencesWindow::getPageWidget(const QString &pagePath) const
 {
     auto parts = pagePath.split('/');
     for (QString &name : parts)
-        name = treeEntryTranslation[name];
+    {
+        if (treeEntryTranslation.contains(name))
+        {
+            name = treeEntryTranslation[name];
+        }
+        else
+        {
+            LOG_DEV("Can't find translation of " << name);
+        }
+    }
 
     QTreeWidgetItem *current = getTopLevelItem(parts.front());
 
@@ -350,7 +366,10 @@ PreferencesPage *PreferencesWindow::getPageWidget(const QString &pagePath)
     {
         QTreeWidgetItem *nxt = getChild(current, parts[i]);
         if (nxt == nullptr)
+        {
+            LOG_DEV("Can't find path: " << pagePath);
             return nullptr;
+        }
         current = nxt;
     }
 
@@ -428,7 +447,7 @@ void PreferencesWindow::updateSearch(QTreeWidgetItem *item, const QString &text)
     item->setHidden(shouldHide);
 }
 
-QTreeWidgetItem *PreferencesWindow::getTopLevelItem(const QString &text)
+QTreeWidgetItem *PreferencesWindow::getTopLevelItem(const QString &text) const
 {
     for (int i = 0; i < menuTree->topLevelItemCount(); ++i)
     {
@@ -438,10 +457,11 @@ QTreeWidgetItem *PreferencesWindow::getTopLevelItem(const QString &text)
             return item;
         }
     }
+    LOG_DEV("Can't find top level item: " << text);
     return nullptr;
 }
 
-QTreeWidgetItem *PreferencesWindow::getChild(QTreeWidgetItem *item, const QString &text)
+QTreeWidgetItem *PreferencesWindow::getChild(QTreeWidgetItem *item, const QString &text) const
 {
     for (int i = 0; i < item->childCount(); ++i)
     {
@@ -454,7 +474,7 @@ QTreeWidgetItem *PreferencesWindow::getChild(QTreeWidgetItem *item, const QStrin
     return nullptr;
 }
 
-int PreferencesWindow::nextNonHiddenPage(int index, int direction, bool includingSelf)
+int PreferencesWindow::nextNonHiddenPage(int index, int direction, bool includingSelf) const
 {
     if (index < 0 || index >= stackedWidget->count())
     {

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -74,6 +74,11 @@ class PreferencesWindow : public QMainWindow
      */
     explicit PreferencesWindow(QWidget *parent);
 
+    /**
+     * @brief check if *pagePath* is a valid settings page path
+     */
+    bool pathExists(const QString &pagePath) const;
+
   public slots:
     /**
      * @brief switch to home and show up
@@ -112,7 +117,7 @@ class PreferencesWindow : public QMainWindow
      * @param pagePath the path to the page
      * @returns returns the widget if it's found, otherwise returns nullptr
      */
-    PreferencesPage *getPageWidget(const QString &pagePath);
+    PreferencesPage *getPageWidget(const QString &pagePath) const;
 
     /**
      * @brief if there are unsaved changes, ask the user to save/discard the changes or cancel the close
@@ -130,13 +135,13 @@ class PreferencesWindow : public QMainWindow
      * @brief get the top level item with the text *text*
      * @returns the top level item or nullptr if not found
      */
-    QTreeWidgetItem *getTopLevelItem(const QString &text);
+    QTreeWidgetItem *getTopLevelItem(const QString &text) const;
 
     /**
      * @brief get the child of *item* with text *text*
      * @returns the child or nullptr if not found
      */
-    QTreeWidgetItem *getChild(QTreeWidgetItem *item, const QString &text);
+    QTreeWidgetItem *getChild(QTreeWidgetItem *item, const QString &text) const;
 
     /**
      * @brief get the index of the next/previous non-hidden page (including the home page)
@@ -145,7 +150,7 @@ class PreferencesWindow : public QMainWindow
      * @param includingSelf when it's true, the result can be the current page
      * @returns the index of the (strictly) next/previous non-hidden page in the stackedWidget
      */
-    int nextNonHiddenPage(int index, int direction = 1, bool includingSelf = false);
+    int nextNonHiddenPage(int index, int direction = 1, bool includingSelf = false) const;
 
     /**
      * The GUI:

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -21,7 +21,6 @@
 #include "Settings/SettingsUpdater.hpp"
 #include "Util/FileUtil.hpp"
 #include "generated/portable.hpp"
-#include <QDebug>
 #include <QFile>
 #include <QFont>
 #include <QRect>
@@ -168,11 +167,8 @@ QVariant SettingsManager::get(QString key, bool alwaysDefault)
         return def->value(key);
     else
     {
-#ifdef QT_DEBUG
         if (!noUnknownKeyWarning.contains(key))
-            qDebug() << "Settings: getting unknown key: " << key;
-#endif
-        LOG_WARN("SettingsManager::getting unknown key: " << key);
+            LOG_DEV("getting unknown key: " << key);
         return QVariant();
     }
 }
@@ -208,10 +204,7 @@ QString SettingsManager::getPathText(const QString &key, bool parent)
 {
     if (!settingPath->contains(key))
     {
-#ifdef QT_DEBUG
-        qDebug() << "SettingsManager: Getting unknown key path: " << key;
-#endif
-        LOG_WARN("Getting unknown key path: " << key);
+        LOG_DEV("Getting unknown key path: " << key);
         return "Unknown";
     }
     auto nodes = settingPath->value(key).split('/');

--- a/src/Settings/SettingsUpdater.cpp
+++ b/src/Settings/SettingsUpdater.cpp
@@ -19,7 +19,6 @@
 #include "Core/SessionManager.hpp"
 #include "Settings/SettingsManager.hpp"
 #include "generated/SettingsHelper.hpp"
-#include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -213,6 +213,11 @@ void AppWindow::dragEnterEvent(QDragEnterEvent *event)
     }
 }
 
+PreferencesWindow *AppWindow::getPreferencesWindow() const
+{
+    return preferencesWindow;
+}
+
 void AppWindow::dropEvent(QDropEvent *event)
 {
     LOG_INFO("Files are being dropped to editor");
@@ -415,7 +420,7 @@ void AppWindow::openTab(const QString &path)
         }
     }
 
-    auto newWindow = new MainWindow(path, getNewUntitledIndex(), preferencesWindow, this);
+    auto newWindow = new MainWindow(path, getNewUntitledIndex(), this);
 
     QString lang = SettingsHelper::getDefaultLanguage();
 
@@ -435,7 +440,7 @@ void AppWindow::openTab(const QString &path)
 
 void AppWindow::openTab(const MainWindow::EditorStatus &status, bool duplicate)
 {
-    auto newWindow = new MainWindow(status, duplicate, getNewUntitledIndex(), preferencesWindow, this);
+    auto newWindow = new MainWindow(status, duplicate, getNewUntitledIndex(), this);
     openTab(newWindow);
 }
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1033,7 +1033,11 @@ void AppWindow::onSettingsApplied(const QString &pagePath)
         onEditorTextChanged(windowAt(i));
     }
 
-    auto pageChanged = [pagePath](const QString &page) { return pagePath.isEmpty() || pagePath == page; };
+    auto pageChanged = [this, pagePath](const QString &page) {
+        if (!preferencesWindow->pathExists(page))
+            LOG_DEV("Unknown path: " << page);
+        return pagePath.isEmpty() || pagePath == page;
+    };
 
     if (pageChanged("Key Bindings"))
         maybeSetHotkeys();

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -68,6 +68,8 @@ class AppWindow : public QMainWindow
     void dropEvent(QDropEvent *event) override;
     void dragEnterEvent(QDragEnterEvent *event) override;
 
+    PreferencesWindow *getPreferencesWindow() const;
+
   public slots:
     void onReceivedMessage(quint32 instanceId, QByteArray message);
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -20,8 +20,8 @@
 
 #include <QMainWindow>
 
+class AppWindow;
 class MessageLogger;
-class PreferencesWindow;
 class QCodeEditor;
 class QFileSystemWatcher;
 class QPushButton;
@@ -75,10 +75,9 @@ class MainWindow : public QMainWindow
         QMap<QString, QVariant> toMap() const;
     };
 
-    explicit MainWindow(int index, PreferencesWindow *preferences, QWidget *parent);
-    explicit MainWindow(const QString &fileOpen, int index, PreferencesWindow *preferences, QWidget *parent);
-    explicit MainWindow(const EditorStatus &status, bool duplicate, int index, PreferencesWindow *preferences,
-                        QWidget *parent);
+    explicit MainWindow(int index, AppWindow *parent);
+    explicit MainWindow(const QString &fileOpen, int index, AppWindow *parent);
+    explicit MainWindow(const EditorStatus &status, bool duplicate, int index, AppWindow *parent);
     ~MainWindow() override;
 
     int getUntitledIndex() const;
@@ -211,7 +210,7 @@ class MainWindow : public QMainWindow
 
     MessageLogger *log = nullptr;
 
-    PreferencesWindow *preferencesWindow = nullptr;
+    AppWindow *appWindow = nullptr;
 
     int untitledIndex;
     QString problemURL;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -211,6 +211,8 @@ class MainWindow : public QMainWindow
 
     MessageLogger *log = nullptr;
 
+    PreferencesWindow *preferencesWindow = nullptr;
+
     int untitledIndex;
     QString problemURL;
     QString filePath;


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description

1. Add `LOG_DEV` which can be used to check for settings path, etc. which are often mistyped or forgot to update.
2. Check the links on the preferences home page.

## How Has This Been Tested?

On Arch Linux with both debug build and release build.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

