### PR TITLE
fix: add suffix for Default File Path For Problem URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Actually fix that Detached Execution doesn't work on Windows with clang++, which was incorrectly fixed in #873.
 -   Change the swap-line shortcuts on macOS from `Ctrl+Shift+Up/Down` to `Command+Control+Up/Down` to fix that the old shortcuts were unusable on macOS. (#863 and #876)
 -   Fix that the icon is not in the center on macOS. (#880)
+-   Fix that there's no suffix when using Default File Path For Problem URLs. (#894)
 
 ## v6.9
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -37,15 +37,11 @@
 #include "generated/version.hpp"
 #include <QCodeEditor>
 #include <QFileSystemWatcher>
-#include <QFontDialog>
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QRegularExpression>
-#include <QSaveFile>
 #include <QScrollBar>
-#include <QShortcut>
-#include <QSyntaxStyle>
 #include <QTemporaryDir>
 #include <QTextBlock>
 #include <QTimer>
@@ -945,12 +941,14 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
                     }
                 }
             }
+
             if (defaultPath.isEmpty())
             {
-                defaultPath = Util::fileNameWithSuffix(
-                    QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(getTabTitle(false, false)),
-                    language);
+                defaultPath =
+                    QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(getTabTitle(false, false));
             }
+
+            defaultPath = Util::fileNameWithSuffix(defaultPath, language);
         }
 
         // Create the parent directories of the default path if they don't exist,


### PR DESCRIPTION
## Description

Add file suffix for Default File Path For Problem URLs.

## Related Issues / Pull Requests

This was introduced in #652.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).