### PR TITLE
fix: completely remove the new window option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,9 +124,6 @@ int main(int argc, char *argv[])
     parser.addOptions(
         {{{"d", "depth"}, "Maximum depth when opening files in directories. No limit if not specified.", "depth", "-1"},
          {{"c", "contest"}, "Open a contest. i.e. Open files named A, B, ..., Z in a given directory."},
-         /*{{"n", "new"},
-          "Open a new window instead of open tabs in an existing window. This may cause error of the competitive "
-          "companion server."},*/
          {"cpp", "Open C++ files in given directories. / Use C++ for open contests."},
          {"java", "Open Java files in given directories. / Use Java for open contests."},
          {"python", "Open Python files in given directories. / Use Python for open contests."},
@@ -192,7 +189,7 @@ int main(int argc, char *argv[])
 
         LOG_INFO("Path extracted as : " << path);
 
-        if (/*!parser.isSet("new") &&*/ app.isSecondary())
+        if (app.isSecondary())
         {
             QJsonObject json;
             json["type"] = "contest";
@@ -243,7 +240,7 @@ int main(int argc, char *argv[])
         LOG_INFO("Path is : " << path);
     }
 
-    if (/*!parser.isSet("new") &&*/ app.isSecondary())
+    if (app.isSecondary())
     {
         QJsonObject json;
         json["type"] = "normal";


### PR DESCRIPTION
In fact, now we are assuming there's only one window, so we'll actually never enable this option again even if #131 is fixed. This closes #131.