### PR TITLE
feat(Settings): save settings to disk on apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Now you can toggle fullscreen mode by pressing F11 or clicking View->Full Screen. (#642, #660 and #670)
 -   In test cases, you can copy the output to the expected. (#688)
 -   Copy test cases between different tabs. (#688)
+-   Now settings are saved to disk as soon as new settings are applied. (#590 and #722)
 
 ### Fixed
 

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -116,7 +116,7 @@ void SettingsManager::init()
 
 void SettingsManager::deinit()
 {
-    saveSettings(Util::configFilePath(configFileLocations[0]));
+    saveSettings(QString());
 
     delete cur;
     delete def;
@@ -155,9 +155,11 @@ void SettingsManager::loadSettings(const QString &path)
 
 void SettingsManager::saveSettings(const QString &path)
 {
-    LOG_INFO("Start saving settings to " + path);
+    const auto savePath = path.isEmpty() ? Util::configFilePath(configFileLocations[0]) : path;
 
-    QSettings setting(path, QSettings::IniFormat);
+    LOG_INFO("Start saving settings to " + savePath);
+
+    QSettings setting(savePath, QSettings::IniFormat);
     setting.clear(); // Otherwise SettingsManager::remove won't work
     save(setting, "", SettingsInfo::getSettings());
 
@@ -166,7 +168,7 @@ void SettingsManager::saveSettings(const QString &path)
 
     setting.sync();
 
-    LOG_INFO("Settings have been saved to " + path);
+    LOG_INFO("Settings have been saved to " + savePath);
 }
 
 QVariant SettingsManager::get(QString const &key, bool alwaysDefault)

--- a/src/Settings/SettingsManager.hpp
+++ b/src/Settings/SettingsManager.hpp
@@ -35,6 +35,11 @@ class SettingsManager
     static void generateDefaultSettings();
 
     static void loadSettings(const QString &path);
+
+    /**
+     * @brief save settings to the given path
+     * @param path the path to save at; if empty, save at the default path
+     */
     static void saveSettings(const QString &path);
 
     static QVariant get(QString const &key, bool alwaysDefault = false);
@@ -44,7 +49,7 @@ class SettingsManager
     static void reset();
 
     /**
-     * @breif set the path of a setting in the preferences window
+     * @brief set the path of a setting in the preferences window
      * @param key the name of the setting
      * @param path The path to the setting, in the form "X/Y/Z/<desc>". The <desc> shouldn't contain slashes.
      * @param trPath the translation of the path, in the form "X->Y->Z-><trdesc>"

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1090,6 +1090,8 @@ void AppWindow::onSettingsApplied(const QString &pagePath)
     {
         DefaultPathManager::fromVariantList(SettingsHelper::getDefaultPathNamesAndPaths());
     }
+
+    SettingsManager::saveSettings(QString());
 }
 
 void AppWindow::onIncomingCompanionRequest(const Extensions::CompanionData &data)


### PR DESCRIPTION
## Description

As discussed in #590, I think it was "live-update like QSettings" that I thought was not easy. Simply saving settings on apply should be just fine.

## Related Issues / Pull Requests

This closes #590.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
