### PR TITLE
docs(VERSIONING): add manual trigger deployment

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -113,7 +113,7 @@ Suppose you are releasing the version `2.4.1`:
 
 Suppose you are releasing `2.3.7` and `2.4.1`:
 
-1.  In [the documentation repo](https://github.com/cpeditor/cpeditor.github.io), create a new branch `v2.4` based on `hugo` (the default branch).
+1.  In [the documentation repo](https://github.com/cpeditor/cpeditor.github.io), create a new branch `v2.4` based on `hugo` (the default branch), push it and manually trigger the deploy action.
 2.  Create a new branch `v2.4` based on master.
 3.  Checkout to `v2.3`. Change [STABLE_VERSION](dist/STABLE_VERSION) to `2.3.`. Do the first 4 steps to [make a new stable release](#the-complete-workflow-to-make-a-new-stable-release). Also do step 5 but the content of the changelog is all changelogs from `2.3.1` to `2.3.7`.
 4.  Merge `v2.3` into `v2.4`. Do the first 5 steps to [make a new beta release](#the-complete-workflow-to-make-a-new-beta-release).


### PR DESCRIPTION
Due to [`52fa697`](https://github.com/cpeditor/cpeditor.github.io/pull/140/commits/52fa6977168cade8132c2cf24bef007f78fe709c), now we need to manually trigger the deployment for new minor versions.