### PR TITLE
feat: add Full Screen in the View menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 -   Now you can opt-in non-monospaced fonts when choosing a font in the Preferences. (#217 and #625)
 -   Format python codes by YAPF. (#652)
 -   Now you can open the corresponding preferences page via a link when asked to check the setting in the message logger. (#659)
--   Now you can toggle fullscreen mode by pressing F11. (#642 and #660)
+-   Now you can toggle fullscreen mode by pressing F11 or clicking View->Full Screen. (#642, #660 and #670)
 
 ### Fixed
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -355,11 +355,7 @@ void AppWindow::maybeSetHotkeys()
             new QShortcut(SettingsHelper::getHotkeySnippets(), this, SLOT(on_actionUseSnippets_triggered())));
     }
 
-    hotkeyObjects.push_back(
-        new QShortcut(Qt::Key_F11, this, [this] { setWindowState(windowState() ^ Qt::WindowFullScreen); }));
-
-    hotkeyObjects.push_back(
-        new QShortcut(Qt::Key_Escape, this, [this] { setWindowState(windowState() & ~Qt::WindowFullScreen); }));
+    hotkeyObjects.push_back(new QShortcut(Qt::Key_Escape, this, [this] { ui->actionFullScreen->setChecked(false); }));
 }
 
 bool AppWindow::closeTab(int index)
@@ -1284,6 +1280,14 @@ void AppWindow::on_actionSplitMode_triggered()
         LOG_INFO("Restored splitter state");
         currentWindow()->setViewMode("split");
     }
+}
+
+void AppWindow::on_actionFullScreen_toggled(bool checked)
+{
+    LOG_INFO(INFO_OF(checked));
+    auto state = windowState();
+    state.setFlag(Qt::WindowFullScreen, checked);
+    setWindowState(state);
 }
 
 void AppWindow::on_actionIndent_triggered()

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -147,6 +147,8 @@ class AppWindow : public QMainWindow
 
     void on_actionSplitMode_triggered();
 
+    void on_actionFullScreen_toggled(bool checked);
+
     void on_actionIndent_triggered();
 
     void on_actionUnindent_triggered();

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -467,6 +467,10 @@ Git commit hash: %3
         <source>https://cpeditor.org/%1/docs</source>
         <translation>https://cpeditor.org/%1/ru/docs</translation>
     </message>
+    <message>
+        <source>Full Screen</source>
+        <translation>Полный экран</translation>
+    </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -467,6 +467,10 @@ git 提交编号: %3
         <source>https://cpeditor.org/%1/docs</source>
         <translation>https://cpeditor.org/%1/zh/docs</translation>
     </message>
+    <message>
+        <source>Full Screen</source>
+        <translation>全屏</translation>
+    </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>

--- a/ui/appwindow.ui
+++ b/ui/appwindow.ui
@@ -101,6 +101,8 @@
     <addaction name="actionEditorMode"/>
     <addaction name="actionIOMode"/>
     <addaction name="actionSplitMode"/>
+    <addaction name="separator"/>
+    <addaction name="actionFullScreen"/>
    </widget>
    <widget class="QMenu" name="menuOptions">
     <property name="title">
@@ -466,6 +468,17 @@
    </property>
    <property name="text">
     <string>Split Mode</string>
+   </property>
+  </action>
+  <action name="actionFullScreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Full Screen</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">F11</string>
    </property>
   </action>
   <action name="actionShowLogs">


### PR DESCRIPTION
## Description

Add Full Screen in the View menu.

## Motivation and Context

To make it easier to be aware of this feature and reduce the chance that the user doesn't know how to exit full screen.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).