### PR TITLE
feat: auto re-compile checker when changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 -   Now the winlibs release on Windows includes LLVM. If you use the `clangd` in this release as the C++ Language Server, `<bits/stdc++.h>` should be properly recognized. (#878)
+-   Now custom checkers will be automatically recompiled if it's changed. (#843 and #898)
 
 ### Fixed
 

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -91,6 +91,8 @@ void Checker::prepare(const QString &compileCommand)
             break;
         }
 
+        hash = Util::getFileHash(checkerResource);
+
         // get the code of the checker
         QString checkerCode = Util::readFile(checkerResource, tr("Read Checker"), log);
         if (checkerCode.isNull())
@@ -272,7 +274,8 @@ bool Checker::checkIgnoreTrailingSpaces(const QString &output, const QString &ex
         while (!answerLine.isEmpty() && answerLine.back().isSpace())
             answerLine.chop(1);
 
-        // if they are considered the same, the current line should be exactly the same after removing trailing spaces
+        // if they are considered the same, the current line should be exactly the same after removing trailing
+        // spaces
         if (outputLine != answerLine)
             return false;
     }

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -274,8 +274,7 @@ bool Checker::checkIgnoreTrailingSpaces(const QString &output, const QString &ex
         while (!answerLine.isEmpty() && answerLine.back().isSpace())
             answerLine.chop(1);
 
-        // if they are considered the same, the current line should be exactly the same after removing trailing
-        // spaces
+        // if they are considered the same, the current line should be exactly the same after removing trailing spaces
         if (outputLine != answerLine)
             return false;
     }

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -117,11 +117,7 @@ void Checker::prepare()
 
 void Checker::reqeustCheck(int index, const QString &input, const QString &output, const QString &expected)
 {
-    if (!isLatest())
-    {
-        LOG_INFO("Recompiling checker");
-        prepare();
-    }
+    recompileIfChanged();
     LOG_INFO(BOOL_INFO_OF(compiled));
     if (compiled)
         check(index, input, output, expected); // check immediately if the checker is compiled
@@ -146,11 +142,8 @@ void Checker::clearTasks()
 
 void Checker::onCompilationFinished()
 {
-    if (!isLatest())
-    {
-        prepare();
+    if (recompileIfChanged())
         return;
-    }
     compiled = true;
     log->info(tr("Checker"), tr("The checker is compiled"));
     for (auto const &t : pendingTasks)
@@ -329,12 +322,16 @@ QString Checker::head(int index)
     return tr("Checker[%1]").arg(index + 1);
 }
 
-bool Checker::isLatest()
+bool Checker::recompileIfChanged()
 {
     if (checkerOriginalPath.isEmpty())
-        return true;
+        return false;
     const QString currentCheckerCode = Util::readFile(checkerOriginalPath, "Read Checker", log);
-    return currentCheckerCode.isNull() || currentCheckerCode == checkerCode;
+    if (currentCheckerCode.isNull() || currentCheckerCode == checkerCode)
+        return false;
+    LOG_INFO("Recompiling checker");
+    prepare();
+    return true;
 }
 
 } // namespace Core

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -347,9 +347,7 @@ bool Checker::isLatest()
     if (checkerResource.isEmpty())
         return true;
     QString newHash = Util::getFileHash(checkerResource);
-    if (newHash.isEmpty() || newHash == hash)
-        return true;
-    return false;
+    return newHash.isEmpty() || newHash == hash;
 }
 
 } // namespace Core

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -330,6 +330,7 @@ bool Checker::recompileIfChanged()
     if (currentCheckerCode.isNull() || currentCheckerCode == checkerCode)
         return false;
     LOG_INFO("Recompiling checker");
+    log->info(tr("Checker"), tr("The source code of the checker has changed, recompiling..."));
     prepare();
     return true;
 }

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -112,7 +112,7 @@ void Checker::prepare()
     connect(compiler, &Compiler::compilationErrorOccurred, this, &Checker::onCompilationErrorOccurred);
     connect(compiler, &Compiler::compilationFailed, this, &Checker::onCompilationFailed);
     connect(compiler, &Compiler::compilationKilled, this, &Checker::onCompilationKilled);
-    compiler->start(checkerTmpPath, "", SettingsHelper::getCppCompileCommand(), "");
+    compiler->start(checkerTmpPath, "", SettingsHelper::getCppCompileCommand(), "C++");
 }
 
 void Checker::reqeustCheck(int index, const QString &input, const QString &output, const QString &expected)

--- a/src/Core/Checker.cpp
+++ b/src/Core/Checker.cpp
@@ -134,6 +134,16 @@ void Checker::onCompilationStarted()
     log->info(tr("Checker"), tr("Started compiling the checker"));
 }
 
+void Checker::clearTasks()
+{
+    pendingTasks.clear();
+    for (auto &t : runners)
+    {
+        delete t;
+    }
+    runners.clear();
+}
+
 void Checker::onCompilationFinished()
 {
     if (!isLatest())

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -108,6 +108,8 @@ class Checker : public QObject
      */
     void clearTasks();
 
+    QString hash;
+
   signals:
     /**
      * @brief return the check result

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -87,10 +87,9 @@ class Checker : public QObject
 
     /**
      * @brief prepare for checking
-     * @param compileCommand the command used to compile the checker
      * @note Testlib checkers will be compiled after calling this function. This should be called only once.
      */
-    void prepare(const QString &compileCommand);
+    void prepare();
 
     /**
      * @brief request the checker to check a testcase
@@ -169,6 +168,8 @@ class Checker : public QObject
      */
     static QString head(int index);
 
+    bool isLatest();
+
     // a struct with the info of a testcase, or called a check task, used to save check requests
     struct Task
     {
@@ -189,8 +190,9 @@ class Checker : public QObject
         _partially = 16
     };
 
-    CheckerType checkerType;         // the type of the checker
-    QString checkerPath;             // the file path to the custom checker
+    CheckerType checkerType; // the type of the checker
+    QString checkerPath;     // the file path to the custom checker
+    QString checkerResource;
     QTemporaryDir *tmpDir = nullptr; // the temp directory to save the I/O files, testlib.h and the compiled checker
                                      // It's not needed by built-in checkers
     MessageLogger *log = nullptr;    // the message logger to show messages to the user

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -51,7 +51,6 @@ class Checker : public QObject
         IgnoreTrailingSpaces, // Ignore blank characters at the end of lines and blank lines at the end.
         Strict,               // White space differences matters, except the differences between \n, \r and \r\n
         /* testlib checkers */
-        /* Ncmp should be the first one in the testlib checkers */
         Ncmp,   // ncmp.cpp in testlib, compare ordered sequences of signed int64 numbers
         Rcmp4,  // rcmp4.cpp in testlib, compare two sequences of doubles, max absolute or relative error = 1e-4
         Rcmp6,  // rcmp6.cpp in testlib, compare two sequences of doubles, max absolute or relative error = 1e-6
@@ -106,8 +105,6 @@ class Checker : public QObject
      * @brief clear the pending tasks and kill executing tasks
      */
     void clearTasks();
-
-    QString hash;
 
   signals:
     /**
@@ -190,16 +187,17 @@ class Checker : public QObject
         _partially = 16
     };
 
-    CheckerType checkerType; // the type of the checker
-    QString checkerPath;     // the file path to the custom checker
-    QString checkerResource;
+    CheckerType checkerType;         // the type of the checker
+    QString checkerTmpPath;          // the file path to checker file in the temp dir
+    QString checkerOriginalPath;     // the path to the original checker
+    QString checkerCode;             // the source code of the checker
     QTemporaryDir *tmpDir = nullptr; // the temp directory to save the I/O files, testlib.h and the compiled checker
                                      // It's not needed by built-in checkers
     MessageLogger *log = nullptr;    // the message logger to show messages to the user
     Compiler *compiler = nullptr;    // the compiler used to compile the checker
     QVector<Runner *> runners;       // the runners used to run the check processes
     QVector<Task> pendingTasks;      // the unsolved check requests
-    bool compiled = false;           // whether the testlib checker is compiled or not
+    std::atomic<bool> compiled;      // whether the testlib checker is compiled or not
                                      // It should be true for built-in checkers.
 };
 

--- a/src/Core/Checker.hpp
+++ b/src/Core/Checker.hpp
@@ -165,7 +165,10 @@ class Checker : public QObject
      */
     static QString head(int index);
 
-    bool isLatest();
+    /**
+     * @returns if checker is changed, it starts recompilation and returns true; otherwise, returns false
+     */
+    bool recompileIfChanged();
 
     // a struct with the info of a testcase, or called a check task, used to save check requests
     struct Task

--- a/src/Util/FileUtil.cpp
+++ b/src/Util/FileUtil.cpp
@@ -155,16 +155,6 @@ QString readFile(const QString &path, const QString &head, MessageLogger *log, b
     return content;
 }
 
-QString getFileHash(const QString &path)
-{
-    QString content = readFile(path);
-    if (content.isEmpty())
-        return QString();
-    QCryptographicHash hash(QCryptographicHash::Md5);
-    hash.addData(content.toUtf8());
-    return hash.result().toHex();
-}
-
 QString configFilePath(QString path)
 {
     return path.replace("$APPCONFIG", QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation))

--- a/src/Util/FileUtil.cpp
+++ b/src/Util/FileUtil.cpp
@@ -20,6 +20,7 @@
 #include "Core/MessageLogger.hpp"
 #include "generated/SettingsHelper.hpp"
 #include <QCoreApplication>
+#include <QCryptographicHash>
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>
@@ -152,6 +153,16 @@ QString readFile(const QString &path, const QString &head, MessageLogger *log, b
     if (content.isNull())
         return "";
     return content;
+}
+
+QString getFileHash(const QString &path)
+{
+    QString content = readFile(path);
+    if (content.isEmpty())
+        return QString();
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    hash.addData(content.toUtf8());
+    return hash.result().toHex();
 }
 
 QString configFilePath(QString path)

--- a/src/Util/FileUtil.cpp
+++ b/src/Util/FileUtil.cpp
@@ -20,7 +20,6 @@
 #include "Core/MessageLogger.hpp"
 #include "generated/SettingsHelper.hpp"
 #include <QCoreApplication>
-#include <QCryptographicHash>
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>

--- a/src/Util/FileUtil.hpp
+++ b/src/Util/FileUtil.hpp
@@ -52,6 +52,9 @@ bool saveFile(const QString &path, const QString &content, const QString &head =
  */
 QString readFile(const QString &path, const QString &head = "Read File", MessageLogger *log = nullptr,
                  bool notExistWarning = false);
+
+QString getFileHash(const QString &path);
+
 /**
  * @brief get the path of a configuration file
  * @param path the original path

--- a/src/Util/FileUtil.hpp
+++ b/src/Util/FileUtil.hpp
@@ -53,8 +53,6 @@ bool saveFile(const QString &path, const QString &content, const QString &head =
 QString readFile(const QString &path, const QString &head = "Read File", MessageLogger *log = nullptr,
                  bool notExistWarning = false);
 
-QString getFileHash(const QString &path);
-
 /**
  * @brief get the path of a configuration file
  * @param path the original path

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -162,6 +162,16 @@ void MainWindow::run()
     if (SettingsHelper::isSaveFileOnExecution())
         saveFile(IgnoreUntitled, tr("Runner"), true);
 
+    if (testcases->checkerType() == Core::Checker::Custom)
+    {
+        QString newHash = Util::getFileHash(testcases->checkerText());
+        if (!newHash.isEmpty() && checker->hash != newHash)
+        {
+            LOG_INFO("Recompiling checker");
+            updateChecker();
+        }
+    }
+
     LOG_INFO("Requesting run of testcases");
     killProcesses();
     testcases->clearOutput();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -162,16 +162,6 @@ void MainWindow::run()
     if (SettingsHelper::isSaveFileOnExecution())
         saveFile(IgnoreUntitled, tr("Runner"), true);
 
-    if (testcases->checkerType() == Core::Checker::Custom)
-    {
-        QString newHash = Util::getFileHash(testcases->checkerText());
-        if (!newHash.isEmpty() && checker->hash != newHash)
-        {
-            LOG_INFO("Recompiling checker");
-            updateChecker();
-        }
-    }
-
     LOG_INFO("Requesting run of testcases");
     killProcesses();
     testcases->clearOutput();
@@ -1255,7 +1245,7 @@ void MainWindow::updateChecker()
     else
         checker = new Core::Checker(testcases->checkerType(), log, this);
     connect(checker, &Core::Checker::checkFinished, testcases, &Widgets::TestCases::setVerdict);
-    checker->prepare(SettingsManager::get(QString("C++/Compile Command")).toString());
+    checker->prepare();
 }
 
 QSplitter *MainWindow::getSplitter()

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -639,6 +639,10 @@ Git commit hash: %3
         <source>Failed to compile the checker: %1</source>
         <translation>Ошибка компиляции символа: %1</translation>
     </message>
+    <message>
+        <source>The source code of the checker has changed, recompiling...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Core::Compiler</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -639,6 +639,10 @@ git 提交编号: %3
         <source>Failed to compile the checker: %1</source>
         <translation>未能成功编译评测器：%1</translation>
     </message>
+    <message>
+        <source>The source code of the checker has changed, recompiling...</source>
+        <translation>评测器的源代码发生改变，正在重新编译...</translation>
+    </message>
 </context>
 <context>
     <name>Core::Compiler</name>


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->
Check the hash of checker's source file to auto re-compile it before run. 
## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->
Fixes #843 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->
macOS 12.0
## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
