### PR TITLE
docs(README): make the positon of languages stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **[Features](https://cpeditor.org) · [Documentation](https://cpeditor.org/docs) · [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) · [FAQ](https://cpeditor.org/docs/faq/)**
 
-[简体中文](README_zh-CN.md) · [Русский](README_ru-RU.md) · [正體中文](README_zh-TW.md)
+English | [Русский](README_ru-RU.md) | [简体中文](README_zh-CN.md) | [正體中文](README_zh-TW.md)
 
 ![demo](assets/demo.gif)
 

--- a/README_ru-RU.md
+++ b/README_ru-RU.md
@@ -11,7 +11,7 @@
 
 **[Возможности](https://cpeditor.org/ru) · [Документация](https://cpeditor.org/ru/docs/) · [Список изменений](CHANGELOG.md) · [Сотрудничество](CONTRIBUTING_ru-RU.md) · [FAQ](https://cpeditor.org/ru/docs/faq/)**
 
-[English](README.md) · [简体中文](README_zh-CN.md) · [正體中文](README_zh-TW.md)
+[English](README.md) | Русский | [简体中文](README_zh-CN.md) | [正體中文](README_zh-TW.md)
 
 ![demo](assets/demo.gif)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -11,7 +11,7 @@
 
 **[特性](https://cpeditor.org/zh) · [文档](https://cpeditor.org/zh/docs) · [更新日志](CHANGELOG.md) · [贡献指南](CONTRIBUTING_zh-CN.md) · [FAQ](https://cpeditor.org/zh/docs/faq/)**
 
-[English](README.md) · [Русский](README_ru-RU.md) · [正體中文](README_zh-TW.md)
+[English](README.md) | [Русский](README_ru-RU.md) | 简体中文 | [正體中文](README_zh-TW.md)
 
 ![demo](assets/demo.gif)
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -11,7 +11,7 @@
 
 **[特色功能](https://cpeditor.org/zh_tw) · [文件](https://cpeditor.org/zh_tw/docs) · [更新紀錄](CHANGELOG.md) · [貢獻指引](CONTRIBUTING_zh-TW.md) · [常見問題](https://cpeditor.org/zh_tw/docs/faq/)**
 
-[简体中文](README_zh-CN.md) · [English](README.md) · [Русский](README_ru-RU.md)
+[English](README.md) | [Русский](README_ru-RU.md) | [简体中文](README_zh-CN.md) | 正體中文
 
 ![demo](assets/demo.gif)
 


### PR DESCRIPTION
Now the links stay in the same position after switching to another language.