### PR TITLE
chore(donors): add missing sponsor and log auto-updater

### DIFF
--- a/DONORS.md
+++ b/DONORS.md
@@ -3,6 +3,7 @@
 <!-- START: GitHub Sponsors -->
 -   [Dazz](https://github.com/npvq)
 -   [mateus sze cosenza](https://github.com/cosenza987)
+-   [Marhoosh](https://github.com/Marhoosh)
 <!-- END: GitHub Sponsors -->
 
 ## Open Collective

--- a/tools/getDonors.py
+++ b/tools/getDonors.py
@@ -4,11 +4,14 @@ import requests
 import sys
 
 def queryGitHub(q):
+    print('GitHub query:')
+    print(q)
     res = requests.post("https://api.github.com/graphql",
         data = json.dumps({"query": q}),
         headers = {
             "Authorization": "token " + sys.argv[1]
         })
+    print('GitHub response:')
     print(res.text)
     return res.json()["data"]
 
@@ -49,11 +52,14 @@ def getGitHub(donors):
         after = sponsors["pageInfo"]["endCursor"]
 
 def queryOpenCollective(q):
+    print('OpenCollective query:')
+    print(q)
     res = requests.post("https://opencollective.com/api/graphql/v2",
         data = json.dumps({"query": q}),
         headers = {
             "content-type": "application/json"
         })
+    print('OpenCollective response:')
     print(res.text)
     return res.json()["data"]
 

--- a/tools/getDonors.py
+++ b/tools/getDonors.py
@@ -9,6 +9,7 @@ def queryGitHub(q):
         headers = {
             "Authorization": "token " + sys.argv[1]
         })
+    print(res.text)
     return res.json()["data"]
 
 def getGitHub(donors):
@@ -53,6 +54,7 @@ def queryOpenCollective(q):
         headers = {
             "content-type": "application/json"
         })
+    print(res.text)
     return res.json()["data"]
 
 def getOpenCollective(donors):


### PR DESCRIPTION
There's a GitHub Sponsor missing from the donor list. I have no idea why it was not auto-updated. Now the responses from the API are logged.