### PR TITLE
fix(PreferencesWindow): fix warnings when clicking links to settings

### DIFF
--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -147,7 +147,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     homePage = new PreferencesHomePage(this);
     connect(homePage, &PreferencesHomePage::requestPage,
-            [this](const QString &path) { switchToPage(getPageWidget(path)); });
+            [this](const QString &path) { switchToPage(getPageWidget(path, false)); });
     stackedWidget->addWidget(homePage);
 
     splitter->setSizes({10000, 30000});
@@ -265,7 +265,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
 bool PreferencesWindow::pathExists(const QString &pagePath) const
 {
-    return getPageWidget(pagePath) != nullptr;
+    return getPageWidget(pagePath, false) != nullptr;
 }
 
 void PreferencesWindow::display()
@@ -286,25 +286,24 @@ void PreferencesWindow::display()
 
 void PreferencesWindow::open(const QString &path)
 {
-    for (auto nodes = path.split('/'); !nodes.isEmpty(); nodes.removeLast())
+    auto page = getPageWidget(path, true);
+
+    if (page == nullptr)
     {
-        auto page = getPageWidget(nodes.join('/'));
-        if (page != nullptr)
-        {
-            if (isHidden())
-                display();
-            else
-                Util::showWidgetOnTop(this);
-            if (switchToPage(page))
-            {
-                auto widget = SettingsManager::getWidget(SettingsManager::getKeyOfPath(path));
-                if (widget != nullptr)
-                    widget->setFocus(Qt::PopupFocusReason);
-                return;
-            }
-        }
+        LOG_DEV("Can't find the given path: " << INFO_OF(path));
+        return;
     }
-    LOG_WARN("Can't find the given path: " << INFO_OF(path));
+
+    if (isHidden())
+        display();
+    else
+        Util::showWidgetOnTop(this);
+    if (switchToPage(page))
+    {
+        auto widget = SettingsManager::getWidget(SettingsManager::getKeyOfPath(path));
+        if (widget != nullptr)
+            widget->setFocus(Qt::PopupFocusReason);
+    }
 }
 
 void PreferencesWindow::updateSearch(const QString &text)
@@ -369,7 +368,7 @@ void PreferencesWindow::addPage(QTreeWidgetItem *item, PreferencesPage *page, co
     connect(page, SIGNAL(settingsApplied(const QString &)), this, SIGNAL(settingsApplied(const QString &)));
 }
 
-PreferencesPage *PreferencesWindow::getPageWidget(const QString &pagePath) const
+PreferencesPage *PreferencesWindow::getPageWidget(const QString &pagePath, bool allowPrefix) const
 {
     auto parts = pagePath.split('/');
     for (QString &name : parts)
@@ -377,10 +376,6 @@ PreferencesPage *PreferencesWindow::getPageWidget(const QString &pagePath) const
         if (treeEntryTranslation.contains(name))
         {
             name = treeEntryTranslation[name];
-        }
-        else
-        {
-            LOG_DEV("Can't find translation of " << name);
         }
     }
 
@@ -395,8 +390,10 @@ PreferencesPage *PreferencesWindow::getPageWidget(const QString &pagePath) const
         QTreeWidgetItem *nxt = getChild(current, parts[i]);
         if (nxt == nullptr)
         {
-            LOG_DEV("Can't find path: " << pagePath);
-            return nullptr;
+            auto res = allowPrefix ? pageWidget[current] : nullptr;
+            if (res == nullptr)
+                LOG_DEV("Can't find path: " << pagePath);
+            return res;
         }
         current = nxt;
     }

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -122,9 +122,10 @@ class PreferencesWindow : public QMainWindow
     /**
      * @brief get the page widget to the page of the given path
      * @param pagePath the path to the page
+     * @param allowPrefix if a prefix of *pagePath* is a page, return it
      * @returns returns the widget if it's found, otherwise returns nullptr
      */
-    PreferencesPage *getPageWidget(const QString &pagePath) const;
+    PreferencesPage *getPageWidget(const QString &pagePath, bool allowPrefix) const;
 
     /**
      * @brief if there are unsaved changes, ask the user to save/discard the changes or cancel the close


### PR DESCRIPTION
## Description

This adds the "allowPrefix" parameter for `PreferencesWindow::getPageWidget`.

## Related Issues / Pull Requests

#659 and #663

## Motivation and Context

There were warnings when clicking links to settings because the old logic was to try removing suffixes from paths until success.

This fixes the false warning and improves performance.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
