### PR TITLE
feat(snippets): Add fallback token-based snippet searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Migrate from Qt5 to Qt6 and KF5 to KF6 Syntax Highlighting. (#1449)
 -   Switch macOS release builds to ARM (Apple Silicon). (#1449)
 -   Snap package now uses `core26` base (Ubuntu 26.04), providing Qt 6.8+. (#1489)
+-   Improved snippet search with token-based prefix matching.
 
 ## v7.1
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -52,6 +52,7 @@
 #include <QTabBar>
 #include <QTimer>
 #include <QUrl>
+#include <QRegularExpression>
 #include <findreplacedialog.h>
 
 AppWindow::AppWindow(bool noRestoreSession, QWidget *parent) : QMainWindow(parent), ui(new Ui::AppWindow)
@@ -1320,10 +1321,53 @@ void AppWindow::on_actionUseSnippets_triggered()
             if (*ok)
             {
                 LOG_INFO("Looking for snippet : " << name);
+
+                // Try exact match first
+                QString matchedName;
                 if (names.contains(name))
                 {
+                    matchedName = name;
+                }
+                else
+                {
+                    // Fall back to token-based prefix matching:
+                    // Split snippet names into tokens on common delimiters and check if
+                    // each query token is a prefix of at least one name token.
+                    static const QRegularExpression delim("[\\s_\\-,;:.!?()\\[\\]{}'\"/\\\\]+");
+                    auto queryTokens = name.toLower().split(delim, Qt::SkipEmptyParts);
+                    for (const auto &snippetName : names)
+                    {
+                        auto nameTokens = snippetName.toLower().split(delim, Qt::SkipEmptyParts);
+                        bool allMatch = true;
+                        for (const auto &qt : queryTokens)
+                        {
+                            bool found = false;
+                            for (const auto &nt : nameTokens)
+                            {
+                                if (nt.startsWith(qt))
+                                {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (!found)
+                            {
+                                allMatch = false;
+                                break;
+                            }
+                        }
+                        if (allMatch)
+                        {
+                            matchedName = snippetName;
+                            break;
+                        }
+                    }
+                }
+
+                if (!matchedName.isEmpty())
+                {
                     LOG_INFO("Found snippet and inserted");
-                    QString content = SettingsHelper::getLanguageConfig(lang).getSnippet(name);
+                    QString content = SettingsHelper::getLanguageConfig(lang).getSnippet(matchedName);
                     current->insertText(content);
                 }
                 else

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1333,7 +1333,7 @@ void AppWindow::on_actionUseSnippets_triggered()
                     // Fall back to token-based prefix matching:
                     // Split snippet names into tokens on common delimiters and check if
                     // each query token is a prefix of at least one name token.
-                    static const QRegularExpression delim("[\\s_\\-,;:.!?()\\[\\]{}'\"/\\\\]+");
+                    static const QRegularExpression delim(R"([\s_\-,;:.!?()\[\]{}'"/\\]+)");
                     auto queryTokens = name.toLower().split(delim, Qt::SkipEmptyParts);
                     for (const auto &snippetName : names)
                     {

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -47,12 +47,12 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QProgressDialog>
+#include <QRegularExpression>
 #include <QShortcut>
 #include <QSplitter>
 #include <QTabBar>
 #include <QTimer>
 #include <QUrl>
-#include <QRegularExpression>
 #include <findreplacedialog.h>
 
 AppWindow::AppWindow(bool noRestoreSession, QWidget *parent) : QMainWindow(parent), ui(new Ui::AppWindow)


### PR DESCRIPTION
## Summary

Improves snippet search by adding token-based prefix matching while preserving the existing `QInputDialog` UI and keyboard navigation.

## Changes

* Added token-based matching fallback for snippet lookup
* Supports delimiters like spaces, underscores, hyphens, brackets, quotes, etc.
* Supports prefix matching on tokens

## Examples

Searching for:

* `functions` now matches `Integer Functions`
* `fun` matches `Functions`
* `max` matches `Math-Max`

## Notes

* Existing UI behavior is preserved
* Minimal implementation with small code changes
