### PR TITLE
Enforced the "123" numerals over local "١٢٣" numerals

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -536,9 +536,15 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
 
     if (isUntitled() && !isTextChanged())
     {
-        QString comments = SettingsHelper::getCompetitiveCompanionHeadComments().replace(
-            "${time}",
-            QDateTime::currentDateTime().toString(SettingsHelper::getCompetitiveCompanionHeadCommentsTimeFormat()));
+        // Create a QLocale object with the C locale to enforce Western Arabic numerals
+        QLocale cLocale(QLocale::C);
+
+        QDateTime currentDateTime = QDateTime::currentDateTime();
+        QString format = SettingsHelper::getCompetitiveCompanionHeadCommentsTimeFormat();
+
+        // Format the date and time using the C locale
+        QString formattedDateTime = cLocale.toString(currentDateTime, format);
+        QString comments = SettingsHelper::getCompetitiveCompanionHeadComments().replace("${time}", formattedDateTime);
 
         auto it = QRegularExpression(R"(\$\{json\..+?\})").globalMatch(comments);
 


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
Living in Egypt, the QT time format uses the non-coding style numerals for the time of problem retrieval when enabling the setting for `Time: ${time}`.

## Related Issues / Pull Requests
None

## Motivation and Context
Going from this 
![image](https://github.com/cpeditor/cpeditor/assets/64744285/2b826c76-b07d-4ca4-bb1c-7691d12057ba)
to this
![image](https://github.com/cpeditor/cpeditor/assets/64744285/711cd18d-07a5-47c8-978c-fedfbff366ab)

## How Has This Been Tested?
Tested it on my Manjaro 
#### System Details Report
- **Date generated:**                              2024-05-24 01:55:48

#### Hardware Information:
- **Processor:**                                   Intel® Core™ i5-8250U × 8
- **Graphics:**                                    Intel® UHD Graphics 620 (KBL GT2)

#### Software Information:
- **Firmware Version:**                            6JCN25WW
- **OS Name:**                                     Manjaro Linux
- **OS Type:**                                     64-bit
- **GNOME Version:**                               46
- **Windowing System:**                            X11
- **Kernel Version:**                              Linux 6.7.12-1-MANJARO

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

