### PR TITLE
fix: MoveToStartOfLine and MoveToEndOfLine behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+### Changed
+
+-   Now the <kbd>Home</kbd> key moves to the first non-whitespace character. (#774 and #1149)
+-   Now when Wrap Text is enabled, <kbd>Home</kbd> and <kbd>End</kbd> moves to the start/end of the whole text line instead of the screen line. (#1149)
+
 ## v6.11
 
 ### Added


### PR DESCRIPTION
## Description

-	`MoveToStartOfLine` (<kbd>Home</kbd>): Move to the first non-whitespace character instead of the start of line if the cursor is after the first non-whitespace character.
-   Fix `MoveToStartOfLine` and `MoveToEndOfLine` to make them actually "MoveToStartOfBlock" and "MoveToEndOfBlock", so that they behave as expected when lines are wrapped.

## Related Issues / Pull Requests

This fixes #774.

## How Has This Been Tested?

On Arch Linux.

Testing on macOS is needed as `MoveToStartOfLine` is not <kbd>Home</kbd> on macOS. And macOS has a `MoveToStartOfBlock` key sequence, maybe special handling is preferred.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).