### PR TITLE
ci: use BOT_TOKEN for update-donors

### DIFF
--- a/.github/workflows/update-donors.yml
+++ b/.github/workflows/update-donors.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-donors:
+    if: github.repository_owner == 'cpeditor'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,6 +25,7 @@ jobs:
         if: steps.diff.outputs.diff == 1
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.BOT_TOKEN }}
           commit-message: "chore: update donor list"
           title: "chore: update donor list"
           branch: "auto-pr/donors"


### PR DESCRIPTION
create-pull-request doesn't trigger other actions when using the default GITHUB_TOKEN. It's fine for other actions like check-format, because the targeted base branch is not a protected branch like master. But update-donors is targeted to the master branch, which needs a personal token in order to get the required status checks passing.