### PR TITLE
fix(KSHRepository): sort theme names case-insensitively

### DIFF
--- a/src/Editor/KSHRepository.cpp
+++ b/src/Editor/KSHRepository.cpp
@@ -33,6 +33,7 @@ QStringList KSyntaxHighlightingRepository::themeNames()
     QStringList names;
     for (const auto &theme : repository.themes())
         names.push_back(theme.name());
+    names.sort(Qt::CaseInsensitive);
     return names;
 }
 } // namespace Editor


### PR DESCRIPTION
There are theme names that start with lowercase and uppercase so it's better to sort them case-insensitively.