### PR TITLE
fix: trigger external change handling when reloading sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Fixed
 
 -   Now you can undo a whole Replace All in a single step instead of one word per undo. (#1036 and #1037)
+-   Now external file changes when CP Editor is not running is properly handled when "Restore last session at startup" is enabled. (#1061)
+-   Fix that saved file content was not restored after abnormal exit when "Restore last session at startup" is enabled. (#1059 and #1061)
 
 ## v6.10
 

--- a/src/Core/SessionManager.cpp
+++ b/src/Core/SessionManager.cpp
@@ -65,6 +65,8 @@ void SessionManager::restoreSession(const QString &path)
         return;
     }
 
+    app->setInitialized(false);
+
     while (app->ui->tabWidget->count() > 0)
     {
         auto *tmp = app->windowAt(0);
@@ -103,6 +105,8 @@ void SessionManager::restoreSession(const QString &path)
 
     if (currentIndex >= 0 && currentIndex < app->ui->tabWidget->count())
         app->ui->tabWidget->setCurrentIndex(currentIndex);
+
+    app->setInitialized();
 }
 
 void SessionManager::setAutoUpdateSession(bool shouldAutoUpdate)

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -178,16 +178,20 @@ void AppWindow::finishConstruction()
             LOG_INFO("Is first-time user");
             preferencesWindow->display();
             SettingsHelper::setFirstTimeUser(false);
+            setInitialized();
         }
         else if (!SettingsHelper::isPromotionDialogShown() &&
                  SettingsHelper::getTotalUsageTime() >= 10 * 60 * 60) // 10 hours or above
         {
             LOG_INFO("Show promotion dialog");
             auto *dialog = new SupportUsDialog(this);
+            connect(dialog, &QDialog::finished, this, &AppWindow::setInitialized);
             dialog->open();
             dialog->move(geometry().center().x() - dialog->width() / 2, geometry().center().y() - dialog->height() / 2);
             SettingsHelper::setPromotionDialogShown(true);
         }
+        else
+            setInitialized();
     });
 }
 
@@ -1614,4 +1618,15 @@ void AppWindow::triggerWakaTime(MainWindow *window, bool isWrite)
 {
     if (window && wakaTime)
         wakaTime->sendHeartBeat(window->getFilePath(), window->getProblemURL(), window->getLanguage(), isWrite);
+}
+
+bool AppWindow::isInitialized() const
+{
+    return _isInitialized;
+}
+
+void AppWindow::setInitialized()
+{
+    _isInitialized = true;
+    emit initialized();
 }

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1625,8 +1625,9 @@ bool AppWindow::isInitialized() const
     return _isInitialized;
 }
 
-void AppWindow::setInitialized()
+void AppWindow::setInitialized(bool flag)
 {
-    _isInitialized = true;
-    emit initialized();
+    _isInitialized = flag;
+    if (flag)
+        emit initialized();
 }

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -69,6 +69,8 @@ class AppWindow : public QMainWindow
 
     bool isInitialized() const;
 
+    void setInitialized(bool flag = true);
+
   protected:
     void closeEvent(QCloseEvent *event) override;
     void dropEvent(QDropEvent *event) override;
@@ -215,8 +217,6 @@ class AppWindow : public QMainWindow
     void openTab(const QString &path, MainWindow *after = nullptr);
 
     void onFileSaved(MainWindow *window);
-
-    void setInitialized();
 
   signals:
     void initialized();

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -67,6 +67,8 @@ class AppWindow : public QMainWindow
 
     PreferencesWindow *getPreferencesWindow() const;
 
+    bool isInitialized() const;
+
   protected:
     void closeEvent(QCloseEvent *event) override;
     void dropEvent(QDropEvent *event) override;
@@ -214,6 +216,11 @@ class AppWindow : public QMainWindow
 
     void onFileSaved(MainWindow *window);
 
+    void setInitialized();
+
+  signals:
+    void initialized();
+
   private:
     Ui::AppWindow *ui;
     MessageLogger *activeLogger = nullptr;
@@ -239,6 +246,8 @@ class AppWindow : public QMainWindow
     Extensions::LanguageServer *pythonServer = nullptr;
 
     Extensions::WakaTime *wakaTime = nullptr;
+
+    std::atomic_bool _isInitialized{false};
 
     explicit AppWindow(bool noHotExit, QWidget *parent = nullptr);
     void finishConstruction();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -517,7 +517,15 @@ void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
                 if (appWindow->isInitialized())
                     onFileWatcherChanged(filePath);
                 else
-                    connect(appWindow, &AppWindow::initialized, [this] { onFileWatcherChanged(filePath); });
+                {
+                    // Change this to Qt::SingleShotConnection after migrating to Qt 6
+                    auto *connection = new QMetaObject::Connection;
+                    *connection = connect(appWindow, &AppWindow::initialized, [this, connection] {
+                        onFileWatcherChanged(filePath);
+                        disconnect(*connection);
+                        delete connection;
+                    });
+                }
             }
         }
     }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -60,6 +60,8 @@ class MainWindow : public QMainWindow
   public:
     struct EditorStatus
     {
+        qint64 timestamp = 0; // MSecsSinceEpoch when the status was recorded
+
         bool isLanguageSet{};
         QString filePath, savedText, problemURL, editorText, language, customCompileCommand;
         int editorCursor{}, editorAnchor{}, horizontalScrollBarValue{}, verticalScrollbarValue{}, untitledIndex{},


### PR DESCRIPTION
## Description

Save the timestamp when saving the session. When restoring a session, compare the timestamp with the file modification time. If the file is newer than the session, trigger an external file change event.

## Related Issues / Pull Requests

This should fix #1059.

## Motivation and Context

#1059, and this can also prevent accidentally overriding external file changes when CP Editor is not running.

## How Has This Been Tested?

On Arch Linux,

1.  external file changes when CP Editor is not running
2.  kill CP Editor by `SIGKILL` to simulate abnormal exit

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
