### PR TITLE
Use pass-by-ref

### DIFF
--- a/src/CodeEditor/CodeEditor.cpp
+++ b/src/CodeEditor/CodeEditor.cpp
@@ -995,7 +995,8 @@ bool CodeEditor::event(QEvent *event)
     return QPlainTextEdit::event(event);
 }
 
-void CodeEditor::squiggle(SeverityLevel level, QPair<int, int> start, QPair<int, int> stop, QString tooltipMessage)
+void CodeEditor::squiggle(SeverityLevel level, const QPair<int, int> &start, const QPair<int, int> &stop,
+                          const QString &tooltipMessage)
 {
     if (stop < start)
         return;

--- a/src/CodeEditor/CodeEditor.hpp
+++ b/src/CodeEditor/CodeEditor.hpp
@@ -98,7 +98,7 @@ class CodeEditor : public QPlainTextEdit
      * @note QPair<int, int>: first -> Line number in 1-based indexing
      *                        second -> Character number in 0-based indexing
      */
-    void squiggle(SeverityLevel level, QPair<int, int>, QPair<int, int>, QString tooltipMessage);
+    void squiggle(SeverityLevel level, const QPair<int, int> &, const QPair<int, int> &, const QString &tooltipMessage);
 
     /**
      * @brief clearSquiggle, Clears complete squiggle from editor
@@ -265,7 +265,7 @@ class CodeEditor : public QPlainTextEdit
     {
         SquiggleInformation() = default;
 
-        SquiggleInformation(QPair<int, int> start, QPair<int, int> stop, QString text)
+        SquiggleInformation(const QPair<int, int> &start, const QPair<int, int> &stop, const QString &text)
             : m_startPos(start), m_stopPos(stop), m_tooltipText(text)
         {
         }

--- a/src/Extensions/LanguageServer.cpp
+++ b/src/Extensions/LanguageServer.cpp
@@ -28,7 +28,7 @@
 namespace Extensions
 {
 
-LanguageServer::LanguageServer(QString lang)
+LanguageServer::LanguageServer(const QString &lang)
 {
     LOG_INFO(INFO_OF(lang));
     this->language = lang;
@@ -50,7 +50,7 @@ LanguageServer::~LanguageServer()
     }
 }
 
-void LanguageServer::openDocument(QString path, CodeEditor *editor, MessageLogger *log)
+void LanguageServer::openDocument(const QString &path, CodeEditor *editor, MessageLogger *log)
 {
     if (isDocumentOpen())
     {
@@ -156,7 +156,7 @@ void LanguageServer::updateSettings()
     }
 }
 
-void LanguageServer::updatePath(QString newPath)
+void LanguageServer::updatePath(const QString &newPath)
 {
     if (lsp == nullptr || (openFile == newPath))
         return;
@@ -217,7 +217,7 @@ CodeEditor::SeverityLevel LanguageServer::lspSeverity(int in)
     return CodeEditor::SeverityLevel::Error;
 }
 
-void LanguageServer::initializeLSP(QString filePath)
+void LanguageServer::initializeLSP(const QString &filePath)
 {
     QFileInfo info(filePath);
     std::string uri = "file://" + info.absoluteDir().absolutePath().toStdString();

--- a/src/Extensions/LanguageServer.hpp
+++ b/src/Extensions/LanguageServer.hpp
@@ -32,17 +32,17 @@ class LanguageServer : public QObject
     Q_OBJECT
 
   public:
-    explicit LanguageServer(QString language);
+    explicit LanguageServer(const QString &language);
     ~LanguageServer();
 
-    void openDocument(QString path, CodeEditor *editor, MessageLogger *logger);
+    void openDocument(const QString &path, CodeEditor *editor, MessageLogger *logger);
     void closeDocument();
     void requestLinting();
 
     bool isDocumentOpen() const;
 
     void updateSettings();
-    void updatePath(QString);
+    void updatePath(const QString &);
 
   private slots:
     void onLSPServerNotificationArrived(QString method, QJsonObject param);
@@ -59,7 +59,7 @@ class LanguageServer : public QObject
     bool shouldCreateClient();
 
     CodeEditor::SeverityLevel lspSeverity(int a);
-    void initializeLSP(QString url);
+    void initializeLSP(const QString &url);
 
     CodeEditor *m_editor = nullptr;
     MessageLogger *logger = nullptr;


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
Using pass-by-ref instead of pass-by-alue.

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
