### PR TITLE
fix(Find/Replace): make Find/Replace a dialog instead of a window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+## Fixed
+
+-   Fix that the Find/Replace dialog is not floating in i3-wm. (#767)
+
 ## v6.8
 
 ### Added

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -278,7 +278,7 @@ void AppWindow::allocate()
 
     findReplaceDialog = new FindReplaceDialog(this);
     findReplaceDialog->setModal(false);
-    findReplaceDialog->setWindowFlags(Qt::Window | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint |
+    findReplaceDialog->setWindowFlags(Qt::Dialog | Qt::WindowMinimizeButtonHint | Qt::WindowMaximizeButtonHint |
                                       Qt::WindowCloseButtonHint);
 
     lspTimerCpp->setInterval(SettingsHelper::getLSPDelayCpp());


### PR DESCRIPTION
## Description

Make Find/Replace a dialog instead of a window.

## Motivation and Context

This makes it a floating window in i3-wm.

## How Has This Been Tested?

On Arch Linux i3-wm.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
