### PR TITLE
fix: add ".exe" in the C++ compilation command on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   Fix that the Find/Replace dialog is not floating in i3-wm. (#767)
 -   Fix text selection color when Dark Fusion is selected. (#788)
 -   Now entering/exiting the full-screen mode outside of CP Editor (via the OS/DE/WM) is correctly handled. (#833)
+-   Fix that Detached Execution doesn't work on Windows with clang++. (#872 and #873)
 
 ## Changed
 

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -121,7 +121,7 @@ QString Compiler::outputPath(const QString &tmpFilePath, const QString &sourceFi
     if (createDirectory)
     {
         if (lang == "C++")
-            QDir().mkpath(QFileInfo(res).absolutePath());
+            QDir().mkpath(QFileInfo(res).absolutePath() + Util::exeSuffix); // Note: Util::exeSuffix is empty on UNIX
         else if (lang == "Java")
             QDir().mkpath(res);
     }
@@ -131,12 +131,10 @@ QString Compiler::outputPath(const QString &tmpFilePath, const QString &sourceFi
 QString Compiler::outputFilePath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
                                  bool createDirectory)
 {
-    auto path = outputPath(tmpFilePath, sourceFilePath, lang, createDirectory);
+    const auto &path = outputPath(tmpFilePath, sourceFilePath, lang, createDirectory);
 
-    if (lang == "C++")
-        path += Util::exeSuffix;
-    else if (lang == "Java")
-        path = QDir(path).filePath(SettingsHelper::getJavaClassName() + ".class");
+    if (lang == "Java")
+        return QDir(path).filePath(SettingsHelper::getJavaClassName() + ".class");
 
     return path;
 }

--- a/src/Core/Compiler.hpp
+++ b/src/Core/Compiler.hpp
@@ -62,6 +62,7 @@ class Compiler : public QObject
 
     /**
      * @brief get the output path (executable file path for C++, class path for Java, tmp file path for Python)
+     * This should be used as an argument in the compilation command
      * @param tmpFilePath the path to the temporary file which is compiled
      * @param sourceFilePath the path to the original source file, if it's empty, tmpFilePath will be used instead of it
      * @param lang the language being compiled
@@ -72,7 +73,7 @@ class Compiler : public QObject
 
     /**
      * @brief Similar to Compiler::outputPath, but returns the path of the output file.
-     * i.e. with .exe on Windows for C++, class file instead of containing directory for Java
+     * This should be used to find the executable file for C++ and class file for Java.
      */
     static QString outputFilePath(const QString &tmpFilePath, const QString &sourceFilePath, const QString &lang,
                                   bool createDirectory = true);


### PR DESCRIPTION
## Related Issues / Pull Requests

This fixes #872.

## How Has This Been Tested?

Not tested yet. I bought a new laptop and my Windows dev environment isn't prepared yet.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
