### PR TITLE
feat: show only the Run button for Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Improved
 
 -   Now unfinished checks will be cancelled at the new execution. (#635)
+-   Now the "Compile" and "Compile and Run" buttons are hidden for Python. (#710)
 
 ## v6.7
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -606,16 +606,7 @@ void MainWindow::applySettings(const QString &pagePath)
     if (pageChanged("Appearance/General"))
     {
         testcases->updateHeights();
-        if (SettingsHelper::isShowCompileAndRunOnly())
-        {
-            ui->compile->hide();
-            ui->runOnly->hide();
-        }
-        else
-        {
-            ui->compile->show();
-            ui->runOnly->show();
-        }
+        updateCompileAndRunButtons();
     }
 
     if (pageChanged("Appearance/Font"))
@@ -731,6 +722,7 @@ void MainWindow::setLanguage(const QString &lang)
     Util::applySettingsToEditor(editor, language);
     customCompileCommand.clear();
     ui->changeLanguageButton->setText(language);
+    updateCompileAndRunButtons();
     isLanguageSet = true;
     emit editorLanguageChanged(this);
 }
@@ -1280,6 +1272,31 @@ int MainWindow::timeLimit() const
     if (customTimeLimit == -1)
         return SettingsHelper::getDefaultTimeLimit();
     return customTimeLimit;
+}
+
+void MainWindow::updateCompileAndRunButtons() const
+{
+    if (language == "Python")
+    {
+        ui->runOnly->show();
+        ui->compile->hide();
+        ui->run->hide();
+    }
+    else
+    {
+        if (SettingsHelper::isShowCompileAndRunOnly())
+        {
+            ui->run->show();
+            ui->runOnly->hide();
+            ui->compile->hide();
+        }
+        else
+        {
+            ui->run->show();
+            ui->runOnly->show();
+            ui->compile->show();
+        }
+    }
 }
 
 // -------------------- COMPILER SLOTS ---------------------------

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -246,5 +246,6 @@ class MainWindow : public QMainWindow
     static QString getRunnerHead(int index);
     QString compileCommand() const;
     int timeLimit() const;
+    void updateCompileAndRunButtons() const;
 };
 #endif // MAINWINDOW_HPP


### PR DESCRIPTION
## Description

Show only the Run button for Python.

## Motivation and Context

Make it more reasonable.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
