### PR TITLE
fix: correct time measurement when test cases are large on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 -   Fix that the icon is not in the center on macOS. (#880)
 -   Fix that there's no suffix when using Default File Path For Problem URLs. (#894)
 -   Fix that when "Save Test Case To A File" the elided version instead of the full content of a test case was saved to the file.
+-   Fix that, on Windows, when there are large test cases, small test cases also take a long time to finish. (#789 and #938)
+-   Fix that, on Windows, when there are large test cases and the user's code is blocking, CP Editor also blocks. (#938)
 
 ## v6.9
 

--- a/src/Core/Runner.cpp
+++ b/src/Core/Runner.cpp
@@ -18,8 +18,10 @@
 #include "Core/Runner.hpp"
 #include "Core/Compiler.hpp"
 #include "Core/EventLogger.hpp"
+#include "Util/FileUtil.hpp"
 #include <QElapsedTimer>
 #include <QFileInfo>
+#include <QTemporaryFile>
 #include <QTimer>
 #include <generated/SettingsHelper.hpp>
 
@@ -86,7 +88,14 @@ void Runner::run(const QString &tmpFilePath, const QString &sourceFilePath, cons
 
     setWorkingDirectory(tmpFilePath, sourceFilePath, lang);
 
-    processInput = input.toUtf8();
+    inputFile = new QTemporaryFile(this);
+    if (!inputFile->open())
+    {
+        emit failedToStartRun(runnerIndex, tr("Failed to create temporary file."));
+        return;
+    }
+    Util::saveFile(inputFile->fileName(), input, "Runner Input", false);
+    runProcess->setStandardInputFile(inputFile->fileName());
 
     killTimer = new QTimer(runProcess);
     killTimer->setSingleShot(true);
@@ -142,7 +151,7 @@ void Runner::runDetached(const QString &tmpFilePath, const QString &sourceFilePa
 
 void Runner::onFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
-    const auto timeUsed = runTimer->elapsed();
+    const auto timeUsed = runTimer->isValid() ? runTimer->elapsed() : 0;
     emit runFinished(runnerIndex, processStdout + runProcess->readAllStandardOutput(),
                      processStderr + runProcess->readAllStandardError(), exitCode, timeUsed, timeLimitExceeded);
 }
@@ -150,11 +159,7 @@ void Runner::onFinished(int exitCode, QProcess::ExitStatus exitStatus)
 void Runner::onStarted()
 {
     if (!isDetachedRun)
-    {
         runTimer->start();
-        runProcess->write(processInput);
-        runProcess->closeWriteChannel();
-    }
     emit runStarted(runnerIndex);
 }
 

--- a/src/Core/Runner.hpp
+++ b/src/Core/Runner.hpp
@@ -28,6 +28,7 @@
 #include <QProcess>
 
 class QElapsedTimer;
+class QTemporaryFile;
 class QTimer;
 
 namespace Core
@@ -173,11 +174,11 @@ class Runner : public QObject
 
     const int runnerIndex;                   // the index of the testcase
     QProcess *runProcess = nullptr;          // the process to run the program
+    QTemporaryFile *inputFile = nullptr;     // redirect stdin to this file
     QTimer *killTimer = nullptr;             // the timer used to kill the process when the time limit is reached
     QElapsedTimer *runTimer = nullptr;       // the timer used to measure how much time did the execution use
     QByteArray processStdout;                // the stdout of the process
     QByteArray processStderr;                // the stderr of the process
-    QByteArray processInput;                 // the input from the test cases
     bool outputLimitExceededEmitted = false; // whether runOutputLimitExceeded is emitted or not
     bool timeLimitExceeded = false;
     bool isDetachedRun = false;

--- a/src/Core/Runner.hpp
+++ b/src/Core/Runner.hpp
@@ -175,9 +175,9 @@ class Runner : public QObject
     QProcess *runProcess = nullptr;          // the process to run the program
     QTimer *killTimer = nullptr;             // the timer used to kill the process when the time limit is reached
     QElapsedTimer *runTimer = nullptr;       // the timer used to measure how much time did the execution use
-    QString processStdout;                   // the stdout of the process
-    QString processStderr;                   // the stderr of the process
-    QString processInput;                    // the input from the test cases
+    QByteArray processStdout;                // the stdout of the process
+    QByteArray processStderr;                // the stderr of the process
+    QByteArray processInput;                 // the input from the test cases
     bool outputLimitExceededEmitted = false; // whether runOutputLimitExceeded is emitted or not
     bool timeLimitExceeded = false;
     bool isDetachedRun = false;

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -687,6 +687,10 @@ Press any key to exit</source>
         <source>Detached execution is not supported on your platform</source>
         <translation>Отдельный запуск не поддерживается на вашей системе</translation>
     </message>
+    <message>
+        <source>Failed to create temporary file.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Core::SessionManager</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -687,6 +687,10 @@ Press any key to exit</source>
         <source>Detached execution is not supported on your platform</source>
         <translation>你的平台上不支持在终端中运行</translation>
     </message>
+    <message>
+        <source>Failed to create temporary file.</source>
+        <translation>未能成功创建临时文件。</translation>
+    </message>
 </context>
 <context>
     <name>Core::SessionManager</name>


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description

cac37ffdc7fd2f05880f9ee5b7107af883d182de uses a temporary file as the stdin of the process instead of using `QProcess::write`, which prevents the main thread from blocking when writing large data to the process on Windows.

1b4d607a827ba6abd9b17e606139d2a87721bdcc is a failed attempt to fix this problem, but it does make the time measurement more accurate on all platforms.

e673712a0db14e005076e72041aacc12fb3e65a9 is another failed attempt which uses QThreadPool.

## Related Issues / Pull Requests

This fixes #789.

## How Has This Been Tested?

On Arch Linux and Windows 10.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).