### PR TITLE
ci: use full SHA for workflows

### DIFF
--- a/.github/workflows/release_checksums.yml
+++ b/.github/workflows/release_checksums.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
       - name: Download assets
-        uses: hecrj/download-release-action@ef523a9
+        uses: hecrj/download-release-action@ef523a951deebec6b821266175f7547906d87073
         with:
           output: downloads
 


### PR DESCRIPTION
https://github.blog/changelog/2021-01-21-github-actions-short-sha-deprecation/