### PR TITLE
ci(macos): switch to macos-latest for building

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -20,7 +20,7 @@ jobs:
             ecm-path: "C:/Program Files/ECM/"
           - os: ubuntu-latest
             binary: cpeditor
-          - os: macos-13
+          - os: macos-latest
             binary: cpeditor.app/Contents/MacOS/cpeditor
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 -   Removed the function to scale the editor font via mouse wheel scroll, as it has been reported to have severe performance issues. (#1249 and #1388)
+-   macOS ARM native builds are published as part of build artifacts.
 
 ## v7.0
 


### PR DESCRIPTION

<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
Now that we are using system kf5 syntax highlighting in #1445 , we can go arm native for macOS. In follow up, I will be updating the release pipelines for all other distributions as well.

## Related Issues / Pull Requests
#1445

## Motivation and Context
macOS x64_64 is almost sunsetting and arm native offers faster CI speed and avoids rosetta2 overhead when running on M-series macs.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate)
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
