### PR TITLE
fix: sort case-insensitively when using snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 -   Now you can undo a whole Replace All in a single step instead of one word per undo. (#1036 and #1037)
+-   Now the snippet names are sorted case-insensitively when choosing snippets. (#1063 and #1065)
 
 ## v6.10
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1262,6 +1262,7 @@ void AppWindow::on_actionUseSnippets_triggered()
     {
         QString lang = current->getLanguage();
         QStringList names = SettingsHelper::getLanguageConfig(lang).getSnippets();
+        names.sort(Qt::CaseInsensitive);
         if (names.isEmpty())
         {
             activeLogger->warn(


### PR DESCRIPTION
## Description

Sort case-insensitively when using snippets.

## Related Issues / Pull Requests

This closes #1063.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).