### PR TITLE
fix(DiffViewer): use test case font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Fixed
+
+-   Now the diff viewer uses the same font as the test cases (monospace by default). (#1396)
+
 ## v7.0
 
 In this version, we have switched to [KSyntaxHighlighting](https://api.kde.org/frameworks/syntax-highlighting/html/), the same framework used by [the Kate editor](https://kate-editor.org/). This upgrade results in significantly improved syntax highlighting, a wider selection of [color themes](https://kate-editor.org/themes/), and additional features like code folding. However, due to extensive refactoring, some bugs may arise.

--- a/src/Widgets/DiffViewer.cpp
+++ b/src/Widgets/DiffViewer.cpp
@@ -43,6 +43,7 @@ DiffViewer::DiffViewer(QWidget *parent) : QMainWindow(parent)
     outputEdit = new QTextEdit(widget);
     outputEdit->setReadOnly(true);
     outputEdit->setWordWrapMode(QTextOption::NoWrap);
+    outputEdit->setFont(SettingsHelper::getTestCasesFont());
     leftLayout->addWidget(outputEdit);
     layout->addLayout(leftLayout);
 
@@ -52,6 +53,7 @@ DiffViewer::DiffViewer(QWidget *parent) : QMainWindow(parent)
     expectedEdit = new QTextEdit(widget);
     expectedEdit->setReadOnly(true);
     expectedEdit->setWordWrapMode(QTextOption::NoWrap);
+    expectedEdit->setFont(SettingsHelper::getTestCasesFont());
     rightLayout->addWidget(expectedEdit);
     layout->addLayout(rightLayout);
 


### PR DESCRIPTION
## Description

Use the test case font for the diff viewer.

## Related Issues / Pull Requests

Requested in the Chinese QQ group.

## Motivation and Context

The diff viewer should use the same font as test cases like monospace.

## How Has This Been Tested

On Arch Linux.

## Screenshots (if appropriate)

Before:

![image](https://github.com/user-attachments/assets/1fa4b83f-bc43-4f70-b111-821ab2c11806)

After:

![image](https://github.com/user-attachments/assets/19ac1d45-dc7d-44b5-83c6-4e5dd5373966)

## Checklist
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).