### PR TITLE
feat: Show dialog on full screen for first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+-   Show dialog on full screen for first time. (#786)
 -   Configurable text cursor width. (#781 and #795)
 -   Now accepted testcases can be auto-unchecked. (#734 and #797)
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -1178,7 +1178,7 @@
     "tip": "Automatically uncheck test cases when they get accepted."
   },
   {
-    "name": "On Full Screen Dialog Shown",
+    "name": "Full Screen Dialog Shown",
     "type": "bool",
     "default": false,
     "notr": true

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -1176,5 +1176,11 @@
     "type": "bool",
     "default": "false",
     "tip": "Automatically uncheck test cases when they get accepted."
+  },
+  {
+    "name": "On Full Screen Dialog Shown",
+    "type": "bool",
+    "default": false,
+    "notr": true
   }
 ]

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -366,8 +366,6 @@ void AppWindow::maybeSetHotkeys()
         hotkeyObjects.push_back(
             new QShortcut(SettingsHelper::getHotkeySnippets(), this, [this] { on_actionUseSnippets_triggered(); }));
     }
-
-    hotkeyObjects.push_back(new QShortcut(Qt::Key_Escape, this, [this] { ui->actionFullScreen->setChecked(false); }));
 }
 
 bool AppWindow::closeTab(int index)
@@ -1302,6 +1300,12 @@ void AppWindow::on_actionFullScreen_toggled(bool checked)
     auto state = windowState();
     state.setFlag(Qt::WindowFullScreen, checked);
     setWindowState(state);
+    if (!SettingsHelper::isOnFullScreenDialogShown())
+    {
+        QMessageBox::information(this, tr("How to exit full-screen"),
+                                 tr("Press the F11 key on your computer's keyboard to exit full-screen mode."));
+        SettingsHelper::setOnFullScreenDialogShown(true);
+    }
 }
 
 void AppWindow::on_actionIndent_triggered()

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1300,11 +1300,10 @@ void AppWindow::on_actionFullScreen_toggled(bool checked)
     auto state = windowState();
     state.setFlag(Qt::WindowFullScreen, checked);
     setWindowState(state);
-    if (!SettingsHelper::isOnFullScreenDialogShown())
+    if (!SettingsHelper::isFullScreenDialogShown())
     {
-        QMessageBox::information(this, tr("How to exit full-screen"),
-                                 tr("Press the F11 key on your computer's keyboard to exit full-screen mode."));
-        SettingsHelper::setOnFullScreenDialogShown(true);
+        QMessageBox::information(this, tr("How to exit full-screen"), tr("Press F11 key to exit full-screen mode."));
+        SettingsHelper::setFullScreenDialogShown(true);
     }
 }
 

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -467,6 +467,14 @@ Git commit hash: %3
         <source>Support us</source>
         <translation>Поддержи нас</translation>
     </message>
+    <message>
+        <source>How to exit full-screen</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Press the F11 key on your computer&apos;s keyboard to exit full-screen mode.</source>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -472,7 +472,7 @@ Git commit hash: %3
         <translation></translation>
     </message>
     <message>
-        <source>Press the F11 key on your computer&apos;s keyboard to exit full-screen mode.</source>
+        <source>Press F11 key to exit full-screen mode.</source>
         <translation></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -472,7 +472,7 @@ git 提交编号: %3
         <translation></translation>
     </message>
     <message>
-        <source>Press the F11 key on your computer&apos;s keyboard to exit full-screen mode.</source>
+        <source>Press F11 key to exit full-screen mode.</source>
         <translation></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -467,6 +467,14 @@ git 提交编号: %3
         <source>Support us</source>
         <translation>支持我们</translation>
     </message>
+    <message>
+        <source>How to exit full-screen</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Press the F11 key on your computer&apos;s keyboard to exit full-screen mode.</source>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>


### PR DESCRIPTION
## Description
This PR removes the ESC push button binding for exiting out of the full screen. Additionally, it will show the dialog for the user who has either accidentally pressed F11 or pressed F11 but doesn't know how to restore the window back to normal

## Related Issues / Pull Requests
https://github.com/cpeditor/cpeditor/issues/786

## Motivation and Context
Esc key will be used to cancel the selection

## How Has This Been Tested?
Ubuntu 21.04

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/2958681/116816814-22ecb080-ab81-11eb-807e-1fe225dce823.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
