### PR TITLE
ci(release): include LLVM in the winlibs release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,36 +7,42 @@ on:
 
 env:
   QT_VERSION: 5.15.2
+  WINLIBS_GCC: 11.1.0
+  WINLIBS_LLVM: 12.0.0
+  WINLIBS_MINGW: 9.0.0-r2
 
 jobs:
-  get-winlibs-versions:
+  # "env" is only available in jobs, we need to convert them to outputs so that they can be used in the matrix
+  get-winlibs-outputs:
     runs-on: ubuntu-latest
     steps:
-      - name: Get Winlibs versions
+      - name: Get winlibs outputs
         id: get
         run: |
-          tag=$(curl https://api.github.com/repos/brechtsanders/winlibs_mingw/releases/latest | jq -r .tag_name)
-          echo "::set-output name=tag-name::$tag"
-          echo "::set-output name=gcc-version::$(echo $tag | cut -d'-' -f 1)"
-          echo "::set-output name=mingw-version::$(echo $tag | rev | cut -d'-' -f -2 | rev)"
+          echo ::set-output name=GCC::$WINLIBS_GCC
+          echo ::set-output name=LLVM::$WINLIBS_LLVM
+          echo ::set-output name=MINGW::$WINLIBS_MINGW
+          echo ::set-output name=tag::$WINLIBS_GCC-$WINLIBS_LLVM-$WINLIBS_MINGW
     outputs:
-      tag-name: ${{ steps.get.outputs.tag-name }}
-      gcc-version: ${{ steps.get.outputs.gcc-version }}
-      mingw-version: ${{ steps.get.outputs.mingw-version }}
+      GCC: ${{ steps.get.outputs.GCC }}
+      LLVM: ${{ steps.get.outputs.LLVM }}
+      MINGW: ${{ steps.get.outputs.MINGW }}
+      tag: ${{ steps.get.outputs.tag }}
 
   release:
     name: "OS: ${{ matrix.config.os }} Arch: ${{ matrix.config.arch }} Portable: ${{ matrix.config.portable-option }} Winlibs: ${{ matrix.config.winlibs }}"
     runs-on: "${{ matrix.config.os }}"
-    needs:
-      - get-winlibs-versions
+    needs: get-winlibs-outputs
     strategy:
       fail-fast: false
       matrix:
         config:
           - os: "ubuntu-18.04"
             portable-option: "Off"
+            winlibs: false
           - os: "macos-latest"
             portable-option: "Off"
+            winlibs: false
           - os: "windows-latest"
             arch: x64
             platform: x64
@@ -70,7 +76,7 @@ jobs:
             platform: x64
             qtarch: win64_msvc2019_64
             portable-option: "Off"
-            filename-suffix: "setup-with-gcc-${{ needs.get-winlibs-versions.outputs.gcc-version }}.exe"
+            filename-suffix: "setup-with-gcc-${{ needs.get-winlibs-outputs.outputs.GCC }}-LLVM-${{ needs.get-winlibs-outputs.outputs.LLVM }}.exe"
             winlibs: true
             winlibs-arch: x86_64-posix-seh
             mingw-arch: mingw64
@@ -79,7 +85,7 @@ jobs:
             platform: x64
             qtarch: win64_msvc2019_64
             portable-option: "On"
-            filename-suffix: "portable-with-gcc-${{ needs.get-winlibs-versions.outputs.gcc-version }}.zip"
+            filename-suffix: "portable-with-gcc-${{ needs.get-winlibs-outputs.outputs.GCC }}-LLVM-${{ needs.get-winlibs-outputs.outputs.LLVM }}.zip"
             winlibs: true
             winlibs-arch: x86_64-posix-seh
             mingw-arch: mingw64
@@ -88,7 +94,7 @@ jobs:
             platform: Win32
             qtarch: win32_msvc2019
             portable-option: "Off"
-            filename-suffix: "setup-with-gcc-${{ needs.get-winlibs-versions.outputs.gcc-version }}.exe"
+            filename-suffix: "setup-with-gcc-${{ needs.get-winlibs-outputs.outputs.GCC }}-LLVM-${{ needs.get-winlibs-outputs.outputs.LLVM }}.exe"
             winlibs: true
             winlibs-arch: i686-posix-dwarf
             mingw-arch: mingw32
@@ -97,7 +103,7 @@ jobs:
             platform: Win32
             qtarch: win32_msvc2019
             portable-option: "On"
-            filename-suffix: "portable-with-gcc-${{ needs.get-winlibs-versions.outputs.gcc-version }}.zip"
+            filename-suffix: "portable-with-gcc-${{ needs.get-winlibs-outputs.outputs.GCC }}-LLVM-${{ needs.get-winlibs-outputs.outputs.LLVM }}.zip"
             winlibs: true
             winlibs-arch: i686-posix-dwarf
             mingw-arch: mingw32
@@ -277,14 +283,14 @@ jobs:
         if: startsWith(matrix.config.os, 'windows') && matrix.config.winlibs
         id: winlibs
         shell: bash
-        run: echo "::set-output name=asset::winlibs-${{ matrix.config.winlibs-arch }}-gcc-${{ needs.get-winlibs-versions.outputs.gcc-version }}-mingw-w64-${{ needs.get-winlibs-versions.outputs.mingw-version }}.7z"
+        run: echo "::set-output name=asset::winlibs-${{ matrix.config.winlibs-arch }}-gcc-${{ needs.get-winlibs-outputs.outputs.GCC }}-llvm-${{ needs.get-winlibs-outputs.outputs.LLVM }}-mingw-w64-${{ needs.get-winlibs-outputs.outputs.MINGW }}.7z"
 
       - name: "[Windows] Download Winlibs"
         if: startsWith(matrix.config.os, 'windows') && matrix.config.winlibs
         uses: robinraju/release-downloader@v1
         with:
           repository: brechtsanders/winlibs_mingw
-          tag: ${{ needs.get-winlibs-versions.outputs.tag-name }}
+          tag: ${{ needs.get-winlibs-outputs.outputs.tag }}
           fileName: ${{ steps.winlibs.outputs.asset }}
 
       - name: "[Windows] Extract Winlibs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Added
+
+-   Now the winlibs release on Windows includes LLVM. If you use the `clangd` in this release as the C++ Language Server, `<bits/stdc++.h>` should be properly recognized. (#878)
+
 ### Fixed
 
 -   Fix that two dialogs are shown when entering full-screen mode for the first time. (#875)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -115,7 +115,7 @@ Suppose you are releasing `2.3.7` and `2.4.1`:
 
 1.  In [the documentation repo](https://github.com/cpeditor/cpeditor.github.io), create a new branch `v2.4` based on `hugo` (the default branch).
 2.  Create a new branch `v2.4` based on master.
-3.  Checkout to `v2.3`. Change [STABLE_VERSION](dist/STABLE_VERSION) to `2.3.`. Do the first 4 steps to [make a new stable release](#the-complete-workflow-to-make-a-new-stable-release). Also do step 5 but the content of the changelog is all changelogs from `2.3.1` to `2.3.7`.
+3.  Checkout to `v2.3`. Change [STABLE_VERSION](dist/STABLE_VERSION) to `2.3.`. Update Qt version and Winlibs version in [release.yml](.github/workflows/release.yml). Do the first 4 steps to [make a new stable release](#the-complete-workflow-to-make-a-new-stable-release). Also do step 5 but the content of the changelog is all changelogs from `2.3.1` to `2.3.7`.
 4.  Merge `v2.3` into `v2.4`. Do the first 5 steps to [make a new beta release](#the-complete-workflow-to-make-a-new-beta-release).
 5.  Create a new branch `merge-2.3.7-2.4.1` based on master. Merge `v2.4` into `merge-2.3.7-2.4.1`. Set the version in [CMakeLists.txt](CMakeLists.txt) to `2.5.0`. Rename `## 2.4.1 (Beta)` in [CHANGELOG.md](CHANGELOG.md) to `## v2.4`. Update the version badges in [README.md](README.md). Create a PR merging `merge-2.3.7-2.4.1` into master.
 


### PR DESCRIPTION
## Description

Include LLVM in the winlibs release.

## Related Issues / Pull Requests

This could be an out-of-box solution for #824.

## Motivation and Context

At least on my Windows, the clangd downloaded on LLVM official website doesn't recognize `<bits/stdc++.h>` while the one in winlibs does.

## How Has This Been Tested?

https://github.com/ouuan/cpeditor/releases/tag/0.20210617.3

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
