### PR TITLE
fix: avoid translating parentheses in file selection filters

### DIFF
--- a/src/Util/FileUtil.cpp
+++ b/src/Util/FileUtil.cpp
@@ -36,11 +36,13 @@ QString fileNameFilter(bool cpp, bool java, bool python)
     QString name;
 
     if (cpp && !java && !python)
-        name = "C++ ";
+        name = QCoreApplication::translate("Util::FileUtil", "C++ Source Files");
     else if (java && !cpp && !python)
-        name = "Java ";
+        name = QCoreApplication::translate("Util::FileUtil", "Java Source Files");
     else if (python && !cpp && !java)
-        name = "Python ";
+        name = QCoreApplication::translate("Util::FileUtil", "Python Source Files");
+    else
+        name = QCoreApplication::translate("Util::FileUtil", "Source Files");
 
     QString filter;
 
@@ -51,7 +53,7 @@ QString fileNameFilter(bool cpp, bool java, bool python)
     if (python)
         filter += " *." + pythonSuffix.join(" *.");
 
-    return QCoreApplication::translate("Util::FileUtil", "%1Source Files (%2)").arg(name, filter.trimmed());
+    return QStringLiteral("%1 (%2)").arg(name, filter);
 }
 
 QString fileNameWithSuffix(const QString &name, const QString &lang)

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -2824,10 +2824,6 @@ This may reduce distractions caused by stopwatch updates.</source>
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <source>%1Source Files (%2)</source>
-        <translation>%1 Πηγαία αρχεία (%2)</translation>
-    </message>
-    <message>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Απέτυχε να ανοίξει [%1]. Μήπως δεν έχετε άδεια εγγραφής;</translation>
     </message>
@@ -2858,6 +2854,22 @@ This may reduce distractions caused by stopwatch updates.</source>
     <message>
         <source>Reveal %1 in File Manager</source>
         <translation>Εμφάνιση του %1 στον διαχειριστή αρχείων</translation>
+    </message>
+    <message>
+        <source>C++ Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Java Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Python Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Source Files</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -2829,10 +2829,6 @@ Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y pu
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <source>%1Source Files (%2)</source>
-        <translation>%1Archivos fuente (%2)</translation>
-    </message>
-    <message>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Error al abrir [%1]. ¿Tengo permiso de escritura?</translation>
     </message>
@@ -2863,6 +2859,22 @@ Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y pu
     <message>
         <source>Reveal %1 in File Manager</source>
         <translation>Mostrar %1 en el administrador de archivos</translation>
+    </message>
+    <message>
+        <source>C++ Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Java Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Python Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Source Files</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -2828,10 +2828,6 @@ Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</tr
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <source>%1Source Files (%2)</source>
-        <translation>%1 Arquivos fontes (%2)</translation>
-    </message>
-    <message>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Falha ao abrir [%1]. Tem permissão para gravar?</translation>
     </message>
@@ -2862,6 +2858,22 @@ Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</tr
     <message>
         <source>Reveal %1 in File Manager</source>
         <translation>Apresentar %1 no Gerenciador de Arquivos</translation>
+    </message>
+    <message>
+        <source>C++ Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Java Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Python Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Source Files</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2826,10 +2826,6 @@ This may reduce distractions caused by stopwatch updates.</source>
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <source>%1Source Files (%2)</source>
-        <translation>%1Исходные файлы (%2)</translation>
-    </message>
-    <message>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Не удалось открыть файл [%1]. Предоставлен ли доступ к записи в фалйл?</translation>
     </message>
@@ -2860,6 +2856,22 @@ This may reduce distractions caused by stopwatch updates.</source>
     <message>
         <source>Reveal %1 in File Manager</source>
         <translation>Показать %1 в Файловом менеджере</translation>
+    </message>
+    <message>
+        <source>C++ Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Java Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Python Source Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Source Files</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -441,7 +441,7 @@ git 提交编号: %3
     </message>
     <message>
         <source>Source File</source>
-        <translation>源文件</translation>
+        <translation>源代码</translation>
     </message>
     <message>
         <source>Executable File</source>
@@ -2819,10 +2819,6 @@ This may reduce distractions caused by stopwatch updates.</source>
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <source>%1Source Files (%2)</source>
-        <translation>%1 源代码 (%2)</translation>
-    </message>
-    <message>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>打开 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
@@ -2853,6 +2849,22 @@ This may reduce distractions caused by stopwatch updates.</source>
     <message>
         <source>Reveal %1 in File Manager</source>
         <translation>在文件管理器中查看%1</translation>
+    </message>
+    <message>
+        <source>C++ Source Files</source>
+        <translation>C++ 源代码</translation>
+    </message>
+    <message>
+        <source>Java Source Files</source>
+        <translation>Java 源代码</translation>
+    </message>
+    <message>
+        <source>Python Source Files</source>
+        <translation>Python 源代码</translation>
+    </message>
+    <message>
+        <source>Source Files</source>
+        <translation>源代码</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2845,10 +2845,6 @@ This may reduce distractions caused by stopwatch updates.</source>
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <source>%1Source Files (%2)</source>
-        <translation>%1 原始檔（%2）</translation>
-    </message>
-    <message>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>無法開啟「%1」。有寫入權限嗎？</translation>
     </message>
@@ -2881,6 +2877,22 @@ This may reduce distractions caused by stopwatch updates.</source>
     <message>
         <source>Reveal %1 in File Manager</source>
         <translation>在檔案管理員中顯示 %1</translation>
+    </message>
+    <message>
+        <source>C++ Source Files</source>
+        <translation>C++ 原始檔</translation>
+    </message>
+    <message>
+        <source>Java Source Files</source>
+        <translation>Java 原始檔</translation>
+    </message>
+    <message>
+        <source>Python Source Files</source>
+        <translation>Python 原始檔</translation>
+    </message>
+    <message>
+        <source>Source Files</source>
+        <translation>原始檔</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description

Avoid translating `()` to `（）` in file selection filters.

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->

This fixes #1434.

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

On Arch Linux

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
