### PR TITLE
feat: update full-sreen state when WindowState changes

### DIFF
--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -242,6 +242,15 @@ void AppWindow::dropEvent(QDropEvent *event)
     openPaths(paths);
 }
 
+void AppWindow::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::WindowStateChange)
+    {
+        ui->actionFullScreen->setChecked(windowState().testFlag(Qt::WindowFullScreen));
+    }
+    QMainWindow::changeEvent(event);
+}
+
 /******************** PRIVATE METHODS ********************/
 void AppWindow::setConnections()
 {

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -64,11 +64,13 @@ class AppWindow : public QMainWindow
                        QWidget *parent = nullptr);
     ~AppWindow() override;
 
+    PreferencesWindow *getPreferencesWindow() const;
+
+  protected:
     void closeEvent(QCloseEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void dragEnterEvent(QDragEnterEvent *event) override;
-
-    PreferencesWindow *getPreferencesWindow() const;
+    void changeEvent(QEvent *event) override;
 
   public slots:
     void onReceivedMessage(quint32 instanceId, QByteArray message);


### PR DESCRIPTION
## Description

Update the full-screen state when the window state is changed without triggering the actionFullScreen action.

## How Has This Been Tested?

In i3-wm, tested with Meta+F.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
