### PR TITLE
build(aur/git): apply workaround for git submodule

### DIFF
--- a/dist/aur/git/PKGBUILD
+++ b/dist/aur/git/PKGBUILD
@@ -53,7 +53,7 @@ prepare() {
     git config submodule.third_party/testlib.url "$srcdir/testlib"
     git config submodule.third_party/qhttp.url "$srcdir/qhttp"
 
-    git submodule update
+    git -c protocol.file.allow=always submodule update
 }
 
 build() {


### PR DESCRIPTION
https://www.reddit.com/r/archlinux/comments/yd6yam/psa_a_recent_git_cve_breaks_all_pkgbuilds/