### PR TITLE
build(aur): add "5" for syntax-highlighting dependency

### DIFF
--- a/dist/aur/git/PKGBUILD
+++ b/dist/aur/git/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc='The editor for competitive programming'
 arch=('x86_64')
 url='https://github.com/cpeditor/cpeditor'
 license=('GPL3')
-depends=('qt5-base' 'syntax-highlighting' 'hicolor-icon-theme')
+depends=('qt5-base' 'syntax-highlighting5' 'hicolor-icon-theme')
 makedepends=(
     "cmake"
     "git"

--- a/dist/aur/stable/PKGBUILD
+++ b/dist/aur/stable/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc='The editor for competitive programming'
 arch=('x86_64')
 url='https://github.com/cpeditor/cpeditor'
 license=('GPL3')
-depends=('qt5-base' 'syntax-highlighting' 'hicolor-icon-theme')
+depends=('qt5-base' 'syntax-highlighting5' 'hicolor-icon-theme')
 makedepends=(
     "cmake"
     "git"


### PR DESCRIPTION
The Arch package changed its name to prepare for KDE 6.