### PR TITLE
fix(snap): use DESTDIR to stage KF6 SyntaxHighlighting into snap

### DIFF
--- a/.github/workflows/push_snap.yml
+++ b/.github/workflows/push_snap.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix/snap-destdir-staging
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/push_snap.yml"

--- a/.github/workflows/push_snap.yml
+++ b/.github/workflows/push_snap.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix/snap-destdir-staging
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/push_snap.yml"

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -43,12 +43,12 @@ parts:
       cd third_party/extra-cmake-modules
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
-      cmake --install build
+      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
       cd -
       cd third_party/syntax-highlighting
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
-      cmake --install build
+      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
       cd -
       craftctl default
     override-prime: |


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
Fixes `libKF6SyntaxHighlighting.so.6: cannot open shared object file` error when running the core26 snap.

Without `DESTDIR=$CRAFT_PART_INSTALL`, `cmake --install` installs ECM and syntax-highlighting to the system `/usr` inside the build instance instead of the craft part install directory. This means the libraries are never staged into the final snap.

## Related Issues / Pull Requests
Fixes runtime error after snap core26 migration (#1489)

## Checklist
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
