### PR TITLE
fix: add back the cursor width setting to the new code editor

### DIFF
--- a/src/Editor/CodeEditor.hpp
+++ b/src/Editor/CodeEditor.hpp
@@ -116,6 +116,8 @@ class CodeEditor : public QPlainTextEdit
      */
     void setVimCursor(bool value);
 
+    void updateCursorWidth();
+
     /**
      * @brief Checks if cursor type is Vim Cursor
      */


### PR DESCRIPTION
Add back the cursor width setting to the new code editor.

## How Has This Been Tested?

On Arch Linux.