### PR TITLE
fix: copy TResult instead of include testlib.h

### DIFF
--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -21,10 +21,9 @@
 #include "Core/MessageLogger.hpp"
 #include "Core/Runner.hpp"
 #include "Util/FileUtil.hpp"
-#include "third_party/testlib/testlib.h"
+#include "generated/SettingsHelper.hpp"
 #include <QFile>
 #include <QTemporaryDir>
-#include <generated/SettingsHelper.hpp>
 
 namespace Core
 {

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -174,6 +174,19 @@ class Checker : public QObject
         QString input, output, expected;
     };
 
+    // copied from testlib.h, see #746 for why not include testlib.h
+    enum TResult
+    {
+        _ok = 0,
+        _wa = 1,
+        _pe = 2,
+        _fail = 3,
+        _dirt = 4,
+        _points = 5,
+        _unexpected_eof = 8,
+        _partially = 16
+    };
+
     CheckerType checkerType;         // the type of the checker
     QString checkerPath;             // the file path to the custom checker
     QTemporaryDir *tmpDir = nullptr; // the temp directory to save the I/O files, testlib.h and the compiled checker


### PR DESCRIPTION
This fixes #746.

## Description

Copy TResult from testlib.h instead of include testlib.h.

## Related Issues / Pull Requests

This fixes #746.

## Additional text

@sonulohani you can test this.
