### PR TITLE
fix: use Q_OS_MACOS instead of Q_OS_MAC

### DIFF
--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -239,7 +239,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .dir(TRKEY("Actions"))
             .page(TRKEY("Save"), {"Save Faster", "Save File On Compilation", "Save File On Execution", "Save Tests"})
             .page(TRKEY("Auto Save"), {"Auto Save", "Auto Save Interval", "Auto Save Interval Type"})
-#if defined(Q_OS_UNIX) && (!defined(Q_OS_MAC))
+#if defined(Q_OS_UNIX) && (!defined(Q_OS_MACOS))
             .page(TRKEY("Detached Execution"), {"Detached Run Terminal Program", "Detached Run Terminal Arguments"})
 #endif
             .page(TRKEY("Save Session"), {"Hot Exit/Enable", "Hot Exit/Auto Save", "Hot Exit/Auto Save Interval"})

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -84,7 +84,7 @@ AppWindow::AppWindow(bool noHotExit, QWidget *parent) : QMainWindow(parent), ui(
     Core::StyleManager::setDefault();
 
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     setWindowIcon(QIcon(":/macos-icon.png"));
 #else
     setWindowIcon(QIcon(":/icon.png"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     SingleApplication::setApplicationName("CP Editor");
     SingleApplication::setApplicationVersion(DISPLAY_VERSION);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     QApplication::setWindowIcon(QIcon(":/macos-icon.png"));
 #else
     QApplication::setWindowIcon(QIcon(":/icon.png"));


### PR DESCRIPTION
Q_OS_MAC is deprecated. It includes not only macOS but also other Apple OSs like iOS.

https://doc.qt.io/qt-5/qtglobal.html#Q_OS_MAC