### PR TITLE
feat: open new tabs adjacent to current tab or duplicated tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 -   Fix that, on Windows, when there are large test cases and the user's code is blocking, CP Editor also blocks. (#938)
 -   Fix that when building with CMake 3.21.1 and Ninja, it results in dupbuild or dependency cycle error. (#941)
 
+### Changed
+
+-   New tabs were opened at the end of the tab list. Now they are opened next to the current tab, or the original tab if the new tab is a duplicate. (#1021)
+
 ## v6.9
 
 ### Added

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -210,7 +210,7 @@ class AppWindow : public QMainWindow
 
     void onViewModeToggle();
 
-    void openTab(const QString &path);
+    void openTab(const QString &path, MainWindow *after = nullptr);
 
     void onFileSaved(MainWindow *window);
 
@@ -250,8 +250,8 @@ class AppWindow : public QMainWindow
     QVector<QShortcut *> hotkeyObjects;
     void maybeSetHotkeys();
     bool closeTab(int index);
-    void openTab(MainWindow *window);
-    void openTab(const MainWindow::EditorStatus &status, bool duplicate = false);
+    void openTab(MainWindow *window, MainWindow *after = nullptr);
+    void openTab(const MainWindow::EditorStatus &status, bool duplicate = false, MainWindow *after = nullptr);
     void openTabs(const QStringList &paths);
     void openPaths(const QStringList &paths, bool cpp = true, bool java = true, bool python = true, int depth = -1);
     QStringList openFolder(const QString &path, bool cpp, bool java, bool python, int depth);


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description

New tabs were opened at the end of the tab list. Now they are opened next to the current tab, or the original tab if the new tab is a duplicate.

## Motivation and Context

This will likely place related tabs adjacently.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
