### PR TITLE
feat: Configurable text cursor width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## UNRELEASED
 
-## Fixed
+### Added
+
+-   Configurable text cursor width. (#781 and #795)
+
+### Fixed
 
 -   Fix that the Find/Replace dialog is not floating in i3-wm. (#767)
 -   Fix text selection color when Dark Fusion is selected. (#788)

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -189,7 +189,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     AddPageHelper(this)
         .page(TRKEY("Code Edit"),
-              {"Tab Width", "Auto Indent", "Wrap Text", "Auto Complete Parentheses", "Auto Remove Parentheses",
+              {"Tab Width", "Cursor Width", "Auto Indent", "Wrap Text", "Auto Complete Parentheses", "Auto Remove Parentheses",
                "Tab Jump Out Parentheses", "Replace Tabs"})
         .dir(TRKEY("Language"))
             .page(TRKEY("General"), {"Default Language"})

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -10,6 +10,13 @@
         ]
     },
     {
+        "name": "Cursor Width",
+        "type": "int",
+        "default": 1,
+        "param": "QVariantList {1,10}",
+        "tip": "The width of the cursor in pixels"
+    },
+    {
         "name": "Geometry",
         "type": "QRect",
         "notr": true

--- a/src/Util/QCodeEditorUtil.cpp
+++ b/src/Util/QCodeEditorUtil.cpp
@@ -31,6 +31,7 @@ void applySettingsToEditor(QCodeEditor *editor, const QString &language)
 {
     LOG_INFO("Applying settings to QCodeEditor");
 
+    editor->setCursorWidth(SettingsHelper::getCursorWidth());
     editor->setTabReplace(SettingsHelper::isReplaceTabs());
     editor->setTabReplaceSize(SettingsHelper::getTabWidth());
     editor->setAutoIndentation(SettingsHelper::isAutoIndent());

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1524,6 +1524,14 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <translation>Ширина символов вкладки или количество пробелов на конце</translation>
     </message>
     <message>
+        <source>Cursor Width</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>The width of the cursor in pixels</source>
+        <translation></translation>
+    </message>
+    <message>
         <source>Editor Font</source>
         <translation>Шрифт редактора</translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1524,6 +1524,14 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <translation>制表符的宽度或缩进的空格个数</translation>
     </message>
     <message>
+        <source>Cursor Width</source>
+        <translation>光标宽度</translation>
+    </message>
+    <message>
+        <source>The width of the cursor in pixels</source>
+        <translation>光标的像素宽度</translation>
+    </message>
+    <message>
         <source>Editor Font</source>
         <translation>编辑器字体</translation>
     </message>


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
Added configurable text cursor width (https://github.com/cpeditor/cpeditor/issues/781). The text cursor width ranges from 1(default) to 10. 

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/2958681/110953531-7acf1e00-836d-11eb-8099-cf6930e1c35c.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
