### PR TITLE
Fix selection when Dark Fusion is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 -   Fix that the Find/Replace dialog is not floating in i3-wm. (#767)
+-   Fix text selection color when Dark Fusion is selected. (#788)
 
 ## v6.8
 

--- a/src/Core/StyleManager.cpp
+++ b/src/Core/StyleManager.cpp
@@ -144,7 +144,7 @@ QPalette StyleManager::darkFusionPalette()
     darkPalette.setColor(QPalette::BrightText, Qt::red);
     darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
     darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
-    darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+    darkPalette.setColor(QPalette::HighlightedText, Qt::white);
     darkPalette.setColor(QPalette::Disabled, QPalette::HighlightedText, disabledColor);
 
     return darkPalette;


### PR DESCRIPTION
## Fixes
Closes #788

## Screenshots (if appropriate)

#### Light theme
![image](https://user-images.githubusercontent.com/2958681/110805503-25303e00-82a7-11eb-8fbc-df4c6e1d2bd5.png)

#### Monokai theme
![image](https://user-images.githubusercontent.com/2958681/110805636-48f38400-82a7-11eb-8b66-0065d50ec836.png)

#### Dracula theme
![image](https://user-images.githubusercontent.com/2958681/110805688-57da3680-82a7-11eb-927e-8d51556c1b8b.png)

#### Solarized Light
![image](https://user-images.githubusercontent.com/2958681/110805751-658fbc00-82a7-11eb-93c8-394c02c116ed.png)

#### Solarized Dark
![image](https://user-images.githubusercontent.com/2958681/110805823-750f0500-82a7-11eb-9eaf-07144c82dd90.png)




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
