### PR TITLE
fix: documentation of settings

### DIFF
--- a/src/Settings/PreferencesPageTemplate.cpp
+++ b/src/Settings/PreferencesPageTemplate.cpp
@@ -42,9 +42,11 @@ PreferencesPageTemplate::PreferencesPageTemplate(QStringList opts, const QString
         SettingsManager::setPath(name, path + "/" + SettingsInfo::findSetting(name).untrDesc,
                                  trPath + "/" + SettingsInfo::findSetting(name).desc);
 
-        const auto docsLinkText = QString(" <a href='%1#%2'>(?)</a>")
-                                      .arg(docsLinkPrefix)
-                                      .arg(si.docAnchor.isEmpty() ? Util::sanitizeAnchorName(si.desc) : si.docAnchor);
+        const auto docsLinkText =
+            si.noDoc ? QString()
+                     : QString(" <a href='%1#%2'>(?)</a>")
+                           .arg(docsLinkPrefix)
+                           .arg(si.docAnchor.isEmpty() ? Util::sanitizeAnchorName(si.desc) : si.docAnchor);
 
         ValueWidget *widget = nullptr;
 

--- a/src/Settings/SettingsInfo.hpp
+++ b/src/Settings/SettingsInfo.hpp
@@ -40,6 +40,7 @@ class SettingsInfo
         QString tip;              // translated tooltips
         QString untrTip;          // untranslated tooltips
         QString docAnchor;        // the anchor of the documentation
+        bool noDoc;               // this setting is very simple so it has no documentation on the website
         bool requireAllDepends{}; // false for one of the depends, true for all depends
         bool immediatelyApply{};
         std::function<void(SettingInfo *, ValueWidget *, QWidget *)> onApply;

--- a/src/Settings/genSettings.py
+++ b/src/Settings/genSettings.py
@@ -56,6 +56,8 @@ def writeInfo(f, obj, lst):
         docAnchor = t.get("docAnchor", "")
         if docAnchor == "":
             docAnchor = json.dumps("")
+        elif docAnchor == "default-paths":
+            docAnchor = f'tr("default-paths", {json.dumps(f"the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path")})'
         else:
             docAnchor = f"tr({json.dumps(docAnchor)}, {json.dumps(f'the anchor of {desc} on the corresponding page of https://cpeditor.org/docs/preferences')})"
         noDoc = t.get("noDoc", False)

--- a/src/Settings/genSettings.py
+++ b/src/Settings/genSettings.py
@@ -58,6 +58,10 @@ def writeInfo(f, obj, lst):
             docAnchor = json.dumps("")
         else:
             docAnchor = f"tr({json.dumps(docAnchor)}, {json.dumps(f'the anchor of {desc} on the corresponding page of https://cpeditor.org/docs/preferences')})"
+        noDoc = t.get("noDoc", False)
+        MUST_HAVE_ONE = ["noDoc", "docAnchor", "tip", "trtip", "notr"]
+        if not any(x in t for x in MUST_HAVE_ONE):
+            print(f'\033[93mWarning:\033[0m none of {MUST_HAVE_ONE} is set for the setting "{name}"')
         requireAllDepends = t.get("requireAllDepends", True)
         immediatelyApply = t.get("immediatelyApply", False)
         onApply = f'[](SettingInfo *info, ValueWidget *widget, QWidget *parent){{ {t.get("onApply", "")} }}'
@@ -80,7 +84,7 @@ def writeInfo(f, obj, lst):
         dependsString += "}"
         old = t.get("old", [])
         f.write(
-            f"    {lst}.append(SettingInfo {{{json.dumps(name)}, {trdesc}, {json.dumps(desc)}, \"{tempname}\", \"{ui}\", {trtip}, {json.dumps(tip)}, {docAnchor}, {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, {{{json.dumps(old)[1:-1]}}}, ")
+            f"    {lst}.append(SettingInfo {{{json.dumps(name)}, {trdesc}, {json.dumps(desc)}, \"{tempname}\", \"{ui}\", {trtip}, {json.dumps(tip)}, {docAnchor}, {json.dumps(noDoc)}, {json.dumps(requireAllDepends)}, {json.dumps(immediatelyApply)}, {onApply}, {dependsString}, {{{json.dumps(old)[1:-1]}}}, ")
         if typename != "Object":
             if "default" in t:
                 if typename == "QString":
@@ -129,6 +133,7 @@ def addDefaultPaths(obj):
             "trdesc": f'tr("Default path used for %1").arg(tr("{action[0]}"))',
             "type": "QString",
             "default": action[1],
+            "docAnchor": "default-paths",
             "trtip": f'tr("The default path used when choosing a path for %1.\\nYou can use ${{<default path name>}} as a place holder.").arg(tr("{action[0]}"))'
         })
         if action[0] == "Save File":
@@ -138,6 +143,7 @@ def addDefaultPaths(obj):
             "trdesc": f'tr("Default paths changed by %1").arg(tr("{action[0]}"))',
             "type": "QString",
             "default": action[2],
+            "docAnchor": "default-paths",
             "trtip": f'tr("The default paths changed after choosing a path for %1.\\nIt is a list of <default path name>s, separated by commas, and can be empty.").arg(tr("{action[0]}"))'
         })
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -23,6 +23,7 @@
     "type": "QFont",
     "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
     "param": "true",
+    "noDoc": true,
     "tip": "The font of the code editor"
   },
   {
@@ -95,12 +96,14 @@
     "name": "Format On Manual Save",
     "desc": "Format code on manual save",
     "type": "bool",
+    "noDoc": true,
     "tip": "Format the code when saving it manually."
   },
   {
     "name": "Format On Auto Save",
     "desc": "Format code on auto-save",
     "type": "bool",
+    "noDoc": true,
     "tip": "Format the code when auto-saving it."
   },
   {
@@ -371,7 +374,7 @@
     "name": "Auto Save",
     "desc": "Enable Auto Save",
     "type": "bool",
-    "tip": "Automatically save the file every 3 seconds."
+    "noDoc": true
   },
   {
     "name": "Auto Save Interval",
@@ -463,6 +466,7 @@
     "desc": "Enable Competitive Companion",
     "type": "bool",
     "default": true,
+    "noDoc": true,
     "tip": "Receive data sent by Competitive Companion and load the example test cases."
   },
   {
@@ -536,48 +540,56 @@
         "name": "Competitive Companion/Enable"
       }
     ],
+    "noDoc": true,
     "tip": "Add a line saying \"Powered By CP Editor\" in the head comments.\nThis doesn't cost you anything, but helps more people to know CP Editor."
   },
   {
     "name": "Hotkey/Format",
     "desc": "Format Codes",
     "type": "QString",
+    "noDoc": true,
     "ui": "ShortcutItem"
   },
   {
     "name": "Hotkey/Kill",
     "desc": "Kill All Processes",
     "type": "QString",
+    "noDoc": true,
     "ui": "ShortcutItem"
   },
   {
     "name": "Hotkey/Compile Run",
     "desc": "Compile and Run",
     "type": "QString",
+    "noDoc": true,
     "ui": "ShortcutItem"
   },
   {
     "name": "Hotkey/Run",
     "desc": "Run Only",
     "type": "QString",
+    "noDoc": true,
     "ui": "ShortcutItem"
   },
   {
     "name": "Hotkey/Compile",
     "desc": "Compile Only",
     "type": "QString",
+    "noDoc": true,
     "ui": "ShortcutItem"
   },
   {
     "name": "Hotkey/Change View Mode",
     "desc": "Change View Mode",
     "type": "QString",
+    "noDoc": true,
     "ui": "ShortcutItem"
   },
   {
     "name": "Hotkey/Snippets",
     "desc": "Use Snippets",
     "type": "QString",
+    "noDoc": true,
     "ui": "ShortcutItem"
   },
   {
@@ -612,6 +624,7 @@
         "name": "Hot Exit/Auto Save"
       }
     ],
+    "noDoc": true,
     "tip": "The time interval between two auto-saves of the current session."
   },
   {
@@ -888,6 +901,7 @@
     "type": "QFont",
     "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
     "param": "true",
+    "noDoc": true,
     "tip": "The font of test cases"
   },
   {
@@ -901,17 +915,20 @@
     "type": "QFont",
     "default": "[](){ QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont); font.setStyleHint(QFont::TypeWriter); return font; }()",
     "param": "true",
+    "noDoc": true,
     "tip": "The font of the message logger"
   },
   {
     "name": "Save File On Compilation",
     "type": "bool",
     "default": "true",
+    "noDoc": true,
     "tip": "Save the source file when compiling it. It won't be saved if the tab is untitled."
   },
   {
     "name": "Save File On Execution",
     "type": "bool",
+    "noDoc": true,
     "tip": "Save the source file when running it. It won't be saved if the tab is untitled."
   },
   {
@@ -1068,6 +1085,7 @@
     "name": "Default Path/Names And Paths",
     "type": "QVariantList",
     "param": "QVariantList { QStringList { tr(\"Name\"), tr(\"The name of a default path\") }, QStringList { tr(\"Path\"), tr(\"The path of a default path\") } }",
+    "docAnchor": "default-paths",
     "tip": "A list of default paths.\nThey can be used in actions' corresponding default paths by using ${<default path name>} as a place holder.\nThey can be either manually set or automatically changed after choosing a path for an action."
   },
   {
@@ -1159,6 +1177,7 @@
     "name": "WakaTime/Enable",
     "desc": "Enable WakaTime",
     "type": "bool",
+    "tip": "Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.",
     "default": false
   },
   {
@@ -1176,6 +1195,7 @@
   {
     "name": "Display Stopwatch",
     "type": "bool",
+    "tip": "Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.",
     "default": false
   },
   {
@@ -1209,6 +1229,7 @@
     "ui": "QComboBox",
     "param": "QStringList {\"aqua\", \"black\", \"blue\", \"fuchsia\", \"gray\", \"green\", \"lime\", \"maroon\", \"navy\", \"olive\", \"orange\", \"purple\", \"red\", \"silver\", \"teal\", \"white\", \"yellow\"}",
     "default": "red",
+    "noDoc": true,
     "tip": "Color of error messages"
   },
   {
@@ -1218,6 +1239,7 @@
     "ui": "QComboBox",
     "param": "QStringList {\"aqua\", \"black\", \"blue\", \"fuchsia\", \"gray\", \"green\", \"lime\", \"maroon\", \"navy\", \"olive\", \"orange\", \"purple\", \"red\", \"silver\", \"teal\", \"white\", \"yellow\"}",
     "default": "green",
+    "noDoc": true,
     "tip": "Color of warning messages"
   }
 ]

--- a/src/Util/Util.cpp
+++ b/src/Util/Util.cpp
@@ -37,7 +37,7 @@ void showWidgetOnTop(QWidget *widget)
 QString sanitizeAnchorName(const QString &str)
 {
     return str.trimmed()
-        .remove(QRegularExpression(R"([!"\#$%&'()*+,\-./:;<=>?@\[\\\]^_‘{|}~]|，|（|）|。)"))
+        .remove(QRegularExpression(R"([!"\#$%&'()*+,./:;<=>?@\[\\\]^_‘{|}~]|，|（|）|。)"))
         .toLower()
         .replace(' ', '-');
 }

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -1696,10 +1696,6 @@ You can use &quot;${filename}&quot; for the complete file name,
         <translation>Επιτροπή αυτόματης αποθήκευσης</translation>
     </message>
     <message>
-        <source>Automatically save the file every 3 seconds.</source>
-        <translation>Αυτόματη αποθήκευση αρχείου ανά 3 δευτερόλεπτα.</translation>
-    </message>
-    <message>
         <source>Wrap Text</source>
         <translation>Αναδίπλωση κειμένου</translation>
     </message>
@@ -2702,6 +2698,19 @@ This may reduce distractions caused by stopwatch updates.</source>
     </message>
     <message>
         <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>default-paths</source>
+        <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -1864,10 +1864,6 @@ Esto se puede sobrescribir para cada paréntesis en cada idioma.</translation>
         <translation>Habilitar Auto Guardado</translation>
     </message>
     <message>
-        <source>Automatically save the file every 3 seconds.</source>
-        <translation>Guarda automáticamente el archivo cada 3 segundos.</translation>
-    </message>
-    <message>
         <source>Auto Save Interval (ms)</source>
         <translation>Intervalo de auto-guardado (ms)</translation>
     </message>
@@ -2707,6 +2703,19 @@ Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y pu
     </message>
     <message>
         <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>default-paths</source>
+        <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -1696,10 +1696,6 @@ Poderá usar &quot;${filename}&quot; para o nome completo do arquivo,
         <translation>Habilitar salvamento automático</translation>
     </message>
     <message>
-        <source>Automatically save the file every 3 seconds.</source>
-        <translation>Salvar automaticamente o arquivo a cada 3 segundos.</translation>
-    </message>
-    <message>
         <source>Wrap Text</source>
         <translation>Quebra de texto</translation>
     </message>
@@ -2706,6 +2702,19 @@ Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</tr
     </message>
     <message>
         <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>default-paths</source>
+        <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1696,10 +1696,6 @@ You can use &quot;${filename}&quot; for the complete file name,
         <translation>Включить автосохранение</translation>
     </message>
     <message>
-        <source>Automatically save the file every 3 seconds.</source>
-        <translation>Автоматически сохранять файл каждые 3 секунды.</translation>
-    </message>
-    <message>
         <source>Wrap Text</source>
         <translation>Свернуть текст</translation>
     </message>
@@ -2704,6 +2700,19 @@ This may reduce distractions caused by stopwatch updates.</source>
     </message>
     <message>
         <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>default-paths</source>
+        <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2697,16 +2697,16 @@ This may reduce distractions caused by stopwatch updates.</source>
     </message>
     <message>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
-        <translation type="unfinished"></translation>
+        <translation>使用 WakaTime 来记录你的时间使用情况。需要安装 WakaTime CLI。</translation>
     </message>
     <message>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
-        <translation type="unfinished"></translation>
+        <translation>在 UI 中显示计时器。你可以用它来记录做题用时。</translation>
     </message>
     <message>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
-        <translation type="unfinished"></translation>
+        <translation>默认路径</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -1695,10 +1695,6 @@ You can use &quot;${filename}&quot; for the complete file name,
         <translation>自动保存</translation>
     </message>
     <message>
-        <source>Automatically save the file every 3 seconds.</source>
-        <translation>每 3 秒自动保存代码。</translation>
-    </message>
-    <message>
         <source>Wrap Text</source>
         <translation>文本自动换行</translation>
     </message>
@@ -2698,6 +2694,19 @@ This may reduce distractions caused by stopwatch updates.</source>
     <message>
         <source>Color of warning messages</source>
         <translation>警告信息的颜色</translation>
+    </message>
+    <message>
+        <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>default-paths</source>
+        <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -1877,10 +1877,6 @@ This can be overridden for each parenthesis in each language.</source>
         <translation>啟用自動存檔</translation>
     </message>
     <message>
-        <source>Automatically save the file every 3 seconds.</source>
-        <translation>每 3 秒自動存檔。</translation>
-    </message>
-    <message>
         <source>Auto Save Interval (ms)</source>
         <translation>自動存檔間隔 (ms)</translation>
     </message>
@@ -2721,6 +2717,19 @@ This may reduce distractions caused by stopwatch updates.</source>
     </message>
     <message>
         <source>Color of warning messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>default-paths</source>
+        <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
## Description

Add `noDoc` option to hide documentation links for simple settings, and some other fixes.

## Motivation and Context

Documentation is missing for some settings and just a duplicate of its name for several settings.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
