### PR TITLE
fix(snap): add missing stage-packages for Qt Qml/Quick/OpenGL/ICU

### DIFF
--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -34,6 +34,10 @@ parts:
       - libqt6network6
       - libqt6svg6
       - libqt6core5compat6
+      - libqt6opengl6
+      - libqt6qml6
+      - libqt6quick6
+      - libicu78
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
Fixes runtime errors when running the core26 snap:
- `libicuuc.so.78: cannot open shared object file`
- `libkquicksyntaxhighlightingplugin.so` missing dependencies: `libQt6OpenGL.so.6`, `libQt6Qml.so.6`, `libQt6QmlMeta.so.6`, `libQt6QmlModels.so.6`, `libQt6QmlWorkerScript.so.6`, `libQt6Quick.so.6`

Added `libqt6opengl6`, `libqt6qml6`, `libqt6quick6`, and `libicu78` to stage-packages.

## Related Issues / Pull Requests
Follow-up to #1489 and #1490

## Checklist
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
