### PR TITLE
fix(CodeEditor): add ESC to cancel selection and correct Home/End behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 -   UNIX signal handler is now more robust. (#1166 and #1304)
+-   Now pressing `Home` goes to the first non-blank character. When lines are wrapped, now `Home` and `End` are based on text lines instead of visual lines. (#774 and #1310)
 
 ## v6.11
 

--- a/src/Editor/CodeEditor.cpp
+++ b/src/Editor/CodeEditor.cpp
@@ -1091,6 +1091,34 @@ void CodeEditor::keyPressEvent(QKeyEvent *e)
         setTextCursor(cursor);
     }
 
+    const auto shift = e->modifiers().testFlag(Qt::ShiftModifier);
+    e->setModifiers(e->modifiers() & ~Qt::ShiftModifier); // to match Shift+Home to MoveToStartOfLine
+
+    if (e->matches(QKeySequence::MoveToStartOfLine))
+    {
+        auto cursor = textCursor();
+        const auto line = cursor.block().text();
+        const auto leadingSpaceCount = QRegularExpression("^\\s*").match(line).capturedLength();
+        const auto cursorPos = cursor.positionInBlock();
+        const auto moveMode = shift ? QTextCursor::KeepAnchor : QTextCursor::MoveAnchor;
+        if (cursorPos > leadingSpaceCount)
+            cursor.movePosition(QTextCursor::PreviousCharacter, moveMode, cursorPos - leadingSpaceCount);
+        else
+            cursor.movePosition(QTextCursor::StartOfBlock, moveMode);
+        setTextCursor(cursor);
+        return;
+    }
+
+    if (e->matches(QKeySequence::MoveToEndOfLine))
+    {
+        auto cursor = textCursor();
+        cursor.movePosition(QTextCursor::EndOfBlock, shift ? QTextCursor::KeepAnchor : QTextCursor::MoveAnchor);
+        setTextCursor(cursor);
+        return;
+    }
+
+    e->setModifiers(e->modifiers() | (shift ? Qt::ShiftModifier : Qt::NoModifier));
+
     QPlainTextEdit::keyPressEvent(e);
 }
 

--- a/src/Editor/CodeEditor.cpp
+++ b/src/Editor/CodeEditor.cpp
@@ -1084,6 +1084,13 @@ void CodeEditor::keyPressEvent(QKeyEvent *e)
         return;
     }
 
+    if (e->key() == Qt::Key_Escape && textCursor().hasSelection())
+    {
+        auto cursor = textCursor();
+        cursor.clearSelection();
+        setTextCursor(cursor);
+    }
+
     QPlainTextEdit::keyPressEvent(e);
 }
 


### PR DESCRIPTION
## Description

Add missing key bindings in the new code editor.

## Related Issues / Pull Requests

It fixes #774 and replaces #1149

## Checklist

- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).