### PR TITLE
Use GNUInstallDirs; install translation files; Fix AppData files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,8 +296,8 @@ if(APPLE)
   )
 endif()
 
-include(GNUInstallDirs)
 if(UNIX AND NOT APPLE)
+  include(GNUInstallDirs)
   install(TARGETS cpeditor
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,13 +296,15 @@ if(APPLE)
   )
 endif()
 
+include(GNUInstallDirs)
 if(UNIX AND NOT APPLE)
   install(TARGETS cpeditor
-          RUNTIME DESTINATION bin
-          LIBRARY DESTINATION lib)
-  install(FILES dist/linux/cpeditor.desktop DESTINATION share/applications)
-  install(FILES resources/icon.png DESTINATION share/icons/hicolor/512x512/apps RENAME cpeditor.png)
-  install(FILES dist/linux/cpeditor.appdata.xml DESTINATION share/metainfo)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(FILES dist/linux/cpeditor.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+  install(FILES resources/icon.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps RENAME cpeditor.png)
+  install(FILES dist/linux/cpeditor.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+  install(FILES ${QMFILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/cpeditor/translations)
 endif()
 
 

--- a/cmake/cpeditor.appdata.xml.in
+++ b/cmake/cpeditor.appdata.xml.in
@@ -17,7 +17,7 @@
     </p>
     <p xml:lang="zh_CN">
       CP Editor 是一个基于 Qt 的轻量级跨平台代码编辑器，专为算法竞赛设计。
-      </p>
+    </p>
     <p xml:lang="zh_TW">
       CP Editor 是一款採用 Qt 的輕巧型跨平台程式碼編輯器，專為競程使用設計。
     </p>

--- a/cmake/cpeditor.appdata.xml.in
+++ b/cmake/cpeditor.appdata.xml.in
@@ -8,10 +8,20 @@
   <summary xml:lang="ru">Редактор кода для спортивного программирования</summary>
   <summary xml:lang="zh_CN">算法竞赛代码编辑器</summary>
   <summary xml:lang="zh_TW">競程程式碼編輯器</summary>
-  <description>CP Editor is a Qt-based, lightweight and cross-platform code editor specially designed for competitive programming. </description>
-  <description xml:lang="ru">CP Editor - это легкий кросс-платформенный редактор кода на базе Qt, специально разработанный для спортивного программирования.</description>
-  <description xml:lang="zh_CN">CP Editor 是一个基于 Qt 的轻量级跨平台代码编辑器，专为算法竞赛设计。</description>
-  <description xml:lang="zh_TW">CP Editor 是一款採用 Qt 的輕巧型跨平台程式碼編輯器，專為競程使用設計。</description>
+  <description>
+    <p>
+      CP Editor is a Qt-based, lightweight and cross-platform code editor specially designed for competitive programming.
+    </p>
+    <p xml:lang="ru">
+      CP Editor - это легкий кросс-платформенный редактор кода на базе Qt, специально разработанный для спортивного программирования.
+    </p>
+    <p xml:lang="zh_CN">
+      CP Editor 是一个基于 Qt 的轻量级跨平台代码编辑器，专为算法竞赛设计。
+      </p>
+    <p xml:lang="zh_TW">
+      CP Editor 是一款採用 Qt 的輕巧型跨平台程式碼編輯器，專為競程使用設計。
+    </p>
+  </description>
   <url type="homepage">https://cpeditor.org</url>
   <url type="bugtracker">https://github.com/cpeditor/cpeditor/issues</url>
   <url type="help">https://github.com/cpeditor/cpeditor/discussions</url>


### PR DESCRIPTION
## Description
- Use GNUInstallDirs for CMake installation
- Install translation files
- Fix AppData files

Ref: 
https://docs.pagure.org/packaging-guidelines/Packaging%3AAppData.html
https://docs.fedoraproject.org/en-US/packaging-guidelines/AppData/


## Related Issues / Pull Requests


## Motivation and Context
I am trying to make cpeditor packaging for Fedora Linux.

## How Has This Been Tested?


## Screenshots (if appropriate)

## Checklist
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
