### PR TITLE
feat(Preferences): add links to the docs in the preferences window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Copy test cases between different tabs. (#688)
 -   Now settings are saved to disk as soon as new settings are applied. (#590 and #722)
 -   x86 release for 32-bit Windows. (#719 and #723)
+-   Open documentation links in the preferences window. (#733)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,8 @@ add_executable(cpeditor
     src/Widgets/ContestDialog.hpp
     src/Widgets/DiffViewer.cpp
     src/Widgets/DiffViewer.hpp
+    src/Widgets/RichTextCheckBox.cpp
+    src/Widgets/RichTextCheckBox.hpp
     src/Widgets/SupportUsDialog.cpp
     src/Widgets/SupportUsDialog.hpp
     src/Widgets/TestCase.cpp

--- a/src/Core/Translator.cpp
+++ b/src/Core/Translator.cpp
@@ -27,6 +27,8 @@ const static QMap<QString, QString> locales = {{"简体中文", "zh_CN"}, {"Ру
 
 const static QMap<QString, QString> suffixes = {{"zh_CN", "_zh-CN"}, {"ru_RU", "_ru-RU"}};
 
+const static QMap<QString, QString> code = {{"zh_CN", "zh"}, {"ru_RU", "ru"}};
+
 QTranslator *Translator::translator = nullptr;
 
 void Translator::setLocale()
@@ -62,10 +64,20 @@ void Translator::setLocale()
 
 QString Translator::langSuffix()
 {
+    return suffixes[langName()];
+}
+
+QString Translator::langCode()
+{
+    return code[langName()];
+}
+
+QString Translator::langName()
+{
     const auto language = SettingsHelper::getLocale();
 
     if (language == "system")
-        return suffixes[QLocale::system().name()];
-    return suffixes[locales[language]];
+        return QLocale::system().name();
+    return locales[language];
 }
 } // namespace Core

--- a/src/Core/Translator.hpp
+++ b/src/Core/Translator.hpp
@@ -33,7 +33,11 @@ class Translator : public QObject
 
     static QString langSuffix();
 
+    static QString langCode();
+
   private:
+    static QString langName();
+
     static QTranslator *translator;
 };
 } // namespace Core

--- a/src/Settings/PreferencesGridPage.cpp
+++ b/src/Settings/PreferencesGridPage.cpp
@@ -51,6 +51,7 @@ void PreferencesGridPage::addRow(ValueWidget *widget, const QString &key, const 
     else
     {
         auto *label = new QLabel(tr(labelText.toUtf8()), this);
+        label->setOpenExternalLinks(true);
         if (!tip.isEmpty())
             label->setToolTip(tr(tip.toUtf8()));
         gridLayout->addWidget(label, row, 0);

--- a/src/Settings/PreferencesHomePage.cpp
+++ b/src/Settings/PreferencesHomePage.cpp
@@ -18,7 +18,7 @@
 #include "Settings/PreferencesHomePage.hpp"
 #include "Core/EventLogger.hpp"
 #include "Settings/PreferencesWindow.hpp"
-#include "generated/version.hpp"
+#include "Util/Util.hpp"
 #include <QLabel>
 #include <QPixmap>
 #include <QPushButton>
@@ -66,10 +66,9 @@ void PreferencesHomePage::init()
     layout->addSpacing(20);
 
     // add manual label
-    auto *manualLabel = new QLabel(
-        tr("You can read the <a href=\"%1\">documentation</a> or go "
-           "through the settings for more information.")
-            .arg(QUrl(tr("https://cpeditor.org/%1/docs").arg(MINOR_VERSION)).url(QUrl::NormalizePathSegments)));
+    auto *manualLabel = new QLabel(tr("You can read the <a href=\"%1\">documentation</a> or go "
+                                      "through the settings for more information.")
+                                       .arg(Util::websiteLink("docs")));
     manualLabel->setOpenExternalLinks(true);
     layout->addWidget(manualLabel);
     layout->setAlignment(manualLabel, Qt::AlignCenter);

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -29,7 +29,7 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, const QString
 {
     PreferencesPage::setPath(path, trPath);
 
-    const QString &docsLinkPrefix =
+    const QString docsLinkPrefix =
         Util::websiteLink("docs/preferences/" + Util::sanitizeAnchorName(path.split('/').first()));
 
     for (const QString &name : options)

--- a/src/Settings/PreferencesPageTemplate.hpp
+++ b/src/Settings/PreferencesPageTemplate.hpp
@@ -25,11 +25,10 @@ class PreferencesPageTemplate : public PreferencesGridPage
     Q_OBJECT
 
   public:
-    explicit PreferencesPageTemplate(QStringList opts, bool alignTop = true, QWidget *parent = nullptr);
+    explicit PreferencesPageTemplate(QStringList opts, const QString &path, const QString &trPath, bool alignTop = true,
+                                     QWidget *parent = nullptr);
 
     QStringList content() override;
-
-    void setPath(const QString &path, const QString &trPath) override;
 
   private:
     bool areSettingsChanged() override;

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -36,9 +36,9 @@
 #include <QTreeWidget>
 #include <QVBoxLayout>
 
-AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, const QStringList &content)
+AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, const QStringList &content, bool alignTop)
 {
-    return page(key, trkey, new PreferencesPageTemplate(content));
+    return page(key, trkey, new PreferencesPageTemplate(content, pathFor(key), trPathFor(trkey), alignTop, window));
 }
 
 AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, PreferencesPage *newpage)
@@ -54,7 +54,7 @@ AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, Pre
     {
         currentItem = new QTreeWidgetItem({trkey});
         tree->addTopLevelItem(currentItem);
-        newpage->setPath(key, trkey);
+        newpage->setPath(pathFor(key), trPathFor(trkey));
         newpage->setTitle(trkey);
         window->addPage(currentItem, newpage, content);
     }
@@ -62,7 +62,7 @@ AddPageHelper &AddPageHelper::page(const QString &key, const QString &trkey, Pre
     {
         auto *item = new QTreeWidgetItem({trkey});
         currentItem->addChild(item);
-        newpage->setPath((currentPath + QStringList(key)).join('/'), (currentTrPath + QStringList(trkey)).join('/'));
+        newpage->setPath(pathFor(key), trPathFor(trkey));
         if (key == "@")
             newpage->setTitle(currentItem->text(0));
         else
@@ -107,6 +107,16 @@ void AddPageHelper::ensureAtTop() const
 bool AddPageHelper::atTop() const
 {
     return currentPath.isEmpty();
+}
+
+QString AddPageHelper::pathFor(const QString &key)
+{
+    return (currentPath + QStringList(key)).join('/');
+}
+
+QString AddPageHelper::trPathFor(const QString &trkey)
+{
+    return (currentTrPath + QStringList(trkey)).join('/');
 }
 
 AddPageHelper::AddPageHelper(PreferencesWindow *w) : window(w), tree(window->menuTree)
@@ -240,19 +250,18 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .dir(TRKEY("Extensions"))
             .dir(TRKEY("Code Formatting"))
                 .page(TRKEY("General"), {"Format On Manual Save", "Format On Auto Save"})
-                .page(TRKEY("Clang Format"), new PreferencesPageTemplate({"Clang Format/Program", "Clang Format/Arguments", "Clang Format/Style"}, false))
-                .page(TRKEY("YAPF"), new PreferencesPageTemplate({"YAPF/Program", "YAPF/Arguments", "YAPF/Style"}, false))
+                .page(TRKEY("Clang Format"), {"Clang Format/Program", "Clang Format/Arguments", "Clang Format/Style"}, false)
+                .page(TRKEY("YAPF"), {"YAPF/Program", "YAPF/Arguments", "YAPF/Style"}, false)
             .end()
             .dir(TRKEY("Language Server"))
                 .page("C++ Server", tr("%1 Server").arg(tr("C++")), {"LSP/Use Linting C++", "LSP/Delay C++", "LSP/Path C++", "LSP/Args C++"})
                 .page("Java Server", tr("%1 Server").arg(tr("Java")), {"LSP/Use Linting Java", "LSP/Delay Java", "LSP/Path Java", "LSP/Args Java"})
                 .page("Python Server", tr("%1 Server").arg(tr("Python")), {"LSP/Use Linting Python", "LSP/Delay Python", "LSP/Path Python", "LSP/Args Python"})
             .end()
-            .page(TRKEY("Competitive Companion"), new PreferencesPageTemplate({"Competitive Companion/Enable",
-                "Competitive Companion/Open New Tab", "Competitive Companion/Set Time Limit For Tab",
-                "Competitive Companion/Connection Port",
+            .page(TRKEY("Competitive Companion"), {"Competitive Companion/Enable", "Competitive Companion/Open New Tab",
+                "Competitive Companion/Set Time Limit For Tab", "Competitive Companion/Connection Port",
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
-                "Competitive Companion/Head Comments Powered By CP Editor"}, false))
+                "Competitive Companion/Head Comments Powered By CP Editor"}, false)
             .page(TRKEY("CF Tool"), {"CF/Path", "CF/Show Toast Messages"})
         .end()
         .dir(TRKEY("File Path"))

--- a/src/Settings/PreferencesWindow.hpp
+++ b/src/Settings/PreferencesWindow.hpp
@@ -47,7 +47,7 @@ class AddPageHelper
   public:
     explicit AddPageHelper(PreferencesWindow *w);
 
-    AddPageHelper &page(const QString &key, const QString &trkey, const QStringList &content);
+    AddPageHelper &page(const QString &key, const QString &trkey, const QStringList &content, bool alignTop = true);
     AddPageHelper &page(const QString &key, const QString &trkey, PreferencesPage *newpage);
     AddPageHelper &page(const QString &key, const QString &trkey, PreferencesPage *newpage, const QStringList &content);
 
@@ -59,6 +59,9 @@ class AddPageHelper
 
   private:
     bool atTop() const;
+
+    QString pathFor(const QString &key);
+    QString trPathFor(const QString &trkey);
 
     PreferencesWindow *window;
     QTreeWidget *tree;

--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -32,7 +32,14 @@ class SettingsInfo
     class SettingInfo
     {
       public:
-        QString name, desc, untrDesc, type, ui, tip, untrTip;
+        QString name;             // key
+        QString desc;             // translated description
+        QString untrDesc;         // untranslated description
+        QString type;             // int, bool, QString, etc.
+        QString ui;               // type of the widget
+        QString tip;              // translated tooltips
+        QString untrTip;          // untranslated tooltips
+        QString docAnchor;        // the anchor of the documentation
         bool requireAllDepends{}; // false for one of the depends, true for all depends
         bool immediatelyApply{};
         std::function<void(SettingInfo *, ValueWidget *, QWidget *)> onApply;

--- a/src/Settings/ValueWrapper.cpp
+++ b/src/Settings/ValueWrapper.cpp
@@ -18,7 +18,7 @@
 #include "Settings/ValueWrapper.hpp"
 
 // bool
-#include <QCheckBox>
+#include "Widgets/RichTextCheckBox.hpp"
 
 // QString
 #include "Settings/PathItem.hpp"
@@ -46,19 +46,19 @@ void ValueWidget::emitSignal()
 
 void CheckBoxWrapper::init(QString name, QWidget *parent, QVariant /*param*/)
 {
-    auto *item = new QCheckBox(name, parent);
-    connect(item, &QCheckBox::toggled, this, &ValueWidget::emitSignal);
+    auto *item = new RichTextCheckBox(name, parent);
+    connect(item, &RichTextCheckBox::toggled, this, &ValueWidget::emitSignal);
     widget = item;
 }
 
 bool CheckBoxWrapper::get()
 {
-    return qobject_cast<QCheckBox *>(widget)->isChecked();
+    return qobject_cast<RichTextCheckBox *>(widget)->isChecked();
 }
 
 void CheckBoxWrapper::set(bool b)
 {
-    qobject_cast<QCheckBox *>(widget)->setChecked(b);
+    qobject_cast<RichTextCheckBox *>(widget)->setChecked(b);
 }
 
 void LineEditWrapper::init(QWidget *parent, QVariant /*param*/)

--- a/src/Settings/genSettings.py
+++ b/src/Settings/genSettings.py
@@ -53,6 +53,11 @@ def writeInfo(f, obj, lst):
         ui = t.get("ui", "")
         tip = t.get("tip", "")
         trtip = t.get("trtip", f"tr({json.dumps(tip)})")
+        docAnchor = t.get("docAnchor", "")
+        if docAnchor == "":
+            docAnchor = json.dumps("")
+        else:
+            docAnchor = f"tr({json.dumps(docAnchor)}, {json.dumps(f'the anchor of {desc} on the corresponding page of https://cpeditor.org/docs/preferences')})"
         requireAllDepends = t.get("requireAllDepends", True)
         immediatelyApply = t.get("immediatelyApply", False)
         onApply = f'[](SettingInfo *info, ValueWidget *widget, QWidget *parent){{ {t.get("onApply", "")} }}'
@@ -75,7 +80,7 @@ def writeInfo(f, obj, lst):
         dependsString += "}"
         old = t.get("old", [])
         f.write(
-            f"    {lst}.append(SettingInfo {{{json.dumps(name)}, {trdesc}, {json.dumps(desc)}, \"{tempname}\", \"{ui}\", {trtip}, {json.dumps(tip)}, {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, {{{json.dumps(old)[1:-1]}}}, ")
+            f"    {lst}.append(SettingInfo {{{json.dumps(name)}, {trdesc}, {json.dumps(desc)}, \"{tempname}\", \"{ui}\", {trtip}, {json.dumps(tip)}, {docAnchor}, {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, {{{json.dumps(old)[1:-1]}}}, ")
         if typename != "Object":
             if "default" in t:
                 if typename == "QString":

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -571,7 +571,7 @@
     },
     {
         "name": "Competitive Companion/Head Comments",
-        "desc": "Head Comments",
+        "desc": "Content of the head comments",
         "type": "QString",
         "ui": "QPlainTextEdit",
         "default": "Problem: ${json.name}\nContest: ${json.group}\nURL: ${json.url}\nMemory Limit: ${json.memoryLimit} MB\nTime Limit: ${json.timeLimit} ms",
@@ -1087,6 +1087,7 @@
         "desc": "Enable Proxy",
         "type": "bool",
         "default": "true",
+        "docAnchor": "network-proxy",
         "tip": "Enable proxy for checking updates"
     },
     {
@@ -1101,6 +1102,7 @@
                 "name": "Proxy/Enabled"
             }
         ],
+        "docAnchor": "network-proxy",
         "tip": "The type of the proxy. \"System\" for using the system proxy."
     },
     {
@@ -1117,6 +1119,7 @@
                 "check": "return var.toString() != \"System\";"
             }
         ],
+        "docAnchor": "network-proxy",
         "tip": "The host name of the proxy, e.g. 127.0.0.1"
     },
     {
@@ -1134,6 +1137,7 @@
                 "check": "return var.toString() != \"System\";"
             }
         ],
+        "docAnchor": "network-proxy",
         "tip": "The port of the proxy, e.g. 1080"
     },
     {
@@ -1149,6 +1153,7 @@
                 "check": "return var.toString() != \"System\";"
             }
         ],
+        "docAnchor": "network-proxy",
         "tip": "The user of the proxy server. It can be empty if the proxy server doesn't require authentication."
     },
     {
@@ -1164,6 +1169,7 @@
                 "check": "return var.toString() != \"System\";"
             }
         ],
+        "docAnchor": "network-proxy",
         "tip": "The password of the proxy server. It can be empty if the proxy server doesn't require authentication."
     },
     {

--- a/src/Util/Util.cpp
+++ b/src/Util/Util.cpp
@@ -17,6 +17,9 @@
 
 #include "Util/Util.hpp"
 #include "Core/EventLogger.hpp"
+#include "Core/Translator.hpp"
+#include "generated/version.hpp"
+#include <QUrl>
 #include <QWidget>
 
 namespace Util
@@ -28,6 +31,17 @@ void showWidgetOnTop(QWidget *widget)
     widget->setWindowState((widget->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
     widget->activateWindow();
     widget->raise();
+}
+
+QString sanitizeAnchorName(const QString &str)
+{
+    return str.trimmed().remove('+').toLower().replace(' ', '-');
+}
+
+QString websiteLink(const QString &path)
+{
+    return QUrl(QString("https://cpeditor.org/%1/%2/%3").arg(MINOR_VERSION).arg(Core::Translator::langCode()).arg(path))
+        .url(QUrl::NormalizePathSegments);
 }
 
 } // namespace Util

--- a/src/Util/Util.hpp
+++ b/src/Util/Util.hpp
@@ -18,12 +18,16 @@
 #ifndef UTIL_HPP
 #define UTIL_HPP
 
-class QWidget;
+#include <QMetaType>
 
 namespace Util
 {
 
 void showWidgetOnTop(QWidget *widget);
+
+QString sanitizeAnchorName(const QString &str);
+
+QString websiteLink(const QString &path = QString());
 
 } // namespace Util
 

--- a/src/Widgets/RichTextCheckBox.cpp
+++ b/src/Widgets/RichTextCheckBox.cpp
@@ -18,6 +18,7 @@
 // https://www.qtcentre.org/threads/60455-SOLVED-Issues-with-displaying-rich-text-for-a-QCheckBox?p=268211#post268211
 
 #include "Widgets/RichTextCheckBox.hpp"
+#include "Core/EventLogger.hpp"
 #include <QDesktopServices>
 #include <QHBoxLayout>
 #include <QMouseEvent>
@@ -31,6 +32,7 @@ ClickableLabel::ClickableLabel(QWidget *parent) : QLabel(parent)
         this, &QLabel::linkActivated, this,
         [this](const QString &link) {
             linkClicked = true;
+            LOG_INFO(INFO_OF(link));
             QDesktopServices::openUrl(link);
         },
         Qt::DirectConnection);
@@ -40,8 +42,7 @@ void ClickableLabel::mouseReleaseEvent(QMouseEvent *event)
 {
     linkClicked = false;
     QLabel::mouseReleaseEvent(event);
-    if (!linkClicked && contentsRect().contains(event->pos()) &&
-        (event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton))
+    if (!linkClicked && (event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton))
     {
         emit released();
     }
@@ -50,7 +51,7 @@ void ClickableLabel::mouseReleaseEvent(QMouseEvent *event)
 void ClickableLabel::mousePressEvent(QMouseEvent *event)
 {
     QLabel::mousePressEvent(event);
-    if ((event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton))
+    if (event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton)
     {
         emit pressed();
     }
@@ -59,8 +60,7 @@ void ClickableLabel::mousePressEvent(QMouseEvent *event)
 void ClickableLabel::mouseMoveEvent(QMouseEvent *event)
 {
     QLabel::mouseMoveEvent(event);
-    if (contentsRect().contains(event->pos()) &&
-        (event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton))
+    if (event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton)
     {
         emit left();
     }
@@ -68,6 +68,7 @@ void ClickableLabel::mouseMoveEvent(QMouseEvent *event)
 
 HoverCheckBox::HoverCheckBox(QWidget *parent) : QCheckBox(parent)
 {
+    setStyleSheet("QCheckBox{spacing:4px;}");
 }
 
 void HoverCheckBox::paintEvent(QPaintEvent * /*unused*/)
@@ -119,7 +120,8 @@ RichTextCheckBox::RichTextCheckBox(const QString &text, QWidget *parent) : QWidg
     label->setTextFormat(Qt::RichText);
     label->setText(text);
     auto *layout = new QHBoxLayout(this);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
     layout->addWidget(checkBox);
     layout->addWidget(label);
     layout->setAlignment(Qt::AlignLeft);

--- a/src/Widgets/RichTextCheckBox.cpp
+++ b/src/Widgets/RichTextCheckBox.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2019-2021 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+// https://www.qtcentre.org/threads/60455-SOLVED-Issues-with-displaying-rich-text-for-a-QCheckBox?p=268211#post268211
+
+#include "Widgets/RichTextCheckBox.hpp"
+#include <QDesktopServices>
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QStyleOptionButton>
+#include <QStylePainter>
+#include <QTextDocument>
+
+ClickableLabel::ClickableLabel(QWidget *parent) : QLabel(parent)
+{
+    connect(
+        this, &QLabel::linkActivated, this,
+        [this](const QString &link) {
+            linkClicked = true;
+            QDesktopServices::openUrl(link);
+        },
+        Qt::DirectConnection);
+}
+
+void ClickableLabel::mouseReleaseEvent(QMouseEvent *event)
+{
+    linkClicked = false;
+    QLabel::mouseReleaseEvent(event);
+    if (!linkClicked && contentsRect().contains(event->pos()) &&
+        (event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton))
+    {
+        emit released();
+    }
+}
+
+void ClickableLabel::mousePressEvent(QMouseEvent *event)
+{
+    QLabel::mousePressEvent(event);
+    if ((event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton))
+    {
+        emit pressed();
+    }
+}
+
+void ClickableLabel::mouseMoveEvent(QMouseEvent *event)
+{
+    QLabel::mouseMoveEvent(event);
+    if (contentsRect().contains(event->pos()) &&
+        (event->buttons() == Qt::LeftButton || event->button() == Qt::LeftButton))
+    {
+        emit left();
+    }
+}
+
+HoverCheckBox::HoverCheckBox(QWidget *parent) : QCheckBox(parent)
+{
+    isHover = false;
+}
+
+void HoverCheckBox::paintEvent(QPaintEvent *)
+{
+    QStylePainter p(this);
+    QStyleOptionButton opt;
+    initStyleOption(&opt);
+    if (isHover)
+    {
+        opt.state |= QStyle::State_MouseOver;
+    }
+    if (isPressed)
+    {
+        opt.state |= QStyle::State_Sunken;
+    }
+    p.drawControl(QStyle::CE_CheckBox, opt);
+}
+
+void HoverCheckBox::setHover()
+{
+    isHover = true;
+    update();
+}
+
+void HoverCheckBox::setPressed()
+{
+    isPressed = true;
+    update();
+}
+
+void HoverCheckBox::clearPressed()
+{
+    isPressed = false;
+    update();
+}
+
+void HoverCheckBox::clearStates()
+{
+    isHover = false;
+    isPressed = false;
+    update();
+}
+
+RichTextCheckBox::RichTextCheckBox(QString text, QWidget *parent) : QWidget(parent)
+{
+    setMouseTracking(true);
+    checkBox = new HoverCheckBox();
+    label = new ClickableLabel();
+    label->setTextFormat(Qt::RichText);
+    label->setText(text);
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->setMargin(0);
+    layout->addWidget(checkBox);
+    layout->addWidget(label);
+    layout->setAlignment(Qt::AlignLeft);
+    connect(label, &ClickableLabel::released, checkBox, &HoverCheckBox::toggle);
+    connect(label, &ClickableLabel::released, checkBox, &HoverCheckBox::clearPressed);
+    connect(label, &ClickableLabel::pressed, checkBox, &HoverCheckBox::setPressed);
+    connect(label, &ClickableLabel::left, checkBox, &HoverCheckBox::clearStates);
+    connect(checkBox, &HoverCheckBox::toggled, this, &RichTextCheckBox::toggled);
+    connect(checkBox, &HoverCheckBox::clicked, this, &RichTextCheckBox::clicked);
+    connect(label, &ClickableLabel::released, this, &RichTextCheckBox::clicked);
+}
+
+QCheckBox *RichTextCheckBox::getCheckBox()
+{
+    return checkBox;
+}
+
+bool RichTextCheckBox::isChecked() const
+{
+    return checkBox->isChecked();
+}
+
+Qt::CheckState RichTextCheckBox::checkState() const
+{
+    return checkBox->checkState();
+}
+
+QString RichTextCheckBox::text() const
+{
+    return label->text();
+}
+
+QString RichTextCheckBox::plainText() const
+{
+    QTextDocument doc;
+    doc.setHtml(label->text());
+    return doc.toPlainText();
+}
+
+void RichTextCheckBox::clearStates()
+{
+    checkBox->clearStates();
+}
+
+void RichTextCheckBox::setCheckState(Qt::CheckState state)
+{
+    checkBox->setCheckState(state);
+}
+
+void RichTextCheckBox::setChecked(bool value)
+{
+    checkBox->setChecked(value);
+}
+
+void RichTextCheckBox::enterEvent(QEvent * /*event*/)
+{
+    checkBox->setHover();
+}
+
+void RichTextCheckBox::leaveEvent(QEvent * /*event*/)
+{
+    checkBox->clearStates();
+}

--- a/src/Widgets/RichTextCheckBox.cpp
+++ b/src/Widgets/RichTextCheckBox.cpp
@@ -71,7 +71,7 @@ HoverCheckBox::HoverCheckBox(QWidget *parent) : QCheckBox(parent)
     isHover = false;
 }
 
-void HoverCheckBox::paintEvent(QPaintEvent *)
+void HoverCheckBox::paintEvent(QPaintEvent * /*unused*/)
 {
     QStylePainter p(this);
     QStyleOptionButton opt;
@@ -112,14 +112,14 @@ void HoverCheckBox::clearStates()
     update();
 }
 
-RichTextCheckBox::RichTextCheckBox(QString text, QWidget *parent) : QWidget(parent)
+RichTextCheckBox::RichTextCheckBox(const QString &text, QWidget *parent) : QWidget(parent)
 {
     setMouseTracking(true);
     checkBox = new HoverCheckBox();
     label = new ClickableLabel();
     label->setTextFormat(Qt::RichText);
     label->setText(text);
-    QHBoxLayout *layout = new QHBoxLayout(this);
+    auto *layout = new QHBoxLayout(this);
     layout->setMargin(0);
     layout->addWidget(checkBox);
     layout->addWidget(label);
@@ -175,12 +175,12 @@ void RichTextCheckBox::setChecked(bool value)
     checkBox->setChecked(value);
 }
 
-void RichTextCheckBox::enterEvent(QEvent * /*event*/)
+void RichTextCheckBox::enterEvent(QEvent * /*unused*/)
 {
     checkBox->setHover();
 }
 
-void RichTextCheckBox::leaveEvent(QEvent * /*event*/)
+void RichTextCheckBox::leaveEvent(QEvent * /*unused*/)
 {
     checkBox->clearStates();
 }

--- a/src/Widgets/RichTextCheckBox.cpp
+++ b/src/Widgets/RichTextCheckBox.cpp
@@ -68,7 +68,6 @@ void ClickableLabel::mouseMoveEvent(QMouseEvent *event)
 
 HoverCheckBox::HoverCheckBox(QWidget *parent) : QCheckBox(parent)
 {
-    isHover = false;
 }
 
 void HoverCheckBox::paintEvent(QPaintEvent * /*unused*/)

--- a/src/Widgets/RichTextCheckBox.hpp
+++ b/src/Widgets/RichTextCheckBox.hpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2019-2021 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CP Editor.
+ *
+ * CP Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CP Editor behaves in unexpected way and
+ * causes your ratings to go down and or lose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
+
+// https://www.qtcentre.org/threads/60455-SOLVED-Issues-with-displaying-rich-text-for-a-QCheckBox?p=268211#post268211
+
+#ifndef RICHTEXTCHECKBOX_HPP
+#define RICHTEXTCHECKBOX_HPP
+
+#include <QCheckBox>
+#include <QLabel>
+
+class ClickableLabel : public QLabel
+{
+    Q_OBJECT
+
+  public:
+    explicit ClickableLabel(QWidget *parent = nullptr);
+    void mouseReleaseEvent(QMouseEvent *);
+    void mousePressEvent(QMouseEvent *);
+    void mouseMoveEvent(QMouseEvent *);
+
+  signals:
+    void released();
+    void pressed();
+    void left();
+
+  private:
+    std::atomic_bool linkClicked;
+};
+
+class HoverCheckBox : public QCheckBox
+{
+    Q_OBJECT
+
+  public:
+    explicit HoverCheckBox(QWidget *parent = nullptr);
+
+  private:
+    virtual void paintEvent(QPaintEvent *);
+    bool isHover;
+    bool isPressed;
+
+  public slots:
+    void setHover();
+    void setPressed();
+    void clearPressed();
+    void clearStates();
+};
+
+class RichTextCheckBox : public QWidget
+{
+    Q_OBJECT
+
+  public:
+    explicit RichTextCheckBox(QString text, QWidget *parent = nullptr);
+    QCheckBox *getCheckBox();
+    QString text() const;
+    QString plainText() const;
+    Qt::CheckState checkState() const;
+    bool isChecked() const;
+    void clearStates();
+
+  private:
+    HoverCheckBox *checkBox;
+    ClickableLabel *label;
+    virtual void enterEvent(QEvent *);
+    virtual void leaveEvent(QEvent *);
+
+  signals:
+    void toggled(bool);
+    void clicked();
+
+  public slots:
+    void setChecked(bool);
+    void setCheckState(Qt::CheckState state);
+};
+
+#endif // RICHTEXTCHECKBOX_HPP

--- a/src/Widgets/RichTextCheckBox.hpp
+++ b/src/Widgets/RichTextCheckBox.hpp
@@ -39,7 +39,7 @@ class ClickableLabel : public QLabel
     void left();
 
   private:
-    std::atomic_bool linkClicked;
+    std::atomic_bool linkClicked{false};
 };
 
 class HoverCheckBox : public QCheckBox
@@ -49,16 +49,17 @@ class HoverCheckBox : public QCheckBox
   public:
     explicit HoverCheckBox(QWidget *parent = nullptr);
 
-  private:
-    void paintEvent(QPaintEvent * /*unused*/) override;
-    bool isHover;
-    bool isPressed;
-
   public slots:
     void setHover();
     void setPressed();
     void clearPressed();
     void clearStates();
+
+  private:
+    void paintEvent(QPaintEvent * /*unused*/) override;
+
+    std::atomic_bool isHover{false};
+    std::atomic_bool isPressed{false};
 };
 
 class RichTextCheckBox : public QWidget
@@ -74,12 +75,6 @@ class RichTextCheckBox : public QWidget
     bool isChecked() const;
     void clearStates();
 
-  private:
-    HoverCheckBox *checkBox;
-    ClickableLabel *label;
-    void enterEvent(QEvent * /*unused*/) override;
-    void leaveEvent(QEvent * /*unused*/) override;
-
   signals:
     void toggled(bool);
     void clicked();
@@ -87,6 +82,13 @@ class RichTextCheckBox : public QWidget
   public slots:
     void setChecked(bool);
     void setCheckState(Qt::CheckState state);
+
+  private:
+    void enterEvent(QEvent * /*unused*/) override;
+    void leaveEvent(QEvent * /*unused*/) override;
+
+    HoverCheckBox *checkBox = nullptr;
+    ClickableLabel *label = nullptr;
 };
 
 #endif // RICHTEXTCHECKBOX_HPP

--- a/src/Widgets/RichTextCheckBox.hpp
+++ b/src/Widgets/RichTextCheckBox.hpp
@@ -29,9 +29,9 @@ class ClickableLabel : public QLabel
 
   public:
     explicit ClickableLabel(QWidget *parent = nullptr);
-    void mouseReleaseEvent(QMouseEvent *);
-    void mousePressEvent(QMouseEvent *);
-    void mouseMoveEvent(QMouseEvent *);
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
   signals:
     void released();
@@ -50,7 +50,7 @@ class HoverCheckBox : public QCheckBox
     explicit HoverCheckBox(QWidget *parent = nullptr);
 
   private:
-    virtual void paintEvent(QPaintEvent *);
+    void paintEvent(QPaintEvent * /*unused*/) override;
     bool isHover;
     bool isPressed;
 
@@ -66,7 +66,7 @@ class RichTextCheckBox : public QWidget
     Q_OBJECT
 
   public:
-    explicit RichTextCheckBox(QString text, QWidget *parent = nullptr);
+    explicit RichTextCheckBox(const QString &text, QWidget *parent = nullptr);
     QCheckBox *getCheckBox();
     QString text() const;
     QString plainText() const;
@@ -77,8 +77,8 @@ class RichTextCheckBox : public QWidget
   private:
     HoverCheckBox *checkBox;
     ClickableLabel *label;
-    virtual void enterEvent(QEvent *);
-    virtual void leaveEvent(QEvent *);
+    void enterEvent(QEvent * /*unused*/) override;
+    void leaveEvent(QEvent * /*unused*/) override;
 
   signals:
     void toggled(bool);

--- a/src/Widgets/SupportUsDialog.cpp
+++ b/src/Widgets/SupportUsDialog.cpp
@@ -25,7 +25,7 @@
 #include <QTextBrowser>
 #include <QVBoxLayout>
 
-SupportUsDialog::SupportUsDialog(QWidget *parent)
+SupportUsDialog::SupportUsDialog(QWidget *parent) : QDialog(parent)
 {
     setModal(true);
     setAttribute(Qt::WA_DeleteOnClose);

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -597,8 +597,7 @@ void AppWindow::on_actionSupportUs_triggered() // NOLINT: It can be made static
 
 void AppWindow::on_actionManual_triggered() // NOLINT: method can be made static
 {
-    QDesktopServices::openUrl(
-        QUrl(tr("https://cpeditor.org/%1/docs").arg(MINOR_VERSION)).adjusted(QUrl::NormalizePathSegments));
+    QDesktopServices::openUrl(Util::websiteLink("docs"));
 }
 
 void AppWindow::on_actionReportIssues_triggered() // NOLINT: method can be made static

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -460,10 +460,6 @@ Git commit hash: %3
         <translation>Установить лими времени</translation>
     </message>
     <message>
-        <source>https://cpeditor.org/%1/docs</source>
-        <translation>https://cpeditor.org/%1/ru/docs</translation>
-    </message>
-    <message>
         <source>Full Screen</source>
         <translation>Полный экран</translation>
     </message>
@@ -1305,10 +1301,6 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     <message>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>Вы можете почитать &lt;a href=&quot;%1&quot;&gt;документация&lt;/a&gt; или просмотреть настройки для более подробной информации.</translation>
-    </message>
-    <message>
-        <source>https://cpeditor.org/%1/docs</source>
-        <translation>https://cpeditor.org/%1/ru/docs</translation>
     </message>
     <message>
         <source>Appearance Settings</source>
@@ -2446,10 +2438,6 @@ Consult your terminal emulator for the suitable arguments.</source>
 Уточните аргументы, доступные для вашего эмулятора терминала.</translation>
     </message>
     <message>
-        <source>Head Comments</source>
-        <translation>Комментарии в шапке</translation>
-    </message>
-    <message>
         <source>Save Test Case To A File</source>
         <translation>Сохранить тесткейс в файл</translation>
     </message>
@@ -2580,6 +2568,40 @@ You can learn about it by running `yapf --style-help`.</source>
     <message>
         <source>Format the code when auto-saving it.</source>
         <translation>Форматировать код, когда он автоматически сохраняется.</translation>
+    </message>
+    <message>
+        <source>Content of the head comments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Enable Proxy on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -460,10 +460,6 @@ git 提交编号: %3
         <translation>设置时间限制</translation>
     </message>
     <message>
-        <source>https://cpeditor.org/%1/docs</source>
-        <translation>https://cpeditor.org/%1/zh/docs</translation>
-    </message>
-    <message>
         <source>Full Screen</source>
         <translation>全屏</translation>
     </message>
@@ -1305,10 +1301,6 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     <message>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>你可以阅读 &lt;a href=&quot;%1&quot;&gt;文档&lt;/a&gt; 或在设置中浏览以获取更多信息。</translation>
-    </message>
-    <message>
-        <source>https://cpeditor.org/%1/docs</source>
-        <translation>https://cpeditor.org/%1/zh/docs</translation>
     </message>
     <message>
         <source>Appearance Settings</source>
@@ -2439,10 +2431,6 @@ Consult your terminal emulator for the suitable arguments.</source>
 请自行查阅适用于你所使用的终端模拟器的参数。</translation>
     </message>
     <message>
-        <source>Head Comments</source>
-        <translation>头部注释</translation>
-    </message>
-    <message>
         <source>Save Test Case To A File</source>
         <translation>将测试用例保存到文件</translation>
     </message>
@@ -2572,6 +2560,40 @@ You can learn about it by running `yapf --style-help`.</source>
     <message>
         <source>Format the code when auto-saving it.</source>
         <translation>自动保存时格式化代码。</translation>
+    </message>
+    <message>
+        <source>Content of the head comments</source>
+        <translation>头部注释的内容</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Enable Proxy on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>网络代理</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>网络代理</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>网络代理</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>网络代理</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>网络代理</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>网络代理</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description

Add links to the docs in the preferences window.

## Motivation and Context

Make it easier for the users to find the documentation.

## How Has This Been Tested?

On Arch Linux.

## Screenshots (if appropriate)

![图片](https://user-images.githubusercontent.com/30581822/105608122-0d772600-5ddd-11eb-836d-c88fbe6f39c4.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

