### PR TITLE
fix(snap): fix core24 snap build with CMake 3.28 compatibility

### DIFF
--- a/.github/workflows/push_snap.yml
+++ b/.github/workflows/push_snap.yml
@@ -27,11 +27,13 @@ jobs:
         with:
           repository: KDE/extra-cmake-modules
           path: third_party/extra-cmake-modules
+          ref: v6.3.0
 
       - uses: actions/checkout@v6
         with:
           repository: KDE/syntax-highlighting
           path: third_party/syntax-highlighting
+          ref: v6.3.0
 
       - name: Update Snapcraft
         run: |

--- a/.github/workflows/release_snap.yml
+++ b/.github/workflows/release_snap.yml
@@ -25,11 +25,13 @@ jobs:
         with:
           repository: KDE/extra-cmake-modules
           path: third_party/extra-cmake-modules
+          ref: v6.3.0
 
       - uses: actions/checkout@v6
         with:
           repository: KDE/syntax-highlighting
           path: third_party/syntax-highlighting
+          ref: v6.3.0
 
       - name: Get version
         id: get_version

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -39,12 +39,14 @@ parts:
     override-build: |
       cd $CRAFT_PART_SRC
       cd third_party/extra-cmake-modules
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      sudo cmake --build build --config Release --parallel $(nproc) --target install
+      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
+      cmake --build build --parallel $(nproc)
+      cmake --install build
       cd -
       cd third_party/syntax-highlighting
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      sudo cmake --build build --config Release --parallel $(nproc) --target install
+      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
+      cmake --build build --parallel $(nproc)
+      cmake --install build
       cd -
       craftctl default
     override-prime: |


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
- snapcraft.yaml: remove sudo usage (not available in snapcraft v8 LXD containers), use cmake --install with CMAKE_INSTALL_PREFIX=/usr instead
- push_snap.yml, release_snap.yml: pin KDE/extra-cmake-modules and KDE/syntax-highlighting to v6.3.0 tag (compatible with CMake 3.28 on core24 base, newer tags require CMake 3.29+)

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->
Failure when pushing the snapcraft

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
