### PR TITLE
feat(ui): allow closing tabs with middle mouse click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+-   Add middle-click to close tabs. (#1351)
 -   Add vim emulation with [custom commands](https://cpeditor.org/docs/preferences/code-edit/#custom-vim-commands). (#220 and #1270)
 
 ### Changed

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -46,6 +46,7 @@
 #include <QJsonDocument>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QMouseEvent>
 #include <QProgressDialog>
 #include <QRegularExpression>
 #include <QShortcut>
@@ -55,8 +56,7 @@
 #include <QUrl>
 #include <findreplacedialog.h>
 
-#include <QMouseEvent>
-#include <QTabBar>
+
 
 AppWindow::AppWindow(bool noRestoreSession, QWidget *parent) : QMainWindow(parent), ui(new Ui::AppWindow)
 {
@@ -167,7 +167,6 @@ void AppWindow::finishConstruction()
 {
     if (tabCount() == 0)
         openTab("");
-
     ui->tabWidget->tabBar()->installEventFilter(this);
 
 #ifdef Q_OS_WIN
@@ -356,7 +355,7 @@ void AppWindow::applySettings()
 
     maybeSetHotkeys();
 
-    // FindReplaceDialog->readSettings(*SettingsHelper::settings()); FIX IT!!!
+           // FindReplaceDialog->readSettings(*SettingsHelper::settings()); FIX IT!!!
 }
 
 void AppWindow::maybeSetHotkeys()
@@ -492,7 +491,7 @@ void AppWindow::openTabs(const QStringList &paths)
 void AppWindow::openPaths(const QStringList &paths, bool cpp, bool java, bool python, int depth)
 {
     LOG_INFO("Open Path with arguments " << BOOL_INFO_OF(cpp) << BOOL_INFO_OF(java) << BOOL_INFO_OF(python)
-                                         << INFO_OF(depth) << INFO_OF(paths.join(" ")));
+             << INFO_OF(depth) << INFO_OF(paths.join(" ")));
     QStringList res;
     for (auto const &path : paths)
     {
@@ -507,7 +506,7 @@ void AppWindow::openPaths(const QStringList &paths, bool cpp, bool java, bool py
 QStringList AppWindow::openFolder(const QString &path, bool cpp, bool java, bool python, int depth)
 {
     LOG_INFO("Open folder with arguments " << BOOL_INFO_OF(cpp) << BOOL_INFO_OF(java) << BOOL_INFO_OF(python)
-                                           << INFO_OF(depth) << INFO_OF(path));
+             << INFO_OF(depth) << INFO_OF(path));
     auto entries = QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries);
     QStringList res;
     for (auto &entry : entries)
@@ -658,7 +657,7 @@ void AppWindow::on_actionBuildInfo_triggered()
 #else
                            .arg("Unknown")
 #endif
-    );
+                       );
 }
 
 /******************* FILES SECTION *************************/
@@ -1327,7 +1326,7 @@ void AppWindow::on_actionUseSnippets_triggered()
             {
                 LOG_INFO("Looking for snippet : " << name);
 
-                // Try exact match first
+                       // Try exact match first
                 QString matchedName;
                 if (names.contains(name))
                 {
@@ -1760,18 +1759,21 @@ QVector<MainWindow *> AppWindow::getTabs() const
 bool AppWindow::eventFilter(QObject *obj, QEvent *event) {
     QTabBar *tabBar = ui->tabWidget->tabBar();
 
-    if (obj != tabBar || event->type() != QEvent::MouseButtonRelease) {
+    if (obj != tabBar || event->type() != QEvent::MouseButtonRelease)
+    {
         return QMainWindow::eventFilter(obj, event);
     }
 
-    QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+    auto *mouseEvent = static_cast<QMouseEvent *>(event);
 
-    if (mouseEvent->button() != Qt::MiddleButton) {
+    if (mouseEvent->button() != Qt::MiddleButton)
+    {
         return QMainWindow::eventFilter(obj, event);
     }
 
     int index = tabBar->tabAt(mouseEvent->pos());
-    if (index >= 0) {
+    if (index >= 0)
+    {
         closeTab(index);
         return true;
     }

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -56,8 +56,6 @@
 #include <QUrl>
 #include <findreplacedialog.h>
 
-
-
 AppWindow::AppWindow(bool noRestoreSession, QWidget *parent) : QMainWindow(parent), ui(new Ui::AppWindow)
 {
     LOG_INFO(BOOL_INFO_OF(noRestoreSession))
@@ -355,7 +353,7 @@ void AppWindow::applySettings()
 
     maybeSetHotkeys();
 
-           // FindReplaceDialog->readSettings(*SettingsHelper::settings()); FIX IT!!!
+    // FindReplaceDialog->readSettings(*SettingsHelper::settings()); FIX IT!!!
 }
 
 void AppWindow::maybeSetHotkeys()
@@ -491,7 +489,7 @@ void AppWindow::openTabs(const QStringList &paths)
 void AppWindow::openPaths(const QStringList &paths, bool cpp, bool java, bool python, int depth)
 {
     LOG_INFO("Open Path with arguments " << BOOL_INFO_OF(cpp) << BOOL_INFO_OF(java) << BOOL_INFO_OF(python)
-             << INFO_OF(depth) << INFO_OF(paths.join(" ")));
+                                         << INFO_OF(depth) << INFO_OF(paths.join(" ")));
     QStringList res;
     for (auto const &path : paths)
     {
@@ -506,7 +504,7 @@ void AppWindow::openPaths(const QStringList &paths, bool cpp, bool java, bool py
 QStringList AppWindow::openFolder(const QString &path, bool cpp, bool java, bool python, int depth)
 {
     LOG_INFO("Open folder with arguments " << BOOL_INFO_OF(cpp) << BOOL_INFO_OF(java) << BOOL_INFO_OF(python)
-             << INFO_OF(depth) << INFO_OF(path));
+                                           << INFO_OF(depth) << INFO_OF(path));
     auto entries = QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries);
     QStringList res;
     for (auto &entry : entries)
@@ -657,7 +655,7 @@ void AppWindow::on_actionBuildInfo_triggered()
 #else
                            .arg("Unknown")
 #endif
-                       );
+    );
 }
 
 /******************* FILES SECTION *************************/
@@ -1326,7 +1324,7 @@ void AppWindow::on_actionUseSnippets_triggered()
             {
                 LOG_INFO("Looking for snippet : " << name);
 
-                       // Try exact match first
+                // Try exact match first
                 QString matchedName;
                 if (names.contains(name))
                 {
@@ -1756,7 +1754,8 @@ QVector<MainWindow *> AppWindow::getTabs() const
     return tabs;
 }
 
-bool AppWindow::eventFilter(QObject *obj, QEvent *event) {
+bool AppWindow::eventFilter(QObject *obj, QEvent *event)
+{
     QTabBar *tabBar = ui->tabWidget->tabBar();
 
     if (obj != tabBar || event->type() != QEvent::MouseButtonRelease)

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -55,6 +55,9 @@
 #include <QUrl>
 #include <findreplacedialog.h>
 
+#include <QMouseEvent>
+#include <QTabBar>
+
 AppWindow::AppWindow(bool noRestoreSession, QWidget *parent) : QMainWindow(parent), ui(new Ui::AppWindow)
 {
     LOG_INFO(BOOL_INFO_OF(noRestoreSession))
@@ -164,6 +167,8 @@ void AppWindow::finishConstruction()
 {
     if (tabCount() == 0)
         openTab("");
+
+    ui->tabWidget->tabBar()->installEventFilter(this);
 
 #ifdef Q_OS_WIN
     // This is necessary because of setWindowOpacity(0.99) earlier
@@ -1750,4 +1755,26 @@ QVector<MainWindow *> AppWindow::getTabs() const
         }
     }
     return tabs;
+}
+
+bool AppWindow::eventFilter(QObject *obj, QEvent *event) {
+    QTabBar *tabBar = ui->tabWidget->tabBar();
+
+    if (obj != tabBar || event->type() != QEvent::MouseButtonRelease) {
+        return QMainWindow::eventFilter(obj, event);
+    }
+
+    QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+
+    if (mouseEvent->button() != Qt::MiddleButton) {
+        return QMainWindow::eventFilter(obj, event);
+    }
+
+    int index = tabBar->tabAt(mouseEvent->pos());
+    if (index >= 0) {
+        closeTab(index);
+        return true;
+    }
+
+    return QMainWindow::eventFilter(obj, event);
 }

--- a/src/appwindow.hpp
+++ b/src/appwindow.hpp
@@ -84,6 +84,8 @@ class AppWindow : public QMainWindow
     void dragEnterEvent(QDragEnterEvent *event) override;
     void changeEvent(QEvent *event) override;
 
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
   public slots:
     void onReceivedMessage(quint32 instanceId, QByteArray message);
 


### PR DESCRIPTION
## Description
Added an event filter in `AppWindow` to handle `QEvent::MouseButtonRelease` with `Qt::MiddleButton` on the `QTabBar`. This maps the mouse coordinates to the specific tab index and triggers `closeTab(index)`.

## How Has This Been Tested?
Tested locally on Windows (MSYS2 UCRT64) with Qt6.

## Visual Proof / Screenshots
<img width="1920" height="1080" alt="cpeditor_mcXPu0repM" src="https://github.com/user-attachments/assets/94f5cb06-129d-47a6-814c-60cf2039d539" />
Note: As seen in the GIF, tabs are smoothly closed by middle-clicking anywhere on the tab body, without needing to target the 'X' icon.

## Checklist
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
This is my first open-source contribution to CP Editor. Let me know if any further changes are required!