### PR TITLE
feat: edit error/warning messages color of message logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 -   Use [Kate's Syntax highlighter](https://api.kde.org/frameworks/syntax-highlighting/html/) engine for Code Highlighting. (#1101)
--   Add options to select error/warning messages colors for message logger. (#521)
+-   Add options to select error/warning messages colors for message logger. (#521 and #1247)
 
 ### Fixied
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 -   Use [Kate's Syntax highlighter](https://api.kde.org/frameworks/syntax-highlighting/html/) engine for Code Highlighting. (#1101)
+-   Add options to select error/warning messages colors for message logger. (#521)
 
 ### Fixied
 

--- a/src/Core/MessageLogger.cpp
+++ b/src/Core/MessageLogger.cpp
@@ -76,13 +76,13 @@ void MessageLogger::info(const QString &head, const QString &body, bool htmlEsca
 void MessageLogger::warn(const QString &head, const QString &body, bool htmlEscaped)
 {
     LOG_INFO(INFO_OF(head) << INFO_OF(body));
-    message(head, body, "green", htmlEscaped);
+    message(head, body, SettingsHelper::getWarnMessageColor(), htmlEscaped);
 }
 
 void MessageLogger::error(const QString &head, const QString &body, bool htmlEscaped)
 {
     LOG_INFO(INFO_OF(head) << INFO_OF(body));
-    message(head, body, "red", htmlEscaped);
+    message(head, body, SettingsHelper::getErrorMessageColor(), htmlEscaped);
 }
 
 void MessageLogger::onAnchorClicked(const QUrl &link)

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -232,7 +232,8 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
         .end()
         .dir(TRKEY("Appearance"))
             .page(TRKEY("General"),{"Locale", "UI Style", "Editor Theme", "Opacity", "Test Case Maximum Height",
-                                    "Show Compile And Run Only", "Display EOLN In Diff", "Extra Bottom Margin"})
+                                    "Show Compile And Run Only", "Display EOLN In Diff", "Extra Bottom Margin",
+                                    "Error Message Color", "Warn Message Color"})
             .page(TRKEY("Font"), {"Show Only Monospaced Font", "Editor Font", "Test Cases Font", "Message Logger Font",
                                   "Use Custom Application Font", "Custom Application Font"})
         .end()

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -1243,5 +1243,23 @@
         "name": "Display Stopwatch"
       }
     ]
+  },
+  {
+    "name": "Error Message Color",
+    "desc": "Color of error messages",
+    "type": "QString",
+    "ui": "QComboBox",
+    "param": "QStringList {\"aqua\", \"black\", \"blue\", \"fuchsia\", \"gray\", \"green\", \"lime\", \"maroon\", \"navy\", \"olive\", \"orange\", \"purple\", \"red\", \"silver\", \"teal\", \"white\", \"yellow\"}",
+    "default": "red",
+    "tip": "Color of error messages"
+  },
+  {
+    "name": "Warn Message Color",
+    "desc": "Color of warning messages",
+    "type": "QString",
+    "ui": "QComboBox",
+    "param": "QStringList {\"aqua\", \"black\", \"blue\", \"fuchsia\", \"gray\", \"green\", \"lime\", \"maroon\", \"navy\", \"olive\", \"orange\", \"purple\", \"red\", \"silver\", \"teal\", \"white\", \"yellow\"}",
+    "default": "green",
+    "tip": "Color of warning messages"
   }
 ]

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -2696,6 +2696,14 @@ This may reduce distractions caused by stopwatch updates.</source>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color of error messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -2701,6 +2701,14 @@ Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y pu
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color of error messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -2700,6 +2700,14 @@ Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</tr
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color of error messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2698,6 +2698,14 @@ This may reduce distractions caused by stopwatch updates.</source>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color of error messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2693,11 +2693,11 @@ This may reduce distractions caused by stopwatch updates.</source>
     </message>
     <message>
         <source>Color of error messages</source>
-        <translation type="unfinished"></translation>
+        <translation>错误信息的颜色</translation>
     </message>
     <message>
         <source>Color of warning messages</source>
-        <translation type="unfinished"></translation>
+        <translation>警告信息的颜色</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2691,6 +2691,14 @@ This may reduce distractions caused by stopwatch updates.</source>
         <source>Highlight lines containing diagnostics</source>
         <translation>高亮包含代码提示的行</translation>
     </message>
+    <message>
+        <source>Color of error messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2715,6 +2715,14 @@ This may reduce distractions caused by stopwatch updates.</source>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Color of error messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>


### PR DESCRIPTION
feat: Add option to choose error/warning message colors of message logger

## Description
Add two new settings: "Error Message Color" and "Warn Message Color".
These settings are located at Appearance -> General, and have a combo box to select the colors, using default [Qt Colors names](https://doc.qt.io/qt-5/stylesheet-reference.html#color). 
Message Logger code was modified to use these settings instead of hardcoded values.

## Related Issues / Pull Requests
Closes #521

## Motivation and Context
Some users don't like the default colors for various reasons, so, an option to change them was added.

## How Has This Been Tested?
Tested on Fedora Workstation 37, on dark and light modes.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
It's necessary to translate the settings description and also add in the documentation and changelog. 
