### PR TITLE
fix(SignalHandler): properly register signal handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixied
 
--   UNIX signal handler is now more robust. (#1166)
+-   UNIX signal handler is now more robust. (#1166 and #1304)
 
 ## v6.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 -   Use [Kate's Syntax highlighter](https://api.kde.org/frameworks/syntax-highlighting/html/) engine for Code Highlighting. (#1101)
 -   Add options to select error/warning messages colors for message logger. (#521 and #1247)
 
-### Fixied
+### Fixed
 
 -   UNIX signal handler is now more robust. (#1166 and #1304)
 


### PR DESCRIPTION
## Description

Stupid error. `assert` does not run in release mode, so the signal handlers are not registered.

## Related Issues / Pull Requests

This fixes #1168

## How Has This Been Tested?

On Arch Linux with release mode build.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
