### PR TITLE
build: fix build on Arch Linux with CMake 3.26

### DIFF
--- a/.github/workflows/aur-test.yml
+++ b/.github/workflows/aur-test.yml
@@ -46,6 +46,7 @@ jobs:
         id: build-pkg
         with:
           path: ${{ matrix.pkg.path }}
+          archive: 2023/03/13
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

It seems that a recent update of CMake breaks the build on Arch: https://github.com/cpeditor/cpeditor/actions/runs/4456830088

I'm opening this PR to test it against ALA on 3.13 first, and then to see how to fix it.

## How Has This Been Tested?

I downgraded CMake on my laptop and the build succeeded.
