### PR TITLE
fix: remove scaling fonts via mouse wheel scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -   Now the diff viewer uses the same font as the test cases (monospace by default). (#1396)
 
+### Changed
+
+-   Removed the function to scale the editor font via mouse wheel scroll, as it has been reported to have severe performance issues. (#1249 and #1388)
+
 ## v7.0
 
 In this version, we have switched to [KSyntaxHighlighting](https://api.kde.org/frameworks/syntax-highlighting/html/), the same framework used by [the Kate editor](https://kate-editor.org/). This upgrade results in significantly improved syntax highlighting, a wider selection of [color themes](https://kate-editor.org/themes/), and additional features like code folding. However, due to extensive refactoring, some bugs may arise.

--- a/src/Editor/CodeEditor.cpp
+++ b/src/Editor/CodeEditor.cpp
@@ -440,33 +440,6 @@ bool CodeEditor::vimCursor() const
     return m_vimCursor;
 }
 
-void CodeEditor::wheelEvent(QWheelEvent *e)
-{
-    if (e->modifiers() == Qt::ControlModifier)
-    {
-        const auto sizes = QFontDatabase::standardSizes();
-        if (sizes.isEmpty())
-        {
-            LOG_ERR("QFontDatabase::standardSizes() is empty");
-            return;
-        }
-        int newSize = font().pointSize();
-        if (e->angleDelta().y() > 0)
-            newSize = qMin(newSize + 1, sizes.last());
-        else if (e->angleDelta().y() < 0)
-            newSize = qMax(newSize - 1, sizes.first());
-        if (newSize != font().pointSize())
-        {
-            QFont newFont = font();
-            newFont.setPointSize(newSize);
-            setFont(newFont);
-            emit fontChanged(newFont);
-        }
-    }
-    else
-        QPlainTextEdit::wheelEvent(e);
-}
-
 void CodeEditor::highlightOccurrences()
 {
     occurrencesExtraSelections.clear();

--- a/src/Editor/CodeEditor.hpp
+++ b/src/Editor/CodeEditor.hpp
@@ -136,12 +136,6 @@ class CodeEditor : public QPlainTextEdit
 
     void applySettings(const QString &lang);
 
-  signals:
-    /**
-     * @brief Signal, the font is changed by the wheel event.
-     */
-    void fontChanged(const QFont &newFont);
-
   public slots:
     /**
      * @brief Slot, that indent the selected lines.
@@ -203,11 +197,6 @@ class CodeEditor : public QPlainTextEdit
      * @brief Method, update the bottom margin when the font changes.
      */
     void changeEvent(QEvent *e) override;
-
-    /**
-     * @brief Method, update the font size when the wheel is rotated with Ctrl pressed
-     */
-    void wheelEvent(QWheelEvent *e) override;
 
     /**
      * @brief Method, that's called on any key press, posted

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -426,7 +426,6 @@ void AppWindow::openTab(MainWindow *window, MainWindow *after)
     connect(window, &MainWindow::requestUpdateLanguageServerFilePath, this, &AppWindow::updateLanguageServerFilePath);
     connect(window, &MainWindow::editorLanguageChanged, this, &AppWindow::onEditorLanguageChanged);
     connect(window, &MainWindow::editorTextChanged, this, &AppWindow::onEditorTextChanged);
-    connect(window, &MainWindow::editorFontChanged, this, [this] { onSettingsApplied("Appearance/Font"); });
     connect(window, &MainWindow::requestToastMessage, trayIcon,
             [this](QString const &head, QString const &body) { trayIcon->showMessage(head, body); });
     connect(window, &MainWindow::compileOrRunTriggered, this, &AppWindow::onCompileOrRunTriggered);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -119,7 +119,6 @@ void MainWindow::setEditor()
     ui->editorArea->addWidget(editor);
 
     connect(editor, &Editor::CodeEditor::textChanged, this, &MainWindow::onTextChanged);
-    connect(editor, &Editor::CodeEditor::fontChanged, this, &MainWindow::onEditorFontChanged);
     // cursorPositionChanged() does not imply selectionChanged() if you press Left with
     // a selection (and the cursor is at the begin of the selection)
     connect(editor, &Editor::CodeEditor::cursorPositionChanged, this, &MainWindow::updateCursorInfo);
@@ -1240,12 +1239,6 @@ void MainWindow::onTextChanged()
         autoSaveTimer->start();
     }
     emit editorTextChanged(this);
-}
-
-void MainWindow::onEditorFontChanged(const QFont &newFont)
-{
-    SettingsHelper::setEditorFont(newFont);
-    emit editorFontChanged();
 }
 
 void MainWindow::updateCursorInfo()

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -157,7 +157,6 @@ class MainWindow : public QMainWindow
     void onRunKilled(int index);
 
     void onFileWatcherChanged(const QString &);
-    void onEditorFontChanged(const QFont &newFont);
     void onTextChanged();
     void updateCursorInfo();
     void updateChecker();
@@ -178,7 +177,6 @@ class MainWindow : public QMainWindow
     void editorFileChanged();
     void requestUpdateLanguageServerFilePath(MainWindow *window, const QString &path);
     void editorTextChanged(MainWindow *window);
-    void editorFontChanged();
     void confirmTriggered(MainWindow *widget);
     void requestToastMessage(const QString &head, const QString &body);
     void editorLanguageChanged(MainWindow *window);


### PR DESCRIPTION
## Description

Remove the function to scale editor font via mouse wheel scroll.

## Related Issues / Pull Requests

Resolves #1249.

## Motivation and Context

This has been reported to be extremely slow, because it actually applies settings to all tabs besides changing the current editor font.

An option to enable this behavior does not work. Opt-out does not fix the performance issue. Opt-in does not worth it because the user can simply use the font setting to change the font size instead. So this behavior is completely removed.

## How Has This Been Tested?

On Arch Linux.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
