### PR TITLE
fix: set AllowSetForegroundWindow on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,10 @@
 #include <iostream>
 #include <singleapplication.h>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 #define TOJSON(x) json[#x] = x
 
 int main(int argc, char *argv[])
@@ -46,6 +50,10 @@ int main(int argc, char *argv[])
     SingleApplication::setApplicationVersion(DISPLAY_VERSION);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QApplication::setWindowIcon(QIcon(":/icon.png"));
+
+#ifdef Q_OS_WIN
+    AllowSetForegroundWindow(ASFW_ANY); // #657
+#endif
 
     SignalHandler handler;
     QObject::connect(&handler, &SignalHandler::signalReceived, qApp, [](int signal) {


### PR DESCRIPTION
## Description

Set AllowSetForegroundWindow on Windows.

## Related Issues / Pull Requests

This fixes #657 on Windows.

## Motivation and Context

It can be confusing if the running CP Editor doesn't pop up when trying to open the second CP Editor.

And this problem is hard to fix on Linux.

## How Has This Been Tested?

On Windows 10.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
