### PR TITLE
feat: add option to disable CF Tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+### Added
+
+-   An option to disable CF Tool integration. (#1439)
+
 ### Fixed
 
 -   Now the diff viewer uses the same font as the test cases (monospace by default). (#1396)

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -264,7 +264,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                 "Competitive Companion/Set Time Limit For Tab", "Competitive Companion/Connection Port",
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
                 "Competitive Companion/Head Comments Powered By CP Editor"}, false)
-            .page(TRKEY("CF Tool"), {"CF/Path", "CF/Show Toast Messages"})
+            .page(TRKEY("CF Tool"), {"CF/Path", "CF/Show Toast Messages", "CF/Enable CF Tool"})
             .page(TRKEY("WakaTime"),{"WakaTime/Enable", "WakaTime/Path", "WakaTime/Api Key", "WakaTime/Proxy"})
         .end()
         .dir(TRKEY("File Path"))

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -264,7 +264,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                 "Competitive Companion/Set Time Limit For Tab", "Competitive Companion/Connection Port",
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
                 "Competitive Companion/Head Comments Powered By CP Editor"}, false)
-            .page(TRKEY("CF Tool"), {"CF/Enable CF Tool","CF/Path", "CF/Show Toast Messages"})
+            .page(TRKEY("CF Tool"), {"CF/Enable","CF/Path", "CF/Show Toast Messages"})
             .page(TRKEY("WakaTime"),{"WakaTime/Enable", "WakaTime/Path", "WakaTime/Api Key", "WakaTime/Proxy"})
         .end()
         .dir(TRKEY("File Path"))

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -264,7 +264,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                 "Competitive Companion/Set Time Limit For Tab", "Competitive Companion/Connection Port",
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
                 "Competitive Companion/Head Comments Powered By CP Editor"}, false)
-            .page(TRKEY("CF Tool"), {"CF/Path", "CF/Show Toast Messages", "CF/Enable CF Tool"})
+            .page(TRKEY("CF Tool"), {"CF/Enable CF Tool","CF/Path", "CF/Show Toast Messages"})
             .page(TRKEY("WakaTime"),{"WakaTime/Enable", "WakaTime/Path", "WakaTime/Api Key", "WakaTime/Proxy"})
         .end()
         .dir(TRKEY("File Path"))

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -642,7 +642,7 @@
     "tip": "The path to the CF Tool executable file",
     "depends": [
       {
-        "name": "CF/Enable CF Tool"
+        "name": "CF/Enable"
       }
     ]
   },
@@ -654,16 +654,16 @@
     "tip": "Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.",
     "depends": [
       {
-        "name": "CF/Enable CF Tool"
+        "name": "CF/Enable"
       }
     ]
   },
   {
-    "name": "CF/Enable CF Tool",
+    "name": "CF/Enable",
     "desc": "Enable CF Tool",
     "type": "bool",
     "default": "true",
-    "tip": "Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings."
+    "tip": "Enable or disable CF Tool Integration."
   },
   {
     "name": "Show Compile And Run Only",

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -649,6 +649,13 @@
     "tip": "Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor."
   },
   {
+    "name": "CF/Enable CF Tool",
+    "desc": "Enable CF Tool",
+    "type": "bool",
+    "default": "true",
+    "tip": "Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings."
+  },
+  {
     "name": "Show Compile And Run Only",
     "type": "bool",
     "tip": "Hide the Compile Only button and the Run Only button under the code editor in the main window."

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -639,14 +639,24 @@
     "default": "cf",
     "ui": "PathItem",
     "param": "PathItem::Executable",
-    "tip": "The path to the CF Tool executable file"
+    "tip": "The path to the CF Tool executable file",
+    "depends": [
+      {
+        "name": "CF/Enable CF Tool"
+      }
+    ]
   },
   {
     "name": "CF/Show Toast Messages",
     "desc": "Show toast messages for submission verdicts",
     "type": "bool",
     "default": "true",
-    "tip": "Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor."
+    "tip": "Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.",
+    "depends": [
+      {
+        "name": "CF/Enable CF Tool"
+      }
+    ]
   },
   {
     "name": "CF/Enable CF Tool",

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -245,7 +245,7 @@ void MainWindow::saveTests(bool safe)
 
 void MainWindow::setCFToolUI()
 {
-    if (!SettingsHelper::isCFEnableCFTool())
+    if (!SettingsHelper::isCFEnable())
         return;
     if (submitToCodeforces == nullptr)
     {
@@ -642,11 +642,11 @@ void MainWindow::applySettings(const QString &pagePath)
         }
         if (problemURL.contains("codeforces.com"))
         {
-            if (submitToCodeforces == nullptr && SettingsHelper::isCFEnableCFTool())
+            if (submitToCodeforces == nullptr && SettingsHelper::isCFEnable())
             {
                 setCFToolUI();
             }
-            else if (submitToCodeforces != nullptr && !SettingsHelper::isCFEnableCFTool())
+            else if (submitToCodeforces != nullptr && !SettingsHelper::isCFEnable())
             {
                 removeCFToolUI();
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -245,6 +245,8 @@ void MainWindow::saveTests(bool safe)
 
 void MainWindow::setCFToolUI()
 {
+    if (!SettingsHelper::isCFEnableCFTool())
+        return;
     if (submitToCodeforces == nullptr)
     {
         submitToCodeforces = new QPushButton(tr("Submit"), this);
@@ -624,6 +626,20 @@ void MainWindow::applySettings(const QString &pagePath)
             cftool->updatePath(cftoolPath);
             if (submitToCodeforces != nullptr)
                 submitToCodeforces->setEnabled(true);
+        }
+        if (problemURL.contains("codeforces.com"))
+        {
+            if (submitToCodeforces == nullptr && SettingsHelper::isCFEnableCFTool())
+            {
+                setCFToolUI();
+            }
+            else if (submitToCodeforces != nullptr && !SettingsHelper::isCFEnableCFTool())
+            {
+                submitToCodeforces->setEnabled(false);
+                ui->compileAndRunButtons->removeWidget(submitToCodeforces);
+                delete submitToCodeforces;
+                submitToCodeforces = nullptr;
+            }
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -299,7 +299,6 @@ void MainWindow::removeCFToolUI()
         delete cftool;
         cftool = nullptr;
     }
-    return;
 }
 
 int MainWindow::getUntitledIndex() const

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -288,6 +288,20 @@ void MainWindow::setCFToolUI()
     }
 }
 
+void MainWindow::removeCFToolUI()
+{
+    if (submitToCodeforces != nullptr)
+    {
+        submitToCodeforces->setEnabled(false);
+        ui->compileAndRunButtons->removeWidget(submitToCodeforces);
+        delete submitToCodeforces;
+        submitToCodeforces = nullptr;
+        delete cftool;
+        cftool = nullptr;
+    }
+    return;
+}
+
 int MainWindow::getUntitledIndex() const
 {
     return untitledIndex;
@@ -635,10 +649,7 @@ void MainWindow::applySettings(const QString &pagePath)
             }
             else if (submitToCodeforces != nullptr && !SettingsHelper::isCFEnableCFTool())
             {
-                submitToCodeforces->setEnabled(false);
-                ui->compileAndRunButtons->removeWidget(submitToCodeforces);
-                delete submitToCodeforces;
-                submitToCodeforces = nullptr;
+                removeCFToolUI();
             }
         }
     }

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -242,6 +242,7 @@ class MainWindow : public QMainWindow
     void loadTests();
     void saveTests(bool safe);
     void setCFToolUI();
+    void removeCFToolUI(); // Delete cftool&submitToCodeforces pointers, and remove the button from ui
     void setFilePath(QString path, bool updateBinder = true);
     void setText(const QString &text, bool keep = false);
     void updateWatcher();

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -2713,6 +2713,14 @@ This may reduce distractions caused by stopwatch updates.</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Enable CF Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -2718,7 +2718,7 @@ This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -2718,6 +2718,14 @@ Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y pu
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Enable CF Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -2723,7 +2723,7 @@ Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y pu
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -2722,7 +2722,7 @@ Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</tr
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -2717,6 +2717,14 @@ Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</tr
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Enable CF Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2715,6 +2715,14 @@ This may reduce distractions caused by stopwatch updates.</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Enable CF Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -2720,7 +2720,7 @@ This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2713,7 +2713,7 @@ This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2708,6 +2708,14 @@ This may reduce distractions caused by stopwatch updates.</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation>默认路径</translation>
     </message>
+    <message>
+        <source>Enable CF Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ShortcutItem</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2094,8 +2094,8 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation>啟用 CF Tool</translation>
     </message>
     <message>
-        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
-        <translation>啟用以檢查 CF Tool 是否安裝與顯示「送出」按鈕。禁用以隱藏按鈕並抑制警告。</translation>
+        <source>Enable or disable CF Tool Integration.</source>
+        <translation>啟用或禁用CF Tool</translation>
     </message>
     <message>
         <source>Show Compile And Run Only</source>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2090,6 +2090,14 @@ kill the application with SIGKILL which could not be handled by the application.
         <translation>當評判結果揭曉時，顯示快顯通知。此通知在 CP Editor 以外也能見到。</translation>
     </message>
     <message>
+        <source>Enable CF Tool</source>
+        <translation>啟用 CF Tool</translation>
+    </message>
+    <message>
+        <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
+      <translation>啟用以檢查 CF Tool 是否安裝與顯示「送出」按鈕。禁用以隱藏按鈕並抑制警告。</translation>
+    </message>
+    <message>
         <source>Show Compile And Run Only</source>
         <translation>只顯示編譯並執行</translation>
     </message>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2095,7 +2095,7 @@ kill the application with SIGKILL which could not be handled by the application.
     </message>
     <message>
         <source>Enable to check CF Tool and show the submit button. Disable to hide the button and suppress warnings.</source>
-      <translation>啟用以檢查 CF Tool 是否安裝與顯示「送出」按鈕。禁用以隱藏按鈕並抑制警告。</translation>
+        <translation>啟用以檢查 CF Tool 是否安裝與顯示「送出」按鈕。禁用以隱藏按鈕並抑制警告。</translation>
     </message>
     <message>
         <source>Show Compile And Run Only</source>


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->
I add a option to disable the CF Tool.
The enable/disable checkbox is at Preferences > Extensions > CF Tool.
If it is disable, the submit button will be hidden and the cf tool won't be checked (so won't show the warning).

Also, I add the Traditional Chinese translations for the descriptions of the checkbox.

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->
ref #1413

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->
OS: Ubuntu 24.04 
Language: English&zh-TW (To check the translation)
1. Use Competitive Companion to get the problems on Codeforces and atcoder.
2. Toggle the enable CF Tool option.
3. Add another codeforces problem.
4. Toggle the enable CF Tool option.
## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [x] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
