### PR TITLE
fix(snap): use patchelf to set ELF interpreter and rpath for core26

### DIFF
--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -27,6 +27,7 @@ parts:
       - libqt6core5compat6-dev
       - libgl1-mesa-dev
       - git
+      - patchelf
     stage-packages:
       - libqt6core6
       - libqt6gui6
@@ -58,3 +59,9 @@ parts:
     override-prime: |
         craftctl default
         sed -i 's|Icon=.*|Icon=${SNAP}/usr/share/icons/hicolor/512x512/apps/cpeditor.png|g' $CRAFT_PRIME/usr/share/applications/cpeditor.desktop
+        find $CRAFT_PRIME -type f -executable | while read -r elf; do
+            if file "$elf" | grep -q ELF; then
+                patchelf --set-interpreter "/snap/core26/current/lib64/ld-linux-x86-64.so.2" "$elf" 2>/dev/null || true
+                patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../lib/x86_64-linux-gnu:\$ORIGIN/../../lib/x86_64-linux-gnu:/snap/core26/current/lib/x86_64-linux-gnu" "$elf" 2>/dev/null || true
+            fi
+        done


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
Fixes the `GLIBC_2.43 not found` error when running the core26 classic snap on hosts with older glibc.

Classic confinement snaps load the host's glibc, but Qt6 libs from core26 (Ubuntu 26.04) are compiled against glibc 2.43. If the host has an older glibc, the snap fails to run.

The fix uses `patchelf` in `override-prime` to:
1. Set ELF interpreter to `/snap/core26/current/lib64/ld-linux-x86-64.so.2` (core26's ld-linux)
2. Set rpath to include `/snap/core26/current/lib/x86_64-linux-gnu` (core26's glibc)

This ensures the snap uses the core26 glibc at runtime, regardless of the host version.

## Related Issues / Pull Requests
Follow-up to #1489, #1490, #1491

## Checklist
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
