### PR TITLE
fix: Failing CI on macOS for implicit lambda capture and missing default switch case.

### DIFF
--- a/src/Extensions/CompanionServer.cpp
+++ b/src/Extensions/CompanionServer.cpp
@@ -66,7 +66,7 @@ bool CompanionServer::startListeningOn(int port)
         const bool isJson = req->headers().keyHasValue("content-type", "application/json");
         req->collectData();
 
-        req->onEnd([=] {
+        req->onEnd([res, methodType, this, isJson, req] {
             res->addHeader("connection", "close");
             res->addHeader("pragma", "no-cache");
 

--- a/src/Extensions/LanguageServer.cpp
+++ b/src/Extensions/LanguageServer.cpp
@@ -211,6 +211,8 @@ Editor::CodeEditor::SeverityLevel LanguageServer::lspSeverity(int in)
         return Editor::CodeEditor::SeverityLevel::Information;
     case 4:
         return Editor::CodeEditor::SeverityLevel::Hint;
+    default:
+        return Editor::CodeEditor::SeverityLevel::Error;
     }
     // Nothing matched
     return Editor::CodeEditor::SeverityLevel::Error;

--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -91,7 +91,7 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, const QString
         {
             connect(
                 widget, &ValueWidget::valueChanged, this,
-                [=] {
+                [si, widget, this] {
                     SettingsManager::set(si.name, widget->getVariant());
                     emit settingsApplied(PreferencesPage::path());
                 },

--- a/src/SignalHandler.cpp
+++ b/src/SignalHandler.cpp
@@ -74,7 +74,7 @@ SignalHandler::SignalHandler(int mask) : _mask(mask)
 #else
             assert(!::socketpair(AF_UNIX, SOCK_STREAM, 0, socketFd[logical]));
             auto *sn = new QSocketNotifier(socketFd[logical][1], QSocketNotifier::Read, this);
-            connect(sn, &QSocketNotifier::activated, this, [=] {
+            connect(sn, &QSocketNotifier::activated, this, [sn, logical, this] {
                 sn->setEnabled(false);
                 char tmp = 0;
                 ::read(socketFd[logical][1], &tmp, sizeof(tmp));


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
MacOS CI was failing due to some checks, those are fixed.

## Related Issues / Pull Requests
N/A

## Motivation and Context
N/A

## How Has This Been Tested?
N/A
## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
