### PR TITLE
build(aur): add qt5-svg & use SPDX license ID & no fetch ECM KSH

### DIFF
--- a/dist/aur/git/PKGBUILD
+++ b/dist/aur/git/PKGBUILD
@@ -7,14 +7,19 @@ pkgrel=1
 pkgdesc='The editor for competitive programming'
 arch=('x86_64')
 url='https://github.com/cpeditor/cpeditor'
-license=('GPL3')
-depends=('qt5-base' 'syntax-highlighting5' 'hicolor-icon-theme')
+license=('GPL-3.0-or-later')
+depends=(
+    'qt5-base'
+    'qt5-svg'
+    'syntax-highlighting5'
+    'hicolor-icon-theme'
+)
 makedepends=(
-    "cmake"
-    "git"
-    "ninja"
-    "python3"
-    "qt5-tools"
+    'cmake'
+    'git'
+    'ninja'
+    'python3'
+    'qt5-tools'
 )
 optdepends=(
     'cf-tool: submit to Codeforces'
@@ -25,14 +30,16 @@ optdepends=(
     'wakatime: track coding stats'
 )
 provides=('cpeditor')
-conflicts=("cpeditor")
+conflicts=('cpeditor')
 
-source=('git+https://github.com/cpeditor/cpeditor.git'
+source=(
+    'git+https://github.com/cpeditor/cpeditor.git'
     'git+https://github.com/cpeditor/QtFindReplaceDialog.git'
     'git+https://github.com/cpeditor/lsp-cpp.git'
     'git+https://github.com/itay-grudev/singleapplication.git'
     'git+https://github.com/MikeMirzayanov/testlib.git'
-    'git+https://github.com/cpeditor/qhttp.git')
+    'git+https://github.com/cpeditor/qhttp.git'
+)
 
 md5sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
@@ -43,15 +50,13 @@ pkgver() {
 
 prepare() {
     cd "$_pkgname"
-    git submodule init
 
-    git config submodule.third_party/QtFindReplaceDialog.url "$srcdir/QtFindReplaceDialog"
-    git config submodule.third_party/lsp-cpp.url "$srcdir/lsp-cpp"
-    git config submodule.third_party/singleapplication.url "$srcdir/singleapplication"
-    git config submodule.third_party/testlib.url "$srcdir/testlib"
-    git config submodule.third_party/qhttp.url "$srcdir/qhttp"
-
-    git -c protocol.file.allow=always submodule update
+    for _source in "${source[@]:1}"; do
+        _name=$(basename "$_source" .git)
+        _path="third_party/$_name"
+        git config submodule."$_path".url "$srcdir/$_name"
+        git -c protocol.file.allow=always submodule update --init -- "$_path"
+    done
 }
 
 build() {

--- a/dist/aur/stable/PKGBUILD
+++ b/dist/aur/stable/PKGBUILD
@@ -7,14 +7,19 @@ pkgrel=1
 pkgdesc='The editor for competitive programming'
 arch=('x86_64')
 url='https://github.com/cpeditor/cpeditor'
-license=('GPL3')
-depends=('qt5-base' 'syntax-highlighting5' 'hicolor-icon-theme')
+license=('GPL-3.0-or-later')
+depends=(
+    'qt5-base'
+    'qt5-svg'
+    'syntax-highlighting5'
+    'hicolor-icon-theme'
+)
 makedepends=(
-    "cmake"
-    "git"
-    "ninja"
-    "python3"
-    "qt5-tools"
+    'cmake'
+    'git'
+    'ninja'
+    'python3'
+    'qt5-tools'
 )
 optdepends=(
     'cf-tool: submit to Codeforces'
@@ -24,7 +29,6 @@ optdepends=(
     'python: execute Python'
     'wakatime: track coding stats'
 )
-conflicts=("cpeditor-git")
 source=("https://github.com/cpeditor/$pkgname/releases/download/$pkgver/cpeditor-$pkgver-full-source.tar.gz")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
## Description

- Add missing dependency `qt5-svg`. It is usually installed (ref: https://pkgstats.archlinux.de/packages/qt5-base and <https://pkgstats.archlinux.de/packages/qt5-svg>, or on your system `pactree -r qt5-svg`). And it seems that CP Editor can run without `qt5-svg`, only the buttons in the "Support Us" dialog are invisible.
- Use SPDX license identifier. ref: https://rfc.archlinux.page/0016-spdx-license-identifiers/
- Don't fetch ECM and KSH in `cpeditor-git`.
- Some cleanup.

## How Has This Been Tested?

Local `makepkg`