### PR TITLE
ci: use macos-13 intel based runner for ci and release

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -20,7 +20,7 @@ jobs:
             ecm-path: "C:/Program Files/ECM/"
           - os: ubuntu-latest
             binary: cpeditor
-          - os: macos-latest
+          - os: macos-13
             binary: cpeditor.app/Contents/MacOS/cpeditor
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           - os: "ubuntu-20.04"
             portable-option: "Off"
             winlibs: false
-          - os: "macos-latest"
+          - os: "macos-13"
             portable-option: "Off"
             winlibs: false
           - os: "windows-2019"


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->
This is a temporary fix to make the CI happy once again since the `macos-latest` now points to macos-14 runners which are based on ARM.

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

As proposed in https://github.com/cpeditor/cpeditor/discussions/1369 we will eventually plan to go with second option of completely deprecating macOS x64 and going macOS ARM starting v7.0

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
