### PR TITLE
fix(snap): core26 for extra-cmake-modules and syntax-highighting also add wayland support

### DIFF
--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -40,6 +40,7 @@ parts:
       - libqt6qml6
       - libqt6quick6
       - libkf6syntaxhighlighting6
+      - libicu78
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ parts:
     plugin: cmake
     build-packages:
       - build-essential
+      - extra-cmake-modules
+      - libkf6syntaxhighlighting-dev
       - qt6-base-dev
       - qt6-base-dev-tools
       - qt6-tools-dev
@@ -37,27 +39,8 @@ parts:
       - libqt6core5compat6
       - libqt6qml6
       - libqt6quick6
+      - libkf6syntaxhighlighting6
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_PREFIX_PATH=$CRAFT_PART_INSTALL/usr
-    override-build: |
-      cd $CRAFT_PART_SRC
-      cd third_party/extra-cmake-modules
-      git fetch --tags
-      git reset --hard
-      git checkout v6.0.0
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      cmake --build build --parallel $(nproc)
-      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
-      cd -
-      cd third_party/syntax-highlighting
-      git fetch --tags
-      git reset --hard
-      git checkout v6.0.0
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      cmake --build build --parallel $(nproc)
-      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
-      cd -
-      craftctl default

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cpeditor
-base: core24
+base: core26
 build-base: devel
 grade: devel
 confinement: classic
@@ -30,9 +30,9 @@ parts:
       - perl
     stage-packages:
       - libqt6core6t64
-      - libqt6gui6t64
-      - libqt6widgets6t64
-      - libqt6network6t64
+      - libqt6gui6
+      - libqt6widgets6
+      - libqt6network6
       - libqt6svg6
       - libqt6core5compat6
       - libqt6qml6
@@ -48,7 +48,6 @@ parts:
       git fetch --tags
       git reset --hard
       git checkout v6.0.0
-      sed -i 's/qt6_policy(SET QTP0001 NEW)//g' modules/ECMQmlModule6.cmake
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build
@@ -57,7 +56,6 @@ parts:
       git fetch --tags
       git reset --hard
       git checkout v6.0.0
-      sed -i 's/set(REQUIRED_QT_VERSION 6.5.0)/set(REQUIRED_QT_VERSION 6.4.0)/g' CMakeLists.txt
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cpeditor
-base: core24
+base: core26
 build-base: devel
 grade: devel
 confinement: classic

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -46,6 +46,7 @@ parts:
       cd $CRAFT_PART_SRC
       cd third_party/extra-cmake-modules
       git fetch --tags
+      git reset --hard
       git checkout v6.0.0
       sed -i 's/qt6_policy(SET QTP0001 NEW)//g' modules/ECMQmlModule6.cmake
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
@@ -54,6 +55,7 @@ parts:
       cd -
       cd third_party/syntax-highlighting
       git fetch --tags
+      git reset --hard
       git checkout v6.0.0
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cpeditor
-base: core26
+base: core24
 build-base: devel
 grade: devel
 confinement: classic
@@ -24,15 +24,15 @@ parts:
       - qt6-l10n-tools
       - qt6-svg-dev
       - qt6-declarative-dev
-      - libqt6core5compat6-dev
+      - qt6-5compat-dev
       - libgl1-mesa-dev
       - git
       - perl
     stage-packages:
-      - libqt6core6
-      - libqt6gui6
-      - libqt6widgets6
-      - libqt6network6
+      - libqt6core6t64
+      - libqt6gui6t64
+      - libqt6widgets6t64
+      - libqt6network6t64
       - libqt6svg6
       - libqt6core5compat6
       - libqt6qml6
@@ -46,14 +46,14 @@ parts:
       cd $CRAFT_PART_SRC
       cd third_party/extra-cmake-modules
       git fetch --tags
-      git checkout v6.0.0
+      git checkout v5.115.0
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build
       cd -
       cd third_party/syntax-highlighting
       git fetch --tags
-      git checkout v6.0.0
+      git checkout v5.115.0
       sed -i '/include(ECMQmlModule)/d' CMakeLists.txt
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: cpeditor
-base: core26
+base: core24
 build-base: devel
-grade: devel
+grade: stable
 confinement: classic
 adopt-info: cpeditor
 
@@ -27,17 +27,16 @@ parts:
       - libqt6core5compat6-dev
       - libgl1-mesa-dev
       - git
-      - patchelf
     stage-packages:
-      - libqt6core6
-      - libqt6gui6
-      - libqt6widgets6
-      - libqt6network6
-      - libqt6svg6
-      - libqt6core5compat6
-      - libqt6opengl6
-      - libqt6qml6
-      - libqt6quick6
+      - libqt6core6t64
+      - libqt6gui6t64
+      - libqt6widgets6t64
+      - libqt6network6t64
+      - libqt6svg6t64
+      - libqt6core5compat6t64
+      - libqt6opengl6t64
+      - libqt6qml6t64
+      - libqt6quick6t64
       - libicu78
     source: .
     cmake-parameters:
@@ -56,12 +55,3 @@ parts:
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build
       cd -
       craftctl default
-    override-prime: |
-        craftctl default
-        sed -i 's|Icon=.*|Icon=${SNAP}/usr/share/icons/hicolor/512x512/apps/cpeditor.png|g' $CRAFT_PRIME/usr/share/applications/cpeditor.desktop
-        find $CRAFT_PRIME -type f -executable | while read -r elf; do
-            if file "$elf" | grep -q ELF; then
-                patchelf --set-interpreter "/snap/core26/current/lib64/ld-linux-x86-64.so.2" "$elf" 2>/dev/null || true
-                patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../lib/x86_64-linux-gnu:\$ORIGIN/../../lib/x86_64-linux-gnu:/snap/core26/current/lib/x86_64-linux-gnu" "$elf" 2>/dev/null || true
-            fi
-        done

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -11,6 +11,8 @@ apps:
     command: usr/bin/cpeditor
     environment:
       LD_LIBRARY_PATH: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib"
+      QT_PLUGIN_PATH: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/qt6/plugins"
+      QML2_IMPORT_PATH: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/qt6/qml"
 
 parts:
   cpeditor:
@@ -41,6 +43,7 @@ parts:
       - libqt6core5compat6
       - libqt6qml6
       - libqt6quick6
+      - qt6-wayland
       - libkf6syntaxhighlighting6
       - libicu78
     source: .

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ apps:
   cpeditor:
     common-id: cpeditor.desktop
     command: usr/bin/cpeditor
+    environment:
+      LD_LIBRARY_PATH: "$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib"
 
 parts:
   cpeditor:

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cpeditor
-base: core24
+base: core26
 build-base: devel
 grade: devel
 confinement: classic
@@ -17,6 +17,8 @@ parts:
     plugin: cmake
     build-packages:
       - build-essential
+      - extra-cmake-modules
+      - libkf6syntaxhighlighting-dev
       - qt6-base-dev
       - qt6-base-dev-tools
       - qt6-tools-dev
@@ -29,7 +31,7 @@ parts:
       - git
       - perl
     stage-packages:
-      - libqt6core6
+      - libqt6core6t64
       - libqt6gui6
       - libqt6widgets6
       - libqt6network6
@@ -37,29 +39,8 @@ parts:
       - libqt6core5compat6
       - libqt6qml6
       - libqt6quick6
+      - libkf6syntaxhighlighting6
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_PREFIX_PATH=$CRAFT_PART_INSTALL/usr
-    override-build: |
-      cd $CRAFT_PART_SRC
-      cd third_party/extra-cmake-modules
-      git fetch --tags
-      git reset --hard
-      git checkout v6.0.0
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      cmake --build build --parallel $(nproc)
-      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
-      cd -
-      cd third_party/syntax-highlighting
-      git fetch --tags
-      git reset --hard
-      git checkout v6.0.0
-      sed -i 's/set(REQUIRED_QT_VERSION 6.5.0)/set(REQUIRED_QT_VERSION 6.4.2)/' CMakeLists.txt
-      sed -i '/qt6_policy(SET QTP0001 NEW)/d' CMakeLists.txt
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      cmake --build build --parallel $(nproc)
-      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
-      cd -
-      craftctl default

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -27,6 +27,7 @@ parts:
       - libqt6core5compat6-dev
       - libgl1-mesa-dev
       - git
+      - perl
     stage-packages:
       - libqt6core6
       - libqt6gui6
@@ -40,6 +41,7 @@ parts:
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_PREFIX_PATH=$CRAFT_PART_INSTALL/usr
     override-build: |
       cd $CRAFT_PART_SRC
       cd third_party/extra-cmake-modules
@@ -52,7 +54,7 @@ parts:
       cd third_party/syntax-highlighting
       git fetch --tags
       git checkout v6.0.0
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
+      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build
       cd -

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: cpeditor
 base: core24
-build-base: core24
 grade: devel
 confinement: classic
 adopt-info: cpeditor
@@ -24,7 +23,7 @@ parts:
       - qt6-l10n-tools
       - qt6-svg-dev
       - qt6-declarative-dev
-      - libqt6core5compat6-dev
+      - qt6-5compat-dev
       - libgl1-mesa-dev
       - git
     stage-packages:
@@ -40,6 +39,7 @@ parts:
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_PREFIX_PATH=$CRAFT_PART_INSTALL/usr
     override-build: |
       cd $CRAFT_PART_SRC
       cd third_party/extra-cmake-modules

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -57,6 +57,7 @@ parts:
       git fetch --tags
       git reset --hard
       git checkout v6.0.0
+      sed -i 's/set(REQUIRED_QT_VERSION 6.5.0)/set(REQUIRED_QT_VERSION 6.4.0)/g' CMakeLists.txt
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -46,15 +46,15 @@ parts:
       cd $CRAFT_PART_SRC
       cd third_party/extra-cmake-modules
       git fetch --tags
-      git checkout v5.115.0
+      git checkout v6.0.0
+      sed -i 's/qt6_policy(SET QTP0001 NEW)//g' modules/ECMQmlModule6.cmake
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build
       cd -
       cd third_party/syntax-highlighting
       git fetch --tags
-      git checkout v5.115.0
-      sed -i '/include(ECMQmlModule)/d' CMakeLists.txt
+      git checkout v6.0.0
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -32,12 +32,12 @@ parts:
       - libqt6gui6t64
       - libqt6widgets6t64
       - libqt6network6t64
-      - libqt6svg6t64
-      - libqt6core5compat6t64
+      - libqt6svg6
+      - libqt6core5compat6
       - libqt6opengl6t64
-      - libqt6qml6t64
-      - libqt6quick6t64
-      - libicu78
+      - libqt6qml6
+      - libqt6quick6
+      - libicu74
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -54,6 +54,7 @@ parts:
       cd third_party/syntax-highlighting
       git fetch --tags
       git checkout v6.0.0
+      sed -i '/include(ECMQmlModule)/d' CMakeLists.txt
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: cpeditor
 base: core24
-build-base: devel
+build-base: core24
 grade: devel
 confinement: classic
 adopt-info: cpeditor

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: cpeditor
 base: core24
+build-base: devel
 grade: devel
 confinement: classic
 adopt-info: cpeditor
@@ -23,21 +24,35 @@ parts:
       - qt6-l10n-tools
       - qt6-svg-dev
       - qt6-declarative-dev
-      - qt6-5compat-dev
+      - libqt6core5compat6-dev
       - libgl1-mesa-dev
-      - extra-cmake-modules
-      - libkf6syntaxhighlighting-dev
+      - git
+      - patchelf
     stage-packages:
-      - libqt6core6t64
-      - libqt6gui6t64
-      - libqt6widgets6t64
-      - libqt6network6t64
+      - libqt6core6
+      - libqt6gui6
+      - libqt6widgets6
+      - libqt6network6
       - libqt6svg6
       - libqt6core5compat6
+      - libqt6opengl6
       - libqt6qml6
       - libqt6quick6
-      - libkf6syntaxhighlighting6
+      - libicu78
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
+    override-build: |
+      cd $CRAFT_PART_SRC
+      cd third_party/extra-cmake-modules
+      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
+      cmake --build build --parallel $(nproc)
+      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
+      cd -
+      cd third_party/syntax-highlighting
+      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
+      cmake --build build --parallel $(nproc)
+      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
+      cd -
+      craftctl default

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -25,7 +25,8 @@ parts:
       - qt6-declarative-dev
       - qt6-5compat-dev
       - libgl1-mesa-dev
-      - git
+      - extra-cmake-modules
+      - libkf6syntaxhighlighting-dev
     stage-packages:
       - libqt6core6t64
       - libqt6gui6t64
@@ -35,21 +36,8 @@ parts:
       - libqt6core5compat6
       - libqt6qml6
       - libqt6quick6
+      - libkf6syntaxhighlighting6
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_PREFIX_PATH=$CRAFT_PART_INSTALL/usr
-    override-build: |
-      cd $CRAFT_PART_SRC
-      cd third_party/extra-cmake-modules
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      cmake --build build --parallel $(nproc)
-      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
-      cd -
-      cd third_party/syntax-highlighting
-      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
-      cmake --build build --parallel $(nproc)
-      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
-      cd -
-      craftctl default

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -27,7 +27,6 @@ parts:
       - libqt6core5compat6-dev
       - libgl1-mesa-dev
       - git
-      - patchelf
     stage-packages:
       - libqt6core6
       - libqt6gui6
@@ -44,11 +43,15 @@ parts:
     override-build: |
       cd $CRAFT_PART_SRC
       cd third_party/extra-cmake-modules
+      git fetch --tags
+      git checkout v6.0.0
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build
       cd -
       cd third_party/syntax-highlighting
+      git fetch --tags
+      git checkout v6.0.0
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: cpeditor
 base: core24
 build-base: devel
-grade: stable
+grade: devel
 confinement: classic
 adopt-info: cpeditor
 

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -17,8 +17,6 @@ parts:
     plugin: cmake
     build-packages:
       - build-essential
-      - extra-cmake-modules
-      - libkf6syntaxhighlighting-dev
       - qt6-base-dev
       - qt6-base-dev-tools
       - qt6-tools-dev
@@ -39,8 +37,27 @@ parts:
       - libqt6core5compat6
       - libqt6qml6
       - libqt6quick6
-      - libkf6syntaxhighlighting6
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_PREFIX_PATH=$CRAFT_PART_INSTALL/usr
+    override-build: |
+      cd $CRAFT_PART_SRC
+      cd third_party/extra-cmake-modules
+      git fetch --tags
+      git reset --hard
+      git checkout v6.0.0
+      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
+      cmake --build build --parallel $(nproc)
+      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
+      cd -
+      cd third_party/syntax-highlighting
+      git fetch --tags
+      git reset --hard
+      git checkout v6.0.0
+      cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
+      cmake --build build --parallel $(nproc)
+      DESTDIR=$CRAFT_PART_INSTALL cmake --install build
+      cd -
+      craftctl default

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -35,10 +35,8 @@ parts:
       - libqt6network6
       - libqt6svg6
       - libqt6core5compat6
-      - libqt6opengl6
       - libqt6qml6
       - libqt6quick6
-      - libicu78
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cpeditor
-base: core26
+base: core24
 build-base: devel
 grade: devel
 confinement: classic
@@ -29,7 +29,7 @@ parts:
       - git
       - perl
     stage-packages:
-      - libqt6core6t64
+      - libqt6core6
       - libqt6gui6
       - libqt6widgets6
       - libqt6network6
@@ -56,6 +56,8 @@ parts:
       git fetch --tags
       git reset --hard
       git checkout v6.0.0
+      sed -i 's/set(REQUIRED_QT_VERSION 6.5.0)/set(REQUIRED_QT_VERSION 6.4.2)/' CMakeLists.txt
+      sed -i '/qt6_policy(SET QTP0001 NEW)/d' CMakeLists.txt
       cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="$CRAFT_PART_INSTALL/usr;/usr" -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF
       cmake --build build --parallel $(nproc)
       DESTDIR=$CRAFT_PART_INSTALL cmake --install build

--- a/dist/snap/snapcraft.yaml
+++ b/dist/snap/snapcraft.yaml
@@ -34,10 +34,8 @@ parts:
       - libqt6network6t64
       - libqt6svg6
       - libqt6core5compat6
-      - libqt6opengl6t64
       - libqt6qml6
       - libqt6quick6
-      - libicu74
     source: .
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->
Testing on Ubuntu 25 VM


## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
