### PR TITLE
fix(snap): switch to core26 base for Qt6/KF6 compatibility

### DIFF
--- a/.github/workflows/push_snap.yml
+++ b/.github/workflows/push_snap.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix/snap-qt6-policy
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/push_snap.yml"

--- a/.github/workflows/push_snap.yml
+++ b/.github/workflows/push_snap.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix/snap-qt6-policy
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/push_snap.yml"
@@ -19,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: master
           submodules: recursive
           fetch-depth: 0
 
@@ -43,6 +43,7 @@ jobs:
         id: build
 
       - uses: snapcore/action-publish@v1
+        if: github.ref == 'refs/heads/master'
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:

--- a/.github/workflows/push_snap.yml
+++ b/.github/workflows/push_snap.yml
@@ -27,13 +27,11 @@ jobs:
         with:
           repository: KDE/extra-cmake-modules
           path: third_party/extra-cmake-modules
-          ref: v6.3.0
 
       - uses: actions/checkout@v6
         with:
           repository: KDE/syntax-highlighting
           path: third_party/syntax-highlighting
-          ref: v6.3.0
 
       - name: Update Snapcraft
         run: |

--- a/.github/workflows/push_snap.yml
+++ b/.github/workflows/push_snap.yml
@@ -39,6 +39,8 @@ jobs:
 
       - uses: snapcore/action-build@v1
         id: build
+        with:
+          snapcraft-channel: latest/candidate
 
       - uses: snapcore/action-publish@v1
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/release_snap.yml
+++ b/.github/workflows/release_snap.yml
@@ -60,6 +60,7 @@ jobs:
         id: build
         with:
           path: cpeditor-${{ steps.get_version.outputs.version }}-full-source
+          snapcraft-channel: latest/candidate
 
       - uses: snapcore/action-publish@v1
         if: steps.get_version.outputs.ISSTABLE == 'true'

--- a/.github/workflows/release_snap.yml
+++ b/.github/workflows/release_snap.yml
@@ -25,13 +25,11 @@ jobs:
         with:
           repository: KDE/extra-cmake-modules
           path: third_party/extra-cmake-modules
-          ref: v6.3.0
 
       - uses: actions/checkout@v6
         with:
           repository: KDE/syntax-highlighting
           path: third_party/syntax-highlighting
-          ref: v6.3.0
 
       - name: Get version
         id: get_version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   Migrate from Qt5 to Qt6 and KF5 to KF6 Syntax Highlighting. (#1449)
 -   Switch macOS release builds to ARM (Apple Silicon). (#1449)
+-   Snap package now uses `core26` base (Ubuntu 26.04), providing Qt 6.8+. (#1489)
 
 ## v7.1
 

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -28,10 +28,10 @@ parts:
       - libgl1-mesa-dev
       - git
     stage-packages:
-      - libqt6core6t64
-      - libqt6gui6t64
-      - libqt6widgets6t64
-      - libqt6network6t64
+      - libqt6core6
+      - libqt6gui6
+      - libqt6widgets6
+      - libqt6network6
       - libqt6svg6
       - libqt6core5compat6
     source: .

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: cpeditor
 base: core26
-grade: stable
+build-base: core26
+grade: devel
 confinement: classic
 adopt-info: cpeditor
 

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: cpeditor
 base: core26
-build-base: core26
+build-base: devel
 grade: devel
 confinement: classic
 adopt-info: cpeditor

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cpeditor
-base: core24
+base: core26
 grade: stable
 confinement: classic
 adopt-info: cpeditor
@@ -44,8 +44,6 @@ parts:
       cmake --build build --parallel $(nproc)
       cmake --install build
       cd -
-      # Remove qt6_policy call that requires Qt 6.5+, Ubuntu 24.04 ships Qt 6.4.2
-      sed -i '/qt6_policy/d' /usr/share/ECM/modules/ECMQmlModule6.cmake
       cd third_party/syntax-highlighting
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -44,6 +44,8 @@ parts:
       cmake --build build --parallel $(nproc)
       cmake --install build
       cd -
+      # Remove qt6_policy call that requires Qt 6.5+, Ubuntu 24.04 ships Qt 6.4.2
+      sed -i '/qt6_policy/d' /usr/share/ECM/modules/ECMQmlModule6.cmake
       cd third_party/syntax-highlighting
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
The snap build was failing after the Qt6 migration (#1449) because `core24` (Ubuntu 24.04) only ships Qt 6.4.2, which lacks `qt6_policy()` (Qt 6.5+) required by KF6 syntax-highlighting.

This PR switches the snap from `core24` to `core26` (Ubuntu 26.04), which ships Qt 6.8+ and CMake 4.x natively.

Changes:
- `base: core24` → `base: core26` with `build-base: devel` and `grade: devel` (core26 is pre-stable)
- Dropped `t64` suffix from Qt6 stage-packages (not needed in 26.04)
- Added `snapcraft-channel: latest/candidate` to CI workflows (requires snapcraft 9.x)
- Removed all prior workarounds: sed patches for qt6_policy/REQUIRED_QT_VERSION, pinned KDE refs

The snap now publishes from the `core26` base to the `edge` channel on pushes to master, and to `stable` on releases.

## Related Issues / Pull Requests
Fixes snap build failure after Qt6 migration (#1449)

## Motivation and Context
Qt6 migration broke the snap build. core26 resolves this cleanly without hacks.

## How Has This Been Tested?
Snap build verified via push_snap.yml CI workflow.

## Checklist
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
