### PR TITLE
fix: incomplete line numbers at startup

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -76,7 +76,7 @@ MainWindow::MainWindow(int index, AppWindow *parent)
         autoSaveTimer, &QTimer::timeout, autoSaveTimer, [this] { saveFile(AutoSave, tr("Auto Save"), false); },
         Qt::DirectConnection);
     applySettings("");
-    QTimer::singleShot(0, [this] { setLanguage(language); }); // See issue #187 for more information
+    QTimer::singleShot(0, [this] { editor->resize(0, 0); }); // refresh editor geometry
 }
 
 MainWindow::MainWindow(const QString &fileOpen, int index, AppWindow *parent) : MainWindow(index, parent)


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->

Before this change, the line numbers are incomplete at startup:

![image](https://github.com/cpeditor/cpeditor/assets/30581822/21c35ddf-a8dd-4ef0-90c7-cab83d6c4dbd)

Now a resize event of the code editor is triggered at startup to update the geometry of the sidebar.

## Related Issues / Pull Requests

The solution is similar to #187. I cannot reproduce #187 now, but according to the statement there, a resize should also cover that issue.

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

On Arch Linux.