### PR TITLE
feat: add option to toggle ctrl+scroll font scaling (Fixes #1249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+-   Add an option to toggle Ctrl+Scroll font scaling (#1249)
 -   Add vim emulation with [custom commands](https://cpeditor.org/docs/preferences/code-edit/#custom-vim-commands). (#220 and #1270)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Migrate from Qt5 to Qt6 and KF5 to KF6 Syntax Highlighting. (#1449)
 -   Switch macOS release builds to ARM (Apple Silicon). (#1449)
 -   Snap package now uses `core26` base (Ubuntu 26.04), providing Qt 6.8+. (#1489)
+-   Improved snippet search with token-based prefix matching.
 
 ## v7.1
 

--- a/src/Editor/CodeEditor.cpp
+++ b/src/Editor/CodeEditor.cpp
@@ -1399,4 +1399,27 @@ QColor CodeEditor::getTextColor(KSyntaxHighlighting::Theme::TextStyle style)
 {
     return QColor::fromRgba(theme.textColor(style));
 }
+void CodeEditor::wheelEvent(QWheelEvent *e)
+{
+    if (e->modifiers() & Qt::ControlModifier)
+    {
+
+        if (SettingsManager::get("Ctrl Scroll Zoom").toBool())
+        {
+            if (e->angleDelta().y() > 0)
+            {
+                zoomIn(1);
+            }
+            else if (e->angleDelta().y() < 0)
+            {
+                zoomOut(1);
+            }
+        }
+
+        e->accept();
+        return;
+    }
+
+    QPlainTextEdit::wheelEvent(e);
+}
 } // namespace Editor

--- a/src/Editor/CodeEditor.hpp
+++ b/src/Editor/CodeEditor.hpp
@@ -205,6 +205,11 @@ class CodeEditor : public QPlainTextEdit
     void changeEvent(QEvent *e) override;
 
     /**
+     * @brief Method to scale font sizes via mouse wheel zoom.
+     */
+    void wheelEvent(QWheelEvent *e) override;
+
+    /**
      * @brief Method, that's called on any key press, posted
      * into code editor widget. This method is overloaded for:
      *

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -189,7 +189,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
 
     AddPageHelper(this)
         .page(TRKEY("Code Edit"),
-              {"Tab Width", "Cursor Width", "Auto Indent", "Wrap Text", "Auto Complete Parentheses", "Auto Remove Parentheses",
+              {"Tab Width", "Cursor Width", "Auto Indent", "Wrap Text", "Ctrl Scroll Zoom", "Auto Complete Parentheses", "Auto Remove Parentheses",
                "Tab Jump Out Parentheses", "Replace Tabs", "FakeVim/Enable", "FakeVim/RC"})
         .dir(TRKEY("Language"))
             .page(TRKEY("General"), {"Default Language"})
@@ -231,7 +231,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
             .end()
         .end()
         .dir(TRKEY("Appearance"))
-            .page(TRKEY("General"),{"Locale", "UI Style", "Editor Theme", "Opacity", "Test Case Maximum Height",
+            .page(TRKEY("General"),{"Locale", "UI Style", "Editor Theme", "Opacity","Ctrl Scroll Zoom", "Test Case Maximum Height",
                                     "Show Compile And Run Only", "Display EOLN In Diff", "Extra Bottom Margin",
                                     "Error Message Color", "Warn Message Color"})
             .page(TRKEY("Font"), {"Show Only Monospaced Font", "Editor Font", "Test Cases Font", "Message Logger Font",

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -231,7 +231,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
             .end()
         .end()
         .dir(TRKEY("Appearance"))
-            .page(TRKEY("General"),{"Locale", "UI Style", "Editor Theme", "Opacity","Ctrl Scroll Zoom", "Test Case Maximum Height",
+            .page(TRKEY("General"),{"Locale", "UI Style", "Editor Theme", "Opacity", "Test Case Maximum Height",
                                     "Show Compile And Run Only", "Display EOLN In Diff", "Extra Bottom Margin",
                                     "Error Message Color", "Warn Message Color"})
             .page(TRKEY("Font"), {"Show Only Monospaced Font", "Editor Font", "Test Cases Font", "Message Logger Font",

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -438,6 +438,13 @@
     "tip": "Wrap a line into several lines if it doesn't fit into the screen."
   },
   {
+    "name": "Ctrl Scroll Zoom",
+    "desc": "Enable Ctrl+Scroll to change font size",
+    "type": "bool",
+    "default": true,
+    "tip": "Change the editor font size by scrolling the mouse wheel while holding the Ctrl key."
+  },
+  {
     "name": "Beta",
     "desc": "Use the beta version",
     "type": "bool",

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -47,6 +47,7 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QProgressDialog>
+#include <QRegularExpression>
 #include <QShortcut>
 #include <QSplitter>
 #include <QTabBar>
@@ -1320,10 +1321,53 @@ void AppWindow::on_actionUseSnippets_triggered()
             if (*ok)
             {
                 LOG_INFO("Looking for snippet : " << name);
+
+                // Try exact match first
+                QString matchedName;
                 if (names.contains(name))
                 {
+                    matchedName = name;
+                }
+                else
+                {
+                    // Fall back to token-based prefix matching:
+                    // Split snippet names into tokens on common delimiters and check if
+                    // each query token is a prefix of at least one name token.
+                    static const QRegularExpression delim(R"([\s_\-,;:.!?()\[\]{}'"/\\]+)");
+                    auto queryTokens = name.toLower().split(delim, Qt::SkipEmptyParts);
+                    for (const auto &snippetName : names)
+                    {
+                        auto nameTokens = snippetName.toLower().split(delim, Qt::SkipEmptyParts);
+                        bool allMatch = true;
+                        for (const auto &qt : queryTokens)
+                        {
+                            bool found = false;
+                            for (const auto &nt : nameTokens)
+                            {
+                                if (nt.startsWith(qt))
+                                {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (!found)
+                            {
+                                allMatch = false;
+                                break;
+                            }
+                        }
+                        if (allMatch)
+                        {
+                            matchedName = snippetName;
+                            break;
+                        }
+                    }
+                }
+
+                if (!matchedName.isEmpty())
+                {
                     LOG_INFO("Found snippet and inserted");
-                    QString content = SettingsHelper::getLanguageConfig(lang).getSnippet(name);
+                    QString content = SettingsHelper::getLanguageConfig(lang).getSnippet(matchedName);
                     current->insertText(content);
                 }
                 else

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -4,410 +4,465 @@
 <context>
     <name>AppWindow</name>
     <message>
+        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Γρήγορη έξοδος</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>Στην τελευταία έξοδο ο συντάκτης CP έκλεισε απροσδόκητα, θέλετε να επαναφέρεται την προηγούμενη συνεδρίαση;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Εμφάνιση κυρίου παραθύρου</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Άνοιγμα αρχείων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>Σχετικά με το CP συντάκτη %1</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Ο CP συντάκτης&lt;/b&gt; είναι μια εφαρμογή βασισμένη πάνω στο Qt συντάκτη κώδικα. Είναι ειδικά σχεδιασμένο για ανταγωνιστικό προγραμματισμό αντιθέτως με άλλους συντάκτες κώδικα. Ο συντάκτης σας βοηθάει να είστε συγκεντρωμένοι στον αλγοριθμό σας και σας βοηθάει με την αυτοματοποίηση, εκτέλεση και δοκιμή του κώδικα. Μπορεί ακόμα να δοκιμάσει το πρόγραμμα με δοκιμή υποθέσεων από διαφορετικές πλατφόρμες και να στέλνει τις απαντήσεις στο Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Αυτό είναι δωρεάν λογισμικό, δείτε την πηγή για την πνευματική ιδιοκτησία. ΔΕΝ υπάρχει εγγύηση, ούτε για ΕΜΠΟΡΕΥΣΙΜΟΤΗΤΑ ή για ΙΚΑΝΟΤΗΤΑ ΓΙΑ ΣΥΓΚΕΚΡΙΜΕΝΟ ΣΚΟΠΟ. Ο πηγαίος κώδικας του CP κώδικα είναι διαθέσιμος στην ιστοσελίδα &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Ανοίξτε αρχεία</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Επαναφορά προτιμήσεων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>Είστε σίγουροι ότι θέλετε να επαναφέρεται όλες τις προτιμήσεις στης προκαθορισμένες προτιμήσεις;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1316"/>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>απόσπάσματα</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>Δεν υπάρχουν απόσπάσματα για %1. Παρακαλώ προσθέστε απόσπάσματα στο παράθυρο προτιμήσεων.</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Χρησιμοποιήστε απoσπάσματα</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Επιλέξτε ένα απόσπασμα:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>Δεν υπάρχει το απόσπασμα με το όνομα %1 για %2</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Κλείσιμο άλλον</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Κλείστε τα αριστερά</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Κλείστε τα δεξιά</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Αντιγραφή διαδρομής αρχείου</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Αντιγραφή URL προβλήματος</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Προσαρμογή Codeforces URL</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Προσαρμογή CF URL</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Εισάγεται το ID του διαγωνισμού:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Εισάγεται το πρόβλημα του κώδικα (Α-Ω):</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1602"/>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Προσαρμογή πρόβλημα URL</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Εισάγεται το καινούργιο URL του προβλήματος:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Καταγραφέας συμβάτων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Όλες οι καταγραφές εκτός της τωρινής συνεδρίασης έχουν διαγραφεί</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>Συντάκτης CP: Ένας συντάκτης σχεδιασμένος για ανταγωνιστικό προγραμματισμό</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Αποθήκευση ως...</translation>
+        <translation type="vanished">Αποθήκευση ως...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation>Αποθήκευση ως καινούργιο αρχείο</translation>
+        <translation type="vanished">Αποθήκευση ως καινούργιο αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Αποθήκευση όλων</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation>Αποθήκευση όλων τον ανοιχτών αρχείων</translation>
+        <translation type="vanished">Αποθήκευση όλων τον ανοιχτών αρχείων</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation>Κλείσιμο τωρινού</translation>
+        <translation type="vanished">Κλείσιμο τωρινού</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation>Κλείσιμο τωρινής καρτέλας</translation>
+        <translation type="vanished">Κλείσιμο τωρινής καρτέλας</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Κλείσιμο απόθηκευμένων</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation>Κλείσιμο απόθηκευμένων καρτέλων</translation>
+        <translation type="vanished">Κλείσιμο απόθηκευμένων καρτέλων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Κλείσιμο όλων</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation>Κλείσιμο όλων τον καρτέλων</translation>
+        <translation type="vanished">Κλείσιμο όλων τον καρτέλων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation>Έξοδος από την εφαρμογή</translation>
+        <translation type="vanished">Έξοδος από την εφαρμογή</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation>Άνοιγμα αρχείου...</translation>
+        <translation type="vanished">Άνοιγμα αρχείου...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation>Άνοιγμα αρχείων</translation>
+        <translation type="vanished">Άνοιγμα αρχείων</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation>Άνοιγμα διαγωνισμού...</translation>
+        <translation type="vanished">Άνοιγμα διαγωνισμού...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation>Ανοίξτε έναν διαγωνισμό</translation>
+        <translation type="vanished">Ανοίξτε έναν διαγωνισμό</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation>Εσοχή</translation>
+        <translation type="vanished">Εσοχή</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation>Αφαίρεση εσοχής</translation>
+        <translation type="vanished">Αφαίρεση εσοχής</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation>Αλλαγή σειράς πάνω</translation>
+        <translation type="vanished">Αλλαγή σειράς πάνω</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation>Αλλαγή σειράς κάτω</translation>
+        <translation type="vanished">Αλλαγή σειράς κάτω</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation>Αντιγραφή γραμμής</translation>
+        <translation type="vanished">Αντιγραφή γραμμής</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation>Διαγραφή γραμμής</translation>
+        <translation type="vanished">Διαγραφή γραμμής</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation>Μεταβολή σχολίου</translation>
+        <translation type="vanished">Μεταβολή σχολίου</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation>Μεταβολή κομμάτι σχολίου</translation>
+        <translation type="vanished">Μεταβολή κομμάτι σχολίου</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Σύνταξη</translation>
+        <translation type="vanished">Σύνταξη</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Σύνταξη και εκτέλεση</translation>
+        <translation type="vanished">Σύνταξη και εκτέλεση</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Εκτέλεση</translation>
+        <translation type="vanished">Εκτέλεση</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation>Διάταξη κώδικα</translation>
+        <translation type="vanished">Διάταξη κώδικα</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation>Εκτέλεση απόμονωμένου</translation>
+        <translation type="vanished">Εκτέλεση απόμονωμένου</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation>Τερματισμώς διεργασιών</translation>
+        <translation type="vanished">Τερματισμώς διεργασιών</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation>Εύρημα και αντικατάσταση</translation>
+        <translation type="vanished">Εύρημα και αντικατάσταση</translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation>Προτιμήσεις</translation>
+        <translation type="vanished">Προτιμήσεις</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation>Σχετικά με το Qt</translation>
+        <translation type="vanished">Σχετικά με το Qt</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Σχετικά με την κατασκευή</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation>Έλεγχος για ενημέρωσεις</translation>
+        <translation type="vanished">Έλεγχος για ενημέρωσεις</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation>Καινούριο αρχείο</translation>
+        <translation type="vanished">Καινούριο αρχείο</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation>Άνοιγμα νέας καρτέλας στον συντάκτη</translation>
+        <translation type="vanished">Άνοιγμα νέας καρτέλας στον συντάκτη</translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation>Αποθήκευση του αρχείου στον δίσκο</translation>
+        <translation type="vanished">Αποθήκευση του αρχείου στον δίσκο</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation>Χρησιμοποίηση απόσπάσματος...</translation>
+        <translation type="vanished">Χρησιμοποίηση απόσπάσματος...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation>Εξαγωγή ρυθμίσεων...</translation>
+        <translation type="vanished">Εξαγωγή ρυθμίσεων...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation>Εισαγωγή ρυθμίσεων...</translation>
+        <translation type="vanished">Εισαγωγή ρυθμίσεων...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation>Επαναφορά ρυθμίσεων</translation>
+        <translation type="vanished">Επαναφορά ρυθμίσεων</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation>Εγχειρίδιο</translation>
+        <translation type="vanished">Εγχειρίδιο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>Σχετικά</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation>Μοντέλο συντάκτη</translation>
+        <translation type="vanished">Μοντέλο συντάκτη</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation>Μοντέλο Εισόδου / Εξόδου</translation>
+        <translation type="vanished">Μοντέλο Εισόδου / Εξόδου</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation>Μοντέλο διαίρεσης</translation>
+        <translation type="vanished">Μοντέλο διαίρεσης</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation>Εμφάνιση αρχείων συμβάντων</translation>
+        <translation type="vanished">Εμφάνιση αρχείων συμβάντων</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation>Διαγραφή αρχείων συμβάντων</translation>
+        <translation type="vanished">Διαγραφή αρχείων συμβάντων</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Αρχείο</translation>
+        <translation type="vanished">&amp;Αρχείο</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Επεξεργασία</translation>
+        <translation type="vanished">&amp;Επεξεργασία</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation>&amp;Ενέργειες</translation>
+        <translation type="vanished">&amp;Ενέργειες</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation>&amp;Εμφάνιση</translation>
+        <translation type="vanished">&amp;Εμφάνιση</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation>&amp;Επιλογές</translation>
+        <translation type="vanished">&amp;Επιλογές</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Βοήθεια</translation>
+        <translation type="vanished">&amp;Βοήθεια</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Εξαγωγή ρυθμίσεων σε αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Εισαγωγή ρυθμίσεων από αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Εξαγωγή τωρινής συνεδρίασης σε αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Εξαγωγή συνεδρίασης</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Απέτυχε η εξαγωγή της τωρινής συνεδρίασης στο [%1]</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Φόρτωση συνεδρίασης</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Η φόρτωση μιας συνεδρίασης από κάποιο αρχείο θα κλείσει όλες της καρτέλες χωρίς να απόθηκεύση τα αρχεία. Είστε σίγουροι;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Φόρτωση συνεδρίασης από αρχείο</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation>Εξαγωγή συνεδρίασης...</translation>
+        <translation type="vanished">Εξαγωγή συνεδρίασης...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation>Φόρτωση συνεδρίασης...</translation>
+        <translation type="vanished">Φόρτωση συνεδρίασης...</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="779"/>
+        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Αρχείο ρυθμίσεων του συντάκτη CP</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="807"/>
+        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Αρχείο ρυθμίσεων της συνεδρίασης</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation>Αναφορά προβλημάτων</translation>
+        <translation type="vanished">Αναφορά προβλημάτων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Εισαγωγή ρυθμίσεων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Όλες οι ρυθμίσεις θα χαθούνε αφότου εισαχθούνε οι ρυθμίσεις από το αρχείο. Είστε σίγουροι ότι θέλετε να συνεχίσεται;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Αντιγραφή καρτέλας</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -420,197 +475,206 @@ Build time: %4
 Λειτουργικό σύστημα: %5</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Φορητή έκδοση</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Έκδοση εγκατάστασης</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Άνοιγμα προσωρινών αρχείων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>Κανένα αρχείο δεν ανοίχτηκε πρόσφατα</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Καθάρισμα προσωρινών αρχείων</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Πηγαίο αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Εκτελέσιμο αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Άνοιγμα προβλήματος στον φυλλομετρητή</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Προσαρμογή εντολής μεταγλοττιστή</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Ορισμός χρονικού περιθώριου</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation>Πλήρες παράθυρο</translation>
+        <translation type="vanished">Πλήρες παράθυρο</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation>Υποστηριξέ μας</translation>
+        <translation type="vanished">Υποστηριξέ μας</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>Πώς να βγείτε από την πλήρες οθόνη</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>Πατήστε το F11 κουμπί για να βγείτε από πλήρες οθόνη.</translation>
     </message>
     <message>
-        <source>Stress Testing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with generator template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New File From Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C++</source>
-        <translation type="unfinished">C++</translation>
-    </message>
-    <message>
-        <source>Open a new tab with C++ template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="unfinished">Java</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Java template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="unfinished">Python</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Python template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Αναζήτηση...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Εισαγωγή</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Μετανομασία απόσπάσματος</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Φόρτωση απόσπασμάτων από αρχεία</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Εξαγωγή απόσπάσματων σε αρχεία</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Περισσότερα</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Δεν επιλέξατε κάποιο απόσπασμα</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Μη απόθηκευμένα απόσπάσματα</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>Το απόσπασμα [%1] έχει αλλάξει. θέλετε να απόθηκεύσεται τις αλλαγές ή να της απόρρίψετε;</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Διαγραφή απόσπάσματος</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε το απόσπασμα [%1]?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Φόρτωση απόσπασμάτων</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Απέτυχε να ανοίξει [%1]. Μήπως δεν έχετε δικαίωμα ανάγνωσης;</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Εξαγωγή απόσπασμάτων</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Εξαγωγή απόσπασμάτων: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Δεν μπόρεσε να γίνει η εγραφή στο [%1]. Έχετε δικαίωμα εγγραφής;</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>Το όνομα απόσπάσματος δεν μπορεί να είναι άδειο.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Διαμάχη όνομα απόσπασμάτων</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>Το όνομα &quot;%1&quot; είναι ίδη σε χρήση. Θέλετε να το παρακάμψετε; (Το παλιό απόσπασμα με αυτό το όνομα θα διαγραφεί)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>Το όνομα &quot;%1&quot; χρησιμοποιείτε ίδη.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Εισαγωγή απόσπάσματος</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Νέο όνομα απόσπάσματος:</translation>
     </message>
@@ -618,68 +682,93 @@ Build time: %4
 <context>
     <name>Core::Checker</name>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Ελεγκτής ανάγνωσης</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
+        <location filename="../src/Core/Checker.cpp" line="99"/>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
+        <location filename="../src/Core/Checker.cpp" line="301"/>
+        <location filename="../src/Core/Checker.cpp" line="302"/>
+        <location filename="../src/Core/Checker.cpp" line="303"/>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Ελεγκτής</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Απέτυχε να διμιουργηθεί προσωρινός φάκελος</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Ανάγνωση testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Αποθήκευση testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Υπήρξε σφάλμα κατά την σύνταξη του ελέγκτη:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Ελεγκτής[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>Ο ελεγκτής έκλεισε με τον κωδικό%1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>Ο ελεγκτής έκλεισε με άγνωστο κωδικό %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Ξεπεράστηκε το χρονικό περιθώριο (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>Το %1 από τις τρεχόμενες διεργασίες των δοκιμών #%2 περιέχει περισσότερο από %3 χαρακτήρες, που είναι περισσότερο από το όριο εξόδου, οπότε η διεργασία τερματίστηκε. Μπορείτε να αλλάξετε το όριο εξόδου στο %4.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>Ο ελεγκτής σταμάτησε</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Ξεκίνησε η σύνταξη του ελεγκτή</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>Ο ελεγκτής συντάχθηκε</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Απέτυχε να συνταχθή ο ελεκγτής: %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>Ο πηγαίος κώδικας του ελεγκτή άλλαξε, επαναμεταγλώτιση...</translation>
     </message>
@@ -687,18 +776,22 @@ Build time: %4
 <context>
     <name>Core::Compiler</name>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>Το πηγαίο αρχείο [%1] δεν υπάρχει</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Μη υποστηριζόμενη γλώσσα προγραμματισμού &quot;%1&quot;</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>απότυχία να ξεκινήσει ο μεταγλωττιστής. Παρακαλώ ελέξτε το %1 ή εισάγεται την διαδρομή του μεταγλωττιστή στην μεταβλητή του περιβάλλοντος.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 είναι άδειο</translation>
     </message>
@@ -706,32 +799,39 @@ Build time: %4
 <context>
     <name>Core::Runner</name>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>Το πηγαίο αρχείο %1 δεν υπάρχει.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Απέτυχε να διαβαστεί η εντολή run. Μάλλον είναι λογικό πρόβλημα στο λογισμικό.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Απέτυχε να ξεκινήσει. Παρακαλώ τρέξτε το μεταγλωττιστή ξανά.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>Το πρόγραμμα τελειώσε με τον κωδικό %1
 Πατήστε οποιοδήποτε κουμπί για να βγείτε</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Απέτυχε να ξεκινήσει η απόμωνομένη εκτέλεση. Παρακαλώ δείτε τις ρυθμίσεις του εξομοιωτή τερματικό %1.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>Η απόμονωμένη εκτέκεση δεν υποστηρύζεται στην πλατφόρμα σας</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>Απέτυχε η δημιουργία του προσωρινού αρχείου.</translation>
     </message>
@@ -739,10 +839,12 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Επαναφορά τελευταίας συνεδρίας</translation>
     </message>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Επαναφέρεται: [%1]</translation>
     </message>
@@ -750,42 +852,52 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">η `new` δεν δέχεται όρισμα ή πρέπει να είναι ένα από &apos;cpp&apos;, &apos;java&apos; και &apos;python&apos;, ελήφθη [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">το [%1] δεν είναι αρχείο πηγαίου C++, Python ή Java</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">το [%1] δεν υπάρχει. Για να ανοίξετε καρτέλα με ανύπαρκτο αρχείο, χρησιμοποιήστε `open!`</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">το [%1] δεν είναι αριθμός</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">το %1 είναι εκτός εύρους [1, %2]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">Δ/Υ</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">το [%1] δεν είναι έγκυρη λειτουργία προβολής. Πρέπει να είναι &apos;split&apos; ή &apos;edit&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">το %1 δεν είναι έγκυρο όνομα γλώσσας. Πρέπει να είναι &apos;cpp&apos;, &apos;java&apos; ή &apos;python&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">Δεν υπάρχει ενεργή καρτέλα για εκκαθάριση μηνυμάτων</translation>
     </message>
@@ -793,42 +905,63 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF εργαλείο</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>Το CF εργαλείο τερματίστηκε</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>Ο κωδικός του προβλήματος είναι 0, τώρα χρησιμοποιήστε το Α αυτόματα. Αν ο κωδικός προβλήματος δεν είναι το Α, παρακαλώ ορίστε το κώδικα του προβλήματος στο δεξιό κομμάτι του μενού της τρέχουσας καρτέλας.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Απέτυχε να φορτώσουμε την έκδωση του CF εργαλείου. Μήπως δεν βάλατε την διαδρομή του CF εργαλείου στις προτιμήσεις;</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>Το CF εργαλείο ξεκίνησε</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Απέτυχε η εκκίνηση του CF εργαλείου σε 2 δευτερόλεπτα. Έχετε ρυθμίση την διαδρομή του CF εργαλείου στις προτιμήσεις;</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Απέτυχε η ανάλυση του URL [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>Το CF εργαλείο απέτυχε</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>Το CF εργαλείο έκλεισε με μη μηδενικό κωδικό %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Διαγωνισμός %1 πρόβλημα %2</translation>
     </message>
@@ -836,34 +969,50 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Μορφοποιητής</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Απέτυχε η δημιουργία προσωρινού φακέλου</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Τελείωσε η μορφοποίηση</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Μορφοποιητής[stdout]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Μορφοποιητής[stderr]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>Η εντολή μορφοποίησης [%1 %2] τελείωσε με τον κωδικό %3.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>Η διεργασία μορφοποίησης δεν τελείωσε σε 2 δευτερόλεπτα. Αυτό μάλλον είναι γιατί το %1 πρόγραμμα δεν βρέθηκε από το CP συντάκτη. Μπορείτε να ρυθμίσετε την διαδρομή του προγράμματος στο %2.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>Η έξοδος της μορφοποίησης της διεργασίας είναι άδεια. Παρακαλώ δείτε αν υπάρχει όχι στην μετατροπή στις ρυθμίσεις σχετικά με την μορφοποίηση.</translation>
     </message>
@@ -871,32 +1020,39 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>Ο server είναι κλειστός</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>Η θύρα είναι ρυθμισμένει στην %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Υπήρξε σφάλμα με την ανάγνωση στην θύρα %1. Μήπως κάποια άλλη διεργασία χρησιμοποιεί την θύρα;</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Σταμάτησε ο server</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>Ο JSON αναλυτής ανέφερε προβλήματα:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>Η αίτηση που παραλήφθηκε δεν είναι σε μορφή JSON</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>Η %1 αίτηση λήφθηκε και αγνοήθηκε</translation>
     </message>
@@ -904,30 +1060,42 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Server γλώσσας [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Ο server γλώσσας έστειλε ένα σφάλμα. Παρακαλώ δείτε τους καταλόγους για λεπτομέριες.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Απέτυχε η εκκίνηση της LSP διεργασίας. Εισάγατε την διαδρομή του server γλώσσας στο %1;</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Η διεργασία LSP ξεπέρασε το χρονικό περιθώριο</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Η LSP διεργασία έχει πρόβλημα εισόδου / εξόδου</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Η LSP διεργασία έχει πρόβλημα εγγραφής</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Ένα άγνωστο σφάλμα συνέβη στην διεργασία του LSP</translation>
     </message>
@@ -936,50 +1104,50 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation>Εύρημα / Αντικατάσταση</translation>
+        <translation type="vanished">Εύρημα / Αντικατάσταση</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation>Φόρμα</translation>
+        <translation type="vanished">Φόρμα</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation>Εύρημα:</translation>
+        <translation type="vanished">Εύρημα:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation>Αντικατάσταση με:</translation>
+        <translation type="vanished">Αντικατάσταση με:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation>errorLabel</translation>
+        <translation type="vanished">errorLabel</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation>Κατεύθηνση</translation>
+        <translation type="vanished">Κατεύθηνση</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation>Πάνω</translation>
+        <translation type="vanished">Πάνω</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation>Κάτω</translation>
+        <translation type="vanished">Κάτω</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Επιλογές</translation>
+        <translation type="vanished">Επιλογές</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation>Διάκρηση πεζών / κεφαλαίων</translation>
+        <translation type="vanished">Διάκρηση πεζών / κεφαλαίων</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation>Ολόκληρες λέξεις μόνο</translation>
+        <translation type="vanished">Ολόκληρες λέξεις μόνο</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -990,7 +1158,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1001,52 +1169,74 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation>Κοινή έκφραση</translation>
+        <translation type="vanished">Κοινή έκφραση</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation>Εύρημα</translation>
+        <translation type="vanished">Εύρημα</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation>Αντικατάσταση</translation>
+        <translation type="vanished">Αντικατάσταση</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation>Αντικατάσταση όλων</translation>
+        <translation type="vanished">Αντικατάσταση όλων</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../src/mainwindow.cpp" line="185"/>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Μεταγλωττιστής</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Παρακαλώ ορίστε την γλώσσα</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="218"/>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="242"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1492"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Δρομέας</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Λάθος γλώσσα, παρακαλώ εισάγεται την γλώσσα</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Όλοι οι είσοδοι είναι άδειοι, δεν υπάρχει τίποτα να εκτελεστή</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Παράδοση</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Είστε σίγουροι ότι θέλετε να το παραδώσετε</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1057,78 +1247,101 @@ p, li { white-space: pre-wrap; }
  Γλώσσα: %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="328"/>
+        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF εργαλείο</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Υπήρξε σφάλμα κατά την αποθήκευση του προσωρινού αρχείου, η απάντηση δεν παραδόθηκε.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Χωρίς τίτλο-%1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Αποθήκευση ως</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Άνοιγμα προτύπου %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1017"/>
+        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>Το αρχείο [%1] περιέχει περισσότερο από %2 χαρακτήρες, οπότε δεν ανοίχτηκε. Μπορείτε να αλλάξετε το όριο του μήκους του αρχείου στο %3.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Αποθήκευση αρχείου</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
+        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Προσωρινό αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Απέτυχε η δημιουργία του προσωρινού φακέλου</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Διαβάστε το πρότυπο %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Αποθήκευση αλλαγών</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>Αποθήκευση αλλαγών στο [%1] πρίν το κλείσιμο;</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Νέο αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Ορίστε γλώσσα στην καρτέλα</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Ορίστε την γλώσσα που θα χρησιμοποιείται στην τρέχουσα καρτέλα</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Επαναφόρτωση</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1139,150 +1352,180 @@ Do you want to reload it?</source>
 Είστε σίγουροι ότι θέλετε να το φορτώσετε πάλι;</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Γραμμή %1, στήλη %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>%1 γραμμές, %2 χαρακτήρες επιλέχθηκαν</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>%1 χαρακτήρες επιλέχθηκαν</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>Η μεταγλώττιση ξεκίνησε</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>Η μεταγλώττιση τελείωσε</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Προειδοποιήσεις μεταγλώττισης</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Υπήρξαν σφάλματα κατά την μεταγλώττιση</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1517"/>
+        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Σφάλματα μεταγλώττισης</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>Η μεταγλώττιση τερματίστηκε</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>απόσπασμένος δρομέας</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Δρομέας [%1]</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>Η εκτέλεση ξεκίνησε</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>Η εκτέλεση για τις δοκιμές #%1 τελείωσε σε %2ms</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>Η εκτέλεση για την δοκιμή #%1 τελείωσε με μη μηδενικό κωδικό %2 σε %3ms</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Ξεπεράστηκε το χρονικό περιθώριο (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>Η %1 από τις εκτελούμενες διεργασίες στην δοκιμή #%2 περιέχει περισσότερο από %3 χαρακτήρες, που είναι περισσότερο από το όριο εξόδου, οπότε η διεργασία τερματίστηκε. Μπορείτε να αλλάξετε το όριο στο %4.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 τερματίστηκε</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>απόσπασμένος δρομέας</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Δρομέας για την δοκιμή #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation>CP συντάκτης</translation>
+        <translation type="vanished">CP συντάκτης</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation>Πληροφορίες κέρσορα</translation>
+        <translation type="vanished">Πληροφορίες κέρσορα</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Μεταγλώττιση</translation>
+        <translation type="vanished">Μεταγλώττιση</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Εκτέλεση</translation>
+        <translation type="vanished">Εκτέλεση</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Μεταγλώττιση και εκτέλεση</translation>
+        <translation type="vanished">Μεταγλώττιση και εκτέλεση</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation>Μυνύματα</translation>
+        <translation type="vanished">Μυνύματα</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Καθαρισμός</translation>
+        <translation type="vanished">Καθαρισμός</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation>C++</translation>
+        <translation type="vanished">C++</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Αυτόματη αποθήκευση</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>Έχετε ορίσει ένα δεκτό όνομα για την κύρια κλάσση μέσα στην λύση σας; Αν όχι, ορίστε την στο %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Άγνωστο χαρακτηριστικό: [%1]. Παρακαλώ δείτε τα σχόλια των ρυθμίσεων στο  %2.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Ορίστε εντολή μεταγλωττιστή</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Προσαρμοσμένη εντολή μεταγλωττιστή για αυτήν την καρτέλα:</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Ορισμός χρονικού περιθωρίου</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Προσαρμοσμένο χρονικό περιθώριο για αυτήν την καρτέλα: (ms)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Πρέπει να εγκαταστήσετε το εργαλείο CF για να παραδώσετε τον κωδικό σας στο Codeforces. Αν το έχετε ήδη κάνει, εισάγεται το στην μεταβλητή περιβάλλοντος ή ελέγξτε τις ρυθμίσεις σας στο %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Απέτυχε να ξεκινήσει η μεταγλώττιση: %1</translation>
     </message>
@@ -1290,6 +1533,7 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
+        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1299,34 +1543,42 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 Παρενθέσεις</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Εισαγωγή</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Δεν επιλέχθηκε παρένθεση</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Νέα παρένθεση</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Εισάγετε μια παρένθεση (π.χ. {}):</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Διαγραφή παρένθεσης</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε την παρένθεση %1;</translation>
     </message>
@@ -1334,24 +1586,29 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Παρένθεση: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Επιτρέψτε %1 για %2 στο %3.
 Αν είναι εν μέρει επιλεγμένο, η παγκόσμια ρύθμιση στην επεξεργασία κώδικα θα χρησιμοποιηθεί.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Αυτόματη συμπλήρωση</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Αυτόματη διαγραφή</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Tab Jump Out</translation>
     </message>
@@ -1359,18 +1616,25 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="41"/>
+        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Επιλέξτε αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Εκτελέσιμα αρχεία</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="84"/>
+        <location filename="../src/Settings/PathItem.cpp" line="86"/>
+        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Επιλέξτε %1 πηγαίο κωδικα</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Επιλέξτε εκτελέσιμο αρχείο</translation>
     </message>
@@ -1378,34 +1642,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>Καλωσήρθατε στο συντάκτη CP! Ας ξεκινήσουμε.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Ρυθμίσεις συντάκτη κώδικα</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Εντολές μεταγλώττισης και εκτέλεσης С++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Εντολές μεταγλώττισης και εκτέλεσης Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Εντολές εκτέλεσης Python</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>Μπορείτε να διαβάσετε την &lt;a href=&quot;%1&quot;&gt;τεκμηρίωση&lt;/a&gt; ή να διαβάσετε τις ρυθμίσεις για περισσότερες πληροφορίες.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Ρυθμίσεις εμφάνισης</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Ρυθμίσεις γραμματοσειρά</translation>
     </message>
@@ -1413,34 +1685,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>Προκαθορισμένο</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Επαναφόρτωση</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Εφαρμογή</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Επαναφορά των προκαθορισμένων ρυθμίσεων στην τωρινή σελίδα. (Ctrl+D)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Διαγράψτε τις αλλαγές στην τορινή σελίδα. (Ctrl+R)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Αποθήκευση αλλαγών στην τωρινή σελίδα. (Ctrl+S)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Μη απόθηκευμένες αλλαγές</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>Η ρυθμίσεις έχουν αλλάξει. Θέλετε να απόθηκεύσετε τις αλλαγές ή να τις διαγράψετε;</translation>
     </message>
@@ -1448,239 +1728,280 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
+        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Προτιμήσεις</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Αναζήτηση...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Σπίτι</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Πήγαινε στην αρχική σελίδα</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation>Σύνταξη κώδικα</translation>
+        <translation type="vanished">Σύνταξη κώδικα</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation>Γλώσσα</translation>
+        <translation type="vanished">Γλώσσα</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Γενικά</translation>
+        <translation type="vanished">Γενικά</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation>Εμφάνιση</translation>
+        <translation type="vanished">Εμφάνιση</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation>Ενέργειες</translation>
+        <translation type="vanished">Ενέργειες</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Αποθήκευση</translation>
+        <translation type="vanished">Αποθήκευση</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation>Δέσμευση αρχείου και προβλήματος</translation>
+        <translation type="vanished">Δέσμευση αρχείου και προβλήματος</translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation>Επεκτάσεις</translation>
+        <translation type="vanished">Επεκτάσεις</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation>Clang Format</translation>
+        <translation type="vanished">Clang Format</translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation>Γλώσσα Server</translation>
+        <translation type="vanished">Γλώσσα Server</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 Εντολές</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 Πρότυπο</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 απόσπάσματα</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 Παρενθέσεις</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>%1 Server</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation>Competitive Companion</translation>
+        <translation type="vanished">Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation>CF εργαλείο</translation>
+        <translation type="vanished">CF εργαλείο</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation>Διαδρομή αρχείου</translation>
+        <translation type="vanished">Διαδρομή αρχείου</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation>Δοκιμές</translation>
+        <translation type="vanished">Δοκιμές</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation>URL προβλήματος</translation>
+        <translation type="vanished">URL προβλήματος</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation>Δέσμευση πλήκτρων</translation>
+        <translation type="vanished">Δέσμευση πλήκτρων</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation>Προχωρημένα</translation>
+        <translation type="vanished">Προχωρημένα</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation>Ενημέρωση</translation>
+        <translation type="vanished">Ενημέρωση</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation>Όρια</translation>
+        <translation type="vanished">Όρια</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation>Αυτόματη αποθήκευση</translation>
+        <translation type="vanished">Αυτόματη αποθήκευση</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation>Αποθήκευση συνεδρίασης</translation>
+        <translation type="vanished">Αποθήκευση συνεδρίασης</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation>Πληρεξούσιο δικτύου</translation>
+        <translation type="vanished">Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation>Προκαθορισμένη διαδρομή</translation>
+        <translation type="vanished">Προκαθορισμένη διαδρομή</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation>Φόρτωση αλλαγών εξωτερικών αρχείων</translation>
+        <translation type="vanished">Φόρτωση αλλαγών εξωτερικών αρχείων</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation>απόσπώμενη εκτέλεση</translation>
+        <translation type="vanished">απόσπώμενη εκτέλεση</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation>Γραμματοσειρά</translation>
+        <translation type="vanished">Γραμματοσειρά</translation>
     </message>
     <message>
         <source>YAPF</source>
-        <translation>YAPF</translation>
+        <translation type="vanished">YAPF</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation>Μορφοποίηση κώδικα</translation>
+        <translation type="vanished">Μορφοποίηση κώδικα</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation>Δοκιμές</translation>
+        <translation type="vanished">Δοκιμές</translation>
     </message>
     <message>
         <source>WakaTime</source>
-        <translation>WakaTime</translation>
-    </message>
-    <message>
-        <source>Stopwatch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Stress Testing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator Template</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">WakaTime</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Πλάτος καρτέλας</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>Το πλάτος των χαρακτήρων σε καρτέλες ή ο αριθμός τον κενών σε μια εσοχή</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>Πλάτος κέρσορα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>Το πλάτος του κέρσορα σε εικονοκύτταρα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Γραμματοσειρά συντάκτη</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>Η γραμματοσειρά του συντάκτη κώδικα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Προκαθορισμένη γλώσσα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>Η προκαθορισμένη γλώσσα που θα χρησιμοποιείται όταν ανοίγουν νέες καρτέλες</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Διαδρομή</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Η διαδρομή του αρχείου μορφοποίησης Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Το στύλ μορφοποίησης Clang, έχει συνήθως την επέκταση.clang-format.
 Μπορείτε να μάθετε για την μορφοποίηση Clang εδώ &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>Το πρότυπο που θα χρησιμοποιηθεί όταν δημιουργείται αρχεία τύπου C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -1689,52 +2010,71 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 Ο κέρσορας θα είναι στο τέλος του προτύπου αν δεν υπάρχει καμια αναφορά στο regex.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Ανεξάρτητα αν το αντιστάθμισμα είναι σχετικό με την αρχή του regex ή το τέλος του regex.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>Το αντιστάθμισμα είναι σχετικό με τον αριθμό των χαρακτήρων στο regex, συμπεριλαμβάνονται και οι κενοί χαρακτήρες.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>Η εντολή που χρησιμοποιείται για την μεταγλώττιση της C ++. ΔΕΝ πρέπει να περιλαμβάνει την διαδρομή του πηγαίου αρχείου ή την παράμετρο &quot;-o &lt;output file&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Οι παράμετροι όταν εκτελείται ένα πρόγραμμα C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>Το πρότυπο που θα χρησιμοποιείτε με της δημιουργία ενός αρχείου Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>Η εντολή που θα χρησιμοποιείτε όταν μεταγλωττίζεται ένα αρχείο Java.
 ΔΕΝ πρέπει να περιέχει την διαδρομή του πηγαίου αρχείου ή την διαδρομή του μεταγγλωτισμένου αρχείου κλάσης.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Οι παράμετροι όταν εκτελείται ένα πρόγραμμα Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>Η εντολή εκκίνησης του προγράμματος Java. ΔΕΝ πρέπει να περιέχει &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 Εντολή εκτέλεσης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 Όνομα κλάσης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 Διαδρομή κλάσης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -1747,68 +2087,84 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; ή &quot;${tempdir}&quot; για την απόλυτη διαδρομή του προσωρινού φακέλου.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>Το πρότυπο που θα χρησιμοποιηθεί με την δημιουργία ενός καινούργιου αρχείου Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Οι παράμετροι που θα χρησιμοποιηθούν στην εκτέλεση του Python προγράμματος</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>Η εντολή εκκίνησης του προγράμματος Python. ΔΕΝ πρέπει να περιέχει την διαδρομή του πηγαίου προγράμματος.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Θέμα συντάκτη</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>Θέμα ανάδειξεις σύνταξης του συντάκτη κώδικα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Αυτόματη ολοκλήρωση παρενθέσεων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Αυτόματη αφαίρεση παρενθέσεων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Αυτόματη εσοχή</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Εισαγωγή εσοχής όταν δημιουργείται νέα γραμμή μετά από τον χαρακτήρα &quot;{&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Επιτροπή αυτόματης αποθήκευσης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Αναδίπλωση κειμένου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Αναδήπλωση γραμμής σε αρκετές γραμμές αν δεν χωράνε στην οθόνη.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Χρησιμοποιείστε την beta έκδοση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Ελέγξτε για pre release ενημερώσεις. ΠΡΟΣΟΧΗ, αυτές οι εκδόσεις είναι ασταθείς αλλά έχουν περισσότερα χαρακτηριστικά.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Τα ζευγάρια τακτικών εκφράσεων χρησιμοποιούνται όταν προστίθενται ζευγάρια δοκιμών από αρχεία.
 Κάθε ζευγάρι τακτικής έκφρασης αναπαριστά μια δοκιμή.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -1816,34 +2172,76 @@ This can be overridden for each parenthesis in each language.</source>
 Αυτό μπορεί να αλλάξει για κάθε παράγραφο σε κάθε γλώσσα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 Διαδρομή προτύπου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>%1 Πρότυπο τοποθεσίας κέρσορα regex</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>%1 Πρότυπο τύπο αντισταθμίσματος τοποθεσίας κέρσορα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>%1 Πρότυπο αντισταθμίσματος τοποθεσίας κέρσορα χαρακτήρων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 Εντολή μεταγλώττισης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 Διαδρομή εκτελέσιμου αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -1858,14 +2256,19 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; ή &quot;${tempdir}&quot; για την απόλυτη διαδρομή του προσωρινού φακέλου.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 Παράμετροι εκτέλεσης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>Το όνομα της κύριας κλάσης για την λύση σας.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -1873,10 +2276,12 @@ This can be overridden for each parenthesis in each language.</source>
 Αυτό μπορεί να παρακαμψεί κάθε παρένθεση σε κάθε γλώσσα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Βγείτε από ένα ζευγάρι παρενθέσεων πατώντας Tab</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -1884,242 +2289,325 @@ This can be overridden for each parenthesis in each language.</source>
 Αυτό μπορεί να παρακαμπμφθεί για κάθε παρένθεση για κάθε γλώσσα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Enable Ctrl+Scroll to change font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Χρησιμοποιήσει κενών εκτός από τον χαρακτήρα Tab.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Αντικατάσταση Tabs με κενά</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Αποθήκευση δοκιμών κατά την αποθήκευση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Αποθήκευση τον δοκιμών στον δίσκο όταν απόθηκεύεται κάποιο αρχείο, και φώρτοση τον παλιών δοκιμών όταν ανοίξει κάποιο αρχείο.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Έλεγχος για ενημερώσεις κατά την εκκίνηση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Έλεγχος αν υπάρχει νέα έκδοση του CP συντάκτη κατα την εκκίνηση.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Αδιαφάνεια</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>Η αδιαφάνεια του κυρίου παραθύρου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Enable Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Λήψει δεδομένων που απόστάλθηκαν από το Competitive Companion και φόρτωση τον δοκιμών.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Θύρα σύνδεσης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>Η θύρα που χρησιμοποιείται για λήψει δεδομένων από το Competitive Companion σας</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Άνοιγμα νέων καρτελών</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Άνοιγμα νέας καρτέλας για κάθε πρόβλημα του Competitive Companion σας.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Μορφοποίηση κωδικών</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Τερματισμός κάθε διεργασίας</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Μεταγλώττιση και εκτέλεση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Εκτέλεση μόνο</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Μεταγλώττιση μόνο</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Αλλαγή λειτουργία προβολής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Χρησιμοποίηση απόσπάσματος</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>Η διαδρομή του εκτελέσιμου CF εργαλείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Δείξε το &quot;Μεταγλώττιση και εκτέλεση&quot; μόνο</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Κρύψε το &quot;Μεταγλώττιση μόνο&quot; κουμπί και το &quot;Εκτέλεση μόνο&quot; κάτω από τον συντάκτη κώδικα στο κύριο παράθυρο.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Δείξε το EOLN στο Diff</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Χρησιμοποιήστε το χαρακτήρα &quot;¶&quot; για να αναφέρεται το \n χαρακτήρα μέσα στο HTML Diff Viewer.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Αποθήκευση αρχείων γρηγορότερα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Πάντα χρησιμοποίησε το QFile αντί του QSaveFile για αποθήκευση αρχείων.
 Αυτό θα είναι πιο γρήγορο για την αποθήκευση αρχείων αλλά υπάρχει μια πιθανότητα να χαθεί το αρχείο (η πιθανότητα είναι πολύ μικρή).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Όριο μήκους εξόδου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>Ο μέγιστος αριθμός χαρακτήρων για την έξοδο του προγράμματος.
 Το πρόγραμμα θα τερματιστή αν το stdout ή το stderr είναι πολύ μεγάλο.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Όριο μήκους μυνύματος</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>Ο μέγιστος αριθμός χαρακτήρων σε κάθε μύνυμα είναι στο πάνω δεξιά κομμάτι του κύριου παραθύρου.
 Το μύνημα θα εξαφανιστεί αν είναι πολύ μεγάλο.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>HTML Diff Viewer όριο μήκους</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>Ο μέγιστος αριθμός των χαρακτήρων μέσα στο HTML Diff Viewer.
 Το Diff Viewer θα χρησιμοποιήσει την κανονική γραμματοσειρά αν η έξοδος είναι πολύ μεγάλη.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Όριο μήκους άνοιγμα αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>Ο μέγιστος αριθμός χαρακτήρων του πηγαίου αρχείου που θα ανοιχθεί.
 Το πηγαίο αρχείο δεν θα ανεχθεί αν είναι πολύ μεγάλο.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Διαδρομή στο εκτελέσιμο LSP</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>Η διαδρομή στο C++ Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Η διαδρομή στο Java Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Η διαδρομή στο Python Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Χρησιμοποίησε Linting με το Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Εμφάνιση σφάλματος, προειδοποιήσεις και υποδείξεις στο συντάκτη κώδικα για την γλώσσα C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Εμφάνιση σφάλματος, προειδοποιήσεις και υποδείξεις στο συντάκτη κώδικα για την γλώσσα Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Εμφάνιση σφάλματος, προειδοποιήσεις και υποδείξεις στο συντάκτη κώδικα για την γλώσσα Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Χρησιμοποίησε αυτόματη ολοκλήρωση με το Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Χρησιμοποίησε τις απαντήσεις αυτόματης ολοκλήρωσης του Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Καθυστέρηση Linting σε ms</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Καθυστέρηση Linting σε ms μετά από την τελευταόα αλλαγή στον κώδικα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Παράμετροι για τον Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Παράμετροι που θα περάσουν στον Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Δοκιμές για τους κανόνες αντιστοίχισης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Είσοδος Regex</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>Η κοινή έκφραση που θα αντιστοιχηθούν σε όλη την είσοδο στο όνομα αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Απάντηση-Αντικατάσταση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Η έκφραση αντικατάστασης για την απάντηση του ονόματος αρχείου .
 Μπορείτε να χρησιμοποιήσετε &quot;\1&quot; για την πρώτη ομάδα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Είσοδος διαδρομής αποθήκευσης αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2134,10 +2622,12 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${0-index}&quot; Για τον δείκτη της δοκιμής που αρχίζει από το 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Απάντηση διαδρομής αποθήκευσης αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2152,138 +2642,171 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${0-index}&quot; Για τον δείκτη της δοκιμής που αρχίζει από το 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Προκαθορισμένες διαδρομές αρχείων για τα URLs των προβλημάτων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>Η προκαθορισμένη διαδρομή που θα απόθηκεύονται νέα αρχεία όσο υπάρχει το URL του προβλήματος</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL προβλήματος</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>Η κοινή έκφραση που θα αντιστοιχίσει το κομμάτι του URL προβλήματος</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Διαδρομή αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Η έκφραση αντικατάστασης για την διαδρομή αρχείου, χωρίς την επέκταση αρχείου.
 Μπορείτε να χρησιμοποιήσετε το &quot;\1&quot; για την πρώτη ομάδα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Γραμματοσειρά δοκιμών</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>Η γραμματοσειρά των δοκιμών</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Εισάγεται ένα περιθώριο στο κάτω μέρος του συντάκτη κώδικα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Εισάγεται περιθώριο με το ύψος της σελίδας στο κάτω κομμάτι του συντάκτη κώδικα.
 Λόγο ενός τεχνικού προβλήματος, η αλλαγή του περιθωρίου θα επηρεάσει την ιστορίας αναίρεσης.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Γραμματοσειρά καταγραφέας μηνυμάτων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>Η γραμματοσειρά του καταγραφέα μηνυματών</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Αποθήκευση αρχείου μετά την μεταγλώττιση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Αποθήκευση πηγαίου αρχείου κατα την μεταγλώττιση του. Το αρχείο δεν θα απόθηκευτή αν η καρτέλα δεν έχει όνομα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Αποθήκευση αρχείου μετά την εκτέλεση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Αποθήκευση του πηγαίου αρχείου κατά την εκτέλεση του. Δεν θα απόθηκευτή αν η καρτέλα δεν έχει όνομα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Επαναφορά του URL του προβλήματος όταν ανοίξει το αρχείο</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Αν το URL του προβλήματος έχει ρυθμιστεί σε ένα αρχείο, όταν ανοίξεται αυτο το αρχείο ξανά,
 το URL του προβλήματος θα επαναφορτωθεί.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Αν το URL του προβλήματος έχει ρυθμιστεί σε ένα αρχείο, όταν αναλύεται το πρόβλημα
 από ένα Competitive Companion πάλι, το παλιό αρχείο θα ανοιχθεί.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Άνοιτε το παλιό αρχείο όταν αναλύεται το παλιό URL πρόβλημα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>UI γλώσσα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>Η γλώσσα που εμφανίζεται στο UI.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>UI στύλ</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>Το στύλ της εφαρμογής.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Εκτελέστε τους κώδικες σας σε άδειες δοκιμές</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Εκτελέστε των κώδικα σε όλες τις κρυφές δοκιμές ακόμα και αν οι είσοδοι είναι άδειοι.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Ελέγξτε την απάντηση σας στις δοκιμές με άδειες εισόδους</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Ελέγξτε την απάντηση σας αν η έξοδος ή αν η αναμενόμενη έξοδο σας είναι άδεια.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Διάστημα αυτόματης αποθήκευσης (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>Το χρονικό διάστημα ανάμεσα σε μια τροποποίηση και σε αυτόματη αποθήκευση, ή ανάμεσα σε δύο αυτόματες απόθηκεύσης.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Τύπο αυτόματου διάστημα αποθήκευσης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2292,20 +2815,24 @@ Without modification: auto-save happens with a constant interval no matter there
 Χωρίς τροποποίηση μια αυτόματη αποθήκευση με σταθερό διάστημα ανεξαρτήτως αν υπάρχει τροποποίηση ή όχι.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Επαναφορά της τελευταίας συνεδρίασης κατά την εκκίνηση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Επαναφορά της τελευταίας συνεδρίασης κατά την εκκίνηση της εφαρμογής.
 Όταν αυτό είναι ενεργοποιημένο δεν θα σας ρωτάμε αν υπάρχουν αλλαγές που δεν έχουνε απόθηκευτεί.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Αυτόματη αποθήκευση τις τορινής συνεδρίασης περιοδικά</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2314,90 +2841,114 @@ kill the application with SIGKILL which could not be handled by the application.
 να κλείσετε την εφαρμογή.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Αυτόματη αποθήκευση συνεδρίασης περιοδικά</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>Το χρονικό διάστημα ανάμεσα σε δύο αυτόματες απόθηκεύσης της τορινής συνεδρίασης.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Μέγιστο ύψος δοκιμών</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>Το μέγιστο ύψος μιας δοκιμής χωρίς την γραμμή κύλισης σε εικονοστοιχεία.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Το πληρεξούσιο όνομα κεντρικού υπολογιστή π.χ. 127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Η θύρα του πληρεξούσιο π.χ. 1080</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Ο χρήστης του πληρεξούσιο server μπορεί να είναι άδειο αν ο πληρεξούσιος server δεν χεριάζεται αυθεντικοποίηση.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Ο κωδικός του πληρεξούσιο server μπορεί να είναι άδειο αν ο πληρεξούσιος server δεν χεριάζεται αυθεντικοποίηση.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Τύπος</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Όνομα κεντρικού υπολογιστή</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Θύρα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Χρήστης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Κωδικός</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Ο τύπος του πληρεξούσιου.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Χρησιμοποιήστε προσαρμοσμένη γραμματοσειρά για την εφαρμογή</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Χρησιμοποιήστε μια προσαρμοσμένη γραμματοσειρά για ολόκληρη την εφαρμογή αντιθέτος από την προκαθορισμένη γραμματοσειρά του συστηματός σας.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Εφαρμογή προσαρμοσμένης γραμματοσειράς</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>Η προσαρμοσμένη γραμματοσειρά ολόκληρης της εφαρμογής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 Έξοδος μεταγλωττιστή Codec</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Codec κειμένου για την έξοδο του μεταγλωττιστή (προβλήματα, προειδοποιήσεις κ.λ.π.)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Προκαθορισμένη διαδρομή για ονόματα και διαδρομές</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2406,98 +2957,185 @@ They can be either manually set or automatically changed after choosing a path f
 Μπορούν να οριστούν χειροκίνητα ή αυτόματα αφότου οριστεί μια διαδρομή για μια δράση.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Όνομα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>Το όνομα της προκαθορισμένης διαδρομής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>Η διαδρομή της προκαθορισμένης διαδρομής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>Η προκαθορισμένη διαδρομή χρησιμοποιείται όταν επιλέγεται μια διαδρομή για %1.
 Μπορείτε να χρησιμοποιήσετε ${&lt;default path name&gt;}.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Η προκαθορισμένες διαδρομές άλλαξαν αφότου διαλέξατε την διαδρομή %1.
 Είναι μια λίστα του &lt;default path name&gt;, χωρισμένο από κόμματα (επίσης, η λίστα μπορει να είναι άδεια).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Αποθήκευση αρχείου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Ανοιχτός διαγωνισμός</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Άνοιγμα αρχείου μιας δοκιμής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Εισάγεται ζευγάρια από δοκιμές</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Προσαρμοσμένος ελεγκτής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Εξαγωγή και εισαγωγή ρυθμίσεων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Εξαγωγή και φόρτωση συνεδρίασης</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Εξαγωγή και φόρτωση απόσπασμάτον</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Προκαθορισμένη διαδρομή που χρησιμοποιείται για %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Προκαθορισμένες διαδρομές άλλαξαν από %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Μπορεί να παρακαμπτεί από %1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Μορφοποίηση κώδικα από μη αυτόματη αποθήκευση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Μορφοποίηση κώδικα στην αυτόματη αποθήκευση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Αυτόματη φόρτωση εξωτερικών αλλαγμένων αρχείων αν δεν υπάρχουνε μη απόθηκευμένες τροποποίηση</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Αυτόματη φόρτωση τροποποιημένων αρχείων που δεν τροποποιήθηκαν στον συντάκτη CP αν δεν υπάρχουνε μη απόθηκευμένες τροποποιήσης στην συντάκτη CP.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Να φορτώσουμε τα τροποποιημένα εξωτερικά αρχεία</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -2508,32 +3146,39 @@ If this is disabled, external file changes will be ignored unless they are loade
 &quot;%1&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Όριο εξόδου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>Ο μέγιστος αριθμός των χαρακτήρων που μπορεί να εμφανίσει το πρόγραμμα.
 Αν η έξοδος είναι πολύ μεγάλη, τότε η έξοδος θα εξαφανιστεί.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Εμφάνιση μηνύματος για ετυμηγορίες υποβολής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Εμφάνιση μηνύματος όταν η ετυμηγορία της υποβολής είναι γνωστής. Μπορείτε να δείτε αυτό το μύνημα έξω από τον συνακτη CP.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Παράμετροι τερματικού</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Πρόγραμμα τερματικού</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -2542,6 +3187,7 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 Κάποιες πιθανές τιμές είναι konsole, gnome-terminal, xfce-terminal, xterm ή οποιοσδήποτε προσομοιωτής τερματικού.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -2550,10 +3196,15 @@ Consult your terminal emulator for the suitable arguments.</source>
 Ψάξτε τις κατάλληλες εντολές για το τερματικό σας.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Αποθήκευση δοκιμών σε ένα αρχείο</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2564,10 +3215,12 @@ ${time}: ο χρόνος όταν αναλύεται το πρόβλημα
 ${json.X.Y}: αν η παράμετρος είναι από το Competitive Companion σας, μπορείτε να διαβάσετε παραπάνω στο https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Μορφοποίηση χρόνου για τα πάνω σχόλια</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2578,281 +3231,368 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Προσθέστε &quot;Powered By CP Editor&quot; στα πάνω σχόλια</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Προσθέστε την γραμμή &quot;Powered By CP Editor&quot; στα πάνω σχόλια
 Αυτό δεν σασ κοστίζει τίποτα, αλλα βοηθάει άτομα να μάθουν τον συντάκτη CP.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Προκαθορισμένο χρονικό περιθώριο (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>Το προκαθορισμένο χρονικό περιθώριο κατα την εκτέλεση του προγράμματος.
 Το πρόγραμμα θα τερματιστεί αν δεν τερματιστεί μέσα στο χρονικό περιθώριο.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Χρησιμοποιήστε το χρονικό περιθώριο του Competitive Companion σας</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Χρησιμοποιήστε το χρονικό περιθώριο που αναλύθηκε από το Competitive Companion για το χρονικό περιθώριο την αντιστηχη καρτέλα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Εμφανίστε μόνο την Monospaced γραμματοσειρά</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Αλλαγή τοπικού</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Πρέπει να ξανανοίξεται τον συντάκτη CP για να οριστούνε οι αλλαγές.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Εμφάνιση μόνο monospaced γραμματοσειρών όταν επιλέγεται γραμματοσειρά</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Εμφάνιση μήκος δοκιμής</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Ο μέγιστος αριθμός των χαρακτήρων στη δοκιμή που είναι να εμφανιστεί.
 Η δοκιμή θα εξαφανιστεί και θα είναι μόνο για ανάγνωση αν είναι πολύ μεγάλη.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Πρόγραμμα μορφοποίησης Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Παράμετροι μορφοποίησης Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Η παράμετροι που θα περάσουν στην μορφοποίηση Clang ΔΕΝ ΠΡΕΠΕΙ να έχουνε την τιμή&quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Στύλ μορφοποίησης Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Πρόγραμμα YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>Το πρόγραμμα YAPF. Μπορεί να είναι &quot;yapf&quot; (που δεν χρειάζεται παραμέτρουσ) ή &quot;python&quot; (που χρειάζετε την παράμετρο &quot;-m yapf&quot;).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Παράμετροι YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Η παράμετροι που θα περάσουν στο πρόγραμμα YAPF ΔΕΝ ΠΡΕΠΕΙ να έχουνε την τιμή&quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Στύλ YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Οι ρυθμίσεις του στύλ YAPF έιναι συνήθως απόθηκευμένες σε ένα αρχείο με το όνομα .style.yapf ή setup.conf.
 Μπορείτε να μάθετε περισσότερα για το YAPF αν τρέξεται την εντολή &quot;yapf --style-help&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Να γίνεται μορφοποίηση κώδικα όταν τον απόθηκεύεται χειροκείνειτα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Να γίνεται μορφοποίηση κώδικα όταν απόθηκεύεται αυτόματα.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Περιεχόμενα τον πάνω σχολίων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>Αυτόματη αναίρεση απόδεγμένων δοκιμών</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>Αυτόματη απόεπιλογή δοκιμών όταν γίνονται δεκτές.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>Η διαδρομή στο WakaTime εκτελέσιμο αρχείο</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Κλειδί API</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>Επιτροπή WakaTime</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>Επιτρέψτε την σύνδεση στο GitHub όσο ελέγχουμε για ενημερώσεις</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>Μπορεί να βρεθεί στο https://wakatime.com/settings/account.
 Μπορέι να είναι άδειο αν έχετε το παγκόσμιο αρχείο wakatime διαμόρφωση αρχείου ~/.wakatime.cfg.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>Χρησιμοποιήστε πληρεξούσιο</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>Χρησιμοποιήστε Προχωρημένα-&gt;Δίκτυο Πληρεξούσιου για απόστολή δεδομένων στο WakaTime.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>Επιτρέψτε το πληρεξούσιο για έλεγχο ενημερώσεων</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Η άγκυρα για την επιτροπή του μεταξούσιου για έλεγχο ενημερώσεις στην αντίστοίχη σελίδα https://cpeditor.org/docs/preferences</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Ενεργοποίηση εξομοίωσης Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Ενεργοποίηση εξομοίωσης Vim στον Επεξεργαστή Κώδικα</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Ρυθμίσεις Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Το περιεχόμενο του Vim RC. Φορτώνεται κάθε φορά που ξεκινά η εξομοίωση Vim.
@@ -2862,6 +3602,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
+        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Καθαρισμός συντόμευσης</translation>
     </message>
@@ -2869,42 +3610,52 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Εισαγωγή</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Εισαγωγή σειράς (Ctrl+N)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Αφαίρεση</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Διαγραφή της τορινής γραμμής (Ctrl+W)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Αφαίρεση αντικειμένου</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε την τωρινή σειρά;</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Μετακίνηση πάνω</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Μετακίνησης της τωρινής γραμμής πάνω (Ctrl+Shift+Up)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Μετακίνηση κάτω</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Μετακίνηση της τωρινής γραμμής κάτω (Ctrl+Shift+Down)</translation>
     </message>
@@ -2912,6 +3663,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Υποστήριξη / Προσφορά</translation>
     </message>
@@ -2919,34 +3671,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>Σας αρέσει ο συντάκτης CP;</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>Ευχαριστώ που χρησιμοποιείτε τον συντάκτη CP!</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Για να μας υποστειρίξετε μπορείτε να:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Μας δώσετε ένα αστέρι στο GitHub</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Μοιραστείτε τον συντάκτη CP στους φίλους σας</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Να μας υποστηρίξετε οικονομικά</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Να αναφέρεται τι μπορούμε να κάνουμε καλύτερα</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>Χρησιμοποιώ το @cpeditor_, είναι ένα IDE ειδικά σχεδιασμένο για competitive προγραμματιστές, που είναι τέλειο!</translation>
     </message>
@@ -2954,14 +3714,17 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>Δεν βρέθηκε η έκδοση.</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>Δεν βρέθηκε URL για την έκδοση [%1].</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Αυτό το πρόβλημα μάλλον είναι εξαιτίας της έλλιψης της βιβλιοθήκης OpenSSL. Μπορείτε να επησκεφθείτε την ιστοσελίδα &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; για να βρείτε μια βιβλιοθήκη να εγκαθαστείσετε. Πρέπει να εγκαταστείσετε μια εφαρμογή κατάλληλη με: [%1]</translation>
     </message>
@@ -2969,50 +3732,64 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="87"/>
+        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Απέτυχε να ανοίξει [%1]. Μήπως δεν έχετε άδεια εγγραφής;</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="97"/>
+        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Απέτυχε η αποθήκευση του [%1]. Έχετε άδεια εγγραφής;</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>Το αρχείο [%1] δεν υπάρχει</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Απέτυχε να ανοίξει [%1]. Μήπως δεν έχετε άδεια εγγραφής;</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Εμφάνιση %1 μέσα στο Finder</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Εμφάνιση %1 μέσα στον εξερευνητή</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Άνοιγμα φακέλου που περιέχει το %1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Εμφάνιση του %1 στον διαχειριστή αρχείων</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3020,50 +3797,62 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Δημιουργία νέου διαγωνισμού</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Κύριος φάκελος</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Υποφάκελος</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Αριθμός προβλημάτων</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>Ο κύριος φάκελος δεν υπάρχει</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>Ο κύριος φάκελος [%1] δεν υπάρχει. Θέλετε να τον διμιουργήσετε και να συνεχίσετε;</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Απέτυχε η δημιουργία φακέλου</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Απέτυχε η δημιουργία φακέλου [%1].</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Λεπτομέρειες διαγωνισμού</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Αποθήκευση διαδρομής</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Επιλέξτε κύριο φάκελο</translation>
     </message>
@@ -3071,14 +3860,17 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Diff Viewer</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Αναμενόμενα</translation>
     </message>
@@ -3086,26 +3878,33 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation type="unfinished">Επαναφόρτωση</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3113,162 +3912,222 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Ανάγνωση testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Αποθήκευση testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Μεταγλωττιστής</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">Ξεπεράστηκε το χρονικό περιθώριο (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3276,58 +4135,72 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Είσοδος</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Αναμενόμενα</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Εκτέλεση</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Δοκιμή μιας δοκιμής</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Άνοιγμα του Diff Viewer</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Είσοδος #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Έξοδος #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Αναμενόμενο #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Διαγραφή δοκιμής</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε την δοκιμή #%1?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Diff Viewer[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>Η αναμενόμενη έξοδος μπορεί να είναι περισσότερο από %1 χαρακτήρες, ο HTML diff viewer είναι μη ενεργοποιημένος. Μπορείτε να αλλάξετε το όριο μήκους στο %2.</translation>
     </message>
@@ -3335,42 +4208,54 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Φόρτωση αρχείου</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Τροποποίηση σε μεγαλύτερο παράθυρο</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Αλλαγή δοκιμής</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Είσοδος</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Αναμενόμενα</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Αποθήκευση σε αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Αποθήκευση δοκιμής σε αρχείο</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Μόνο οι πρώτοι %1 χαρακτήρες εμφανίζονται. Τώρα ο συντάκτης δοκιμών είναι για ανάγνωση μόνο. Μπορείτε να αλλάξετε το όριο μήκους στο %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Αντιγραφή εξόδου στο αναμενόμενο</translation>
     </message>
@@ -3378,173 +4263,223 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Δοκιμές</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Ελεγκτής:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Εισάγεται δοκιμή</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Περισσότερα</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Εισαγωγή ελεγκτή</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Εισαγωγή προσαρμοσμένου testlib ελεκτή</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Εισάγετε ζευγάρια δοκιμών απο αρχεία</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Επιλογή αρχείων δοκιμών</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Φόρτωση δοκιμών</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Ένα ζευγάρι απο δοκιμές [%1] και [%2] είναι φορτωμένο</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Η είσοδος [%1] είναι φορτωμένη</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Τα παρακάτω αρχεία δεν φορτώθηκαν επειδή δεν έχουνε ταυτοποιηθή:%1. Μπορείτε να αλλάξετε τους κανόνες ταυτοποίησης στο %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε όλες τις δοκιμές;</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Αντιστροφή</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Αγνόηση επόμενων κενών</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Απαραίτητως τα ίδια</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Compare int64s</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Compare doubles, max error 1e-4</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Compare doubles, max error 1e-6</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Compare doubles, max error 1e-9</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Σύγκριση tokens</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Σύγκριση YES/NOs, case insensitive</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Εισαγωγή δοκιμής</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Υπάρχουνε ίδη οι %1 δοκιμές, δεν μπορείτε να προσθέσεται παραπάνω.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Εισαγωγή #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Αναμενόμενο #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Αποθήκευση εισόδου #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Αποθήκευση αναμενόμενων #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Φόρτωση %1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Δοκιμές</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>Μη αποδεκτές / Αποδεκτές / Συνολικά</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Τσεκάρισμα όλων</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Uncheck All</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Uncheck αποδεγμένα</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Διαγραφή όλων</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Διαγραφή άδειων</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Διαγραφεί τσεκαρισμένο</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε όλες τις τσεκαρισμένες δοκιμές;</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Αντιγραφή δοκιμών</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Επικόληση δοκιμών</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Αντιγραφή εξόδου στο αναμενόμενο</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Είστε σίγουροι ότι θέλετε να αντιγράψετε όλη την τσεκαρισμένη έξοδο στα αντοίστιχα αναμενόμενα;</translation>
@@ -3553,26 +4488,32 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Λήψη</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Υπάρχει νέα έκδοση</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>μια νέα %1 έκδωση &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; είναι διαθέσιμη. Δείτε παρακάτω για τις αλλαγε.&lt;br /&gt; Συστίνουμε να κρατήσετε τον συντάκτη ενημερομένο ώστε να μην χάσεται νέες λειτουργίες.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>Beta</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>Stable</translation>
     </message>
@@ -3580,30 +4521,37 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Κλείστε αυτόν τον κατάλογο και ματαιώσετε τον έλεγχο ενημερόσεων</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Ελεχτής ενημερόσεων</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Λήψη λίστα ενημερώσεων...</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Σφάλμα: %1&lt;br /&gt;&lt;br /&gt; Ο ενημερωτής απέτυχε να ελέξη για ενημερώσης. Παρακαλώ δείτε χειροκίνιτα τις ενημερώσεις στο &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/ru/download&quot;&gt;https://cpeditor.org/ru/download&lt;/a&gt; ή &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translatorcomment>The most suitable translation</translatorcomment>
         <translation>Μπράβο, χρησομοποιήτε την τελευτέα έκδοση του CP συντάκτη.</translation>

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -4,465 +4,438 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Γρήγορη έξοδος</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>Στην τελευταία έξοδο ο συντάκτης CP έκλεισε απροσδόκητα, θέλετε να επαναφέρεται την προηγούμενη συνεδρίαση;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Εμφάνιση κυρίου παραθύρου</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Άνοιγμα αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>Σχετικά με το CP συντάκτη %1</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Ο CP συντάκτης&lt;/b&gt; είναι μια εφαρμογή βασισμένη πάνω στο Qt συντάκτη κώδικα. Είναι ειδικά σχεδιασμένο για ανταγωνιστικό προγραμματισμό αντιθέτως με άλλους συντάκτες κώδικα. Ο συντάκτης σας βοηθάει να είστε συγκεντρωμένοι στον αλγοριθμό σας και σας βοηθάει με την αυτοματοποίηση, εκτέλεση και δοκιμή του κώδικα. Μπορεί ακόμα να δοκιμάσει το πρόγραμμα με δοκιμή υποθέσεων από διαφορετικές πλατφόρμες και να στέλνει τις απαντήσεις στο Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Αυτό είναι δωρεάν λογισμικό, δείτε την πηγή για την πνευματική ιδιοκτησία. ΔΕΝ υπάρχει εγγύηση, ούτε για ΕΜΠΟΡΕΥΣΙΜΟΤΗΤΑ ή για ΙΚΑΝΟΤΗΤΑ ΓΙΑ ΣΥΓΚΕΚΡΙΜΕΝΟ ΣΚΟΠΟ. Ο πηγαίος κώδικας του CP κώδικα είναι διαθέσιμος στην ιστοσελίδα &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Ανοίξτε αρχεία</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Επαναφορά προτιμήσεων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>Είστε σίγουροι ότι θέλετε να επαναφέρεται όλες τις προτιμήσεις στης προκαθορισμένες προτιμήσεις;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1316"/>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>απόσπάσματα</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>Δεν υπάρχουν απόσπάσματα για %1. Παρακαλώ προσθέστε απόσπάσματα στο παράθυρο προτιμήσεων.</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Χρησιμοποιήστε απoσπάσματα</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Επιλέξτε ένα απόσπασμα:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>Δεν υπάρχει το απόσπασμα με το όνομα %1 για %2</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Κλείσιμο άλλον</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Κλείστε τα αριστερά</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Κλείστε τα δεξιά</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Αντιγραφή διαδρομής αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Αντιγραφή URL προβλήματος</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Προσαρμογή Codeforces URL</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Προσαρμογή CF URL</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Εισάγεται το ID του διαγωνισμού:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Εισάγεται το πρόβλημα του κώδικα (Α-Ω):</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1602"/>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Προσαρμογή πρόβλημα URL</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Εισάγεται το καινούργιο URL του προβλήματος:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Καταγραφέας συμβάτων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Όλες οι καταγραφές εκτός της τωρινής συνεδρίασης έχουν διαγραφεί</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>Συντάκτης CP: Ένας συντάκτης σχεδιασμένος για ανταγωνιστικό προγραμματισμό</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation type="vanished">Αποθήκευση ως...</translation>
+        <translation>Αποθήκευση ως...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation type="vanished">Αποθήκευση ως καινούργιο αρχείο</translation>
+        <translation>Αποθήκευση ως καινούργιο αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Αποθήκευση όλων</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation type="vanished">Αποθήκευση όλων τον ανοιχτών αρχείων</translation>
+        <translation>Αποθήκευση όλων τον ανοιχτών αρχείων</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation type="vanished">Κλείσιμο τωρινού</translation>
+        <translation>Κλείσιμο τωρινού</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation type="vanished">Κλείσιμο τωρινής καρτέλας</translation>
+        <translation>Κλείσιμο τωρινής καρτέλας</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Κλείσιμο απόθηκευμένων</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation type="vanished">Κλείσιμο απόθηκευμένων καρτέλων</translation>
+        <translation>Κλείσιμο απόθηκευμένων καρτέλων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Κλείσιμο όλων</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation type="vanished">Κλείσιμο όλων τον καρτέλων</translation>
+        <translation>Κλείσιμο όλων τον καρτέλων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation type="vanished">Έξοδος από την εφαρμογή</translation>
+        <translation>Έξοδος από την εφαρμογή</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation type="vanished">Άνοιγμα αρχείου...</translation>
+        <translation>Άνοιγμα αρχείου...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation type="vanished">Άνοιγμα αρχείων</translation>
+        <translation>Άνοιγμα αρχείων</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation type="vanished">Άνοιγμα διαγωνισμού...</translation>
+        <translation>Άνοιγμα διαγωνισμού...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation type="vanished">Ανοίξτε έναν διαγωνισμό</translation>
+        <translation>Ανοίξτε έναν διαγωνισμό</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation type="vanished">Εσοχή</translation>
+        <translation>Εσοχή</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation type="vanished">Αφαίρεση εσοχής</translation>
+        <translation>Αφαίρεση εσοχής</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation type="vanished">Αλλαγή σειράς πάνω</translation>
+        <translation>Αλλαγή σειράς πάνω</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation type="vanished">Αλλαγή σειράς κάτω</translation>
+        <translation>Αλλαγή σειράς κάτω</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation type="vanished">Αντιγραφή γραμμής</translation>
+        <translation>Αντιγραφή γραμμής</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation type="vanished">Διαγραφή γραμμής</translation>
+        <translation>Διαγραφή γραμμής</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation type="vanished">Μεταβολή σχολίου</translation>
+        <translation>Μεταβολή σχολίου</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation type="vanished">Μεταβολή κομμάτι σχολίου</translation>
+        <translation>Μεταβολή κομμάτι σχολίου</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Σύνταξη</translation>
+        <translation>Σύνταξη</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Σύνταξη και εκτέλεση</translation>
+        <translation>Σύνταξη και εκτέλεση</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Εκτέλεση</translation>
+        <translation>Εκτέλεση</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation type="vanished">Διάταξη κώδικα</translation>
+        <translation>Διάταξη κώδικα</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation type="vanished">Εκτέλεση απόμονωμένου</translation>
+        <translation>Εκτέλεση απόμονωμένου</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation type="vanished">Τερματισμώς διεργασιών</translation>
+        <translation>Τερματισμώς διεργασιών</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation type="vanished">Εύρημα και αντικατάσταση</translation>
+        <translation>Εύρημα και αντικατάσταση</translation>
+    </message>
+    <message>
+        <source>Stress Testing...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation type="vanished">Προτιμήσεις</translation>
+        <translation>Προτιμήσεις</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation type="vanished">Σχετικά με το Qt</translation>
+        <translation>Σχετικά με το Qt</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Σχετικά με την κατασκευή</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation type="vanished">Έλεγχος για ενημέρωσεις</translation>
+        <translation>Έλεγχος για ενημέρωσεις</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation type="vanished">Καινούριο αρχείο</translation>
+        <translation>Καινούριο αρχείο</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation type="vanished">Άνοιγμα νέας καρτέλας στον συντάκτη</translation>
+        <translation>Άνοιγμα νέας καρτέλας στον συντάκτη</translation>
+    </message>
+    <message>
+        <source>Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with generator template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with C++ template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Java template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Python template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation type="vanished">Αποθήκευση του αρχείου στον δίσκο</translation>
+        <translation>Αποθήκευση του αρχείου στον δίσκο</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation type="vanished">Χρησιμοποίηση απόσπάσματος...</translation>
+        <translation>Χρησιμοποίηση απόσπάσματος...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation type="vanished">Εξαγωγή ρυθμίσεων...</translation>
+        <translation>Εξαγωγή ρυθμίσεων...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation type="vanished">Εισαγωγή ρυθμίσεων...</translation>
+        <translation>Εισαγωγή ρυθμίσεων...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation type="vanished">Επαναφορά ρυθμίσεων</translation>
+        <translation>Επαναφορά ρυθμίσεων</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation type="vanished">Εγχειρίδιο</translation>
+        <translation>Εγχειρίδιο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>Σχετικά</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation type="vanished">Μοντέλο συντάκτη</translation>
+        <translation>Μοντέλο συντάκτη</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation type="vanished">Μοντέλο Εισόδου / Εξόδου</translation>
+        <translation>Μοντέλο Εισόδου / Εξόδου</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation type="vanished">Μοντέλο διαίρεσης</translation>
+        <translation>Μοντέλο διαίρεσης</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation type="vanished">Εμφάνιση αρχείων συμβάντων</translation>
+        <translation>Εμφάνιση αρχείων συμβάντων</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation type="vanished">Διαγραφή αρχείων συμβάντων</translation>
+        <translation>Διαγραφή αρχείων συμβάντων</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Αρχείο</translation>
+        <translation>&amp;Αρχείο</translation>
+    </message>
+    <message>
+        <source>New File From Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="vanished">&amp;Επεξεργασία</translation>
+        <translation>&amp;Επεξεργασία</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation type="vanished">&amp;Ενέργειες</translation>
+        <translation>&amp;Ενέργειες</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Εμφάνιση</translation>
+        <translation>&amp;Εμφάνιση</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation type="vanished">&amp;Επιλογές</translation>
+        <translation>&amp;Επιλογές</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="vanished">&amp;Βοήθεια</translation>
+        <translation>&amp;Βοήθεια</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Εξαγωγή ρυθμίσεων σε αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Εισαγωγή ρυθμίσεων από αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Εξαγωγή τωρινής συνεδρίασης σε αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Εξαγωγή συνεδρίασης</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Απέτυχε η εξαγωγή της τωρινής συνεδρίασης στο [%1]</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Φόρτωση συνεδρίασης</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Η φόρτωση μιας συνεδρίασης από κάποιο αρχείο θα κλείσει όλες της καρτέλες χωρίς να απόθηκεύση τα αρχεία. Είστε σίγουροι;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Φόρτωση συνεδρίασης από αρχείο</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation type="vanished">Εξαγωγή συνεδρίασης...</translation>
+        <translation>Εξαγωγή συνεδρίασης...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation type="vanished">Φόρτωση συνεδρίασης...</translation>
+        <translation>Φόρτωση συνεδρίασης...</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="779"/>
-        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Αρχείο ρυθμίσεων του συντάκτη CP</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="807"/>
-        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Αρχείο ρυθμίσεων της συνεδρίασης</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation type="vanished">Αναφορά προβλημάτων</translation>
+        <translation>Αναφορά προβλημάτων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Εισαγωγή ρυθμίσεων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Όλες οι ρυθμίσεις θα χαθούνε αφότου εισαχθούνε οι ρυθμίσεις από το αρχείο. Είστε σίγουροι ότι θέλετε να συνεχίσεται;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Αντιγραφή καρτέλας</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -475,206 +448,169 @@ Build time: %4
 Λειτουργικό σύστημα: %5</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Φορητή έκδοση</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Έκδοση εγκατάστασης</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Άνοιγμα προσωρινών αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>Κανένα αρχείο δεν ανοίχτηκε πρόσφατα</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Καθάρισμα προσωρινών αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Πηγαίο αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Εκτελέσιμο αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Άνοιγμα προβλήματος στον φυλλομετρητή</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Προσαρμογή εντολής μεταγλοττιστή</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Ορισμός χρονικού περιθώριου</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation type="vanished">Πλήρες παράθυρο</translation>
+        <translation>Πλήρες παράθυρο</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation type="vanished">Υποστηριξέ μας</translation>
+        <translation>Υποστηριξέ μας</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>Πώς να βγείτε από την πλήρες οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>Πατήστε το F11 κουμπί για να βγείτε από πλήρες οθόνη.</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="obsolete">C++</translation>
+        <translation type="unfinished">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="obsolete">Java</translation>
+        <translation type="unfinished">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="obsolete">Python</translation>
+        <translation type="unfinished">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Αναζήτηση...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Εισαγωγή</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Μετανομασία απόσπάσματος</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Φόρτωση απόσπασμάτων από αρχεία</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Εξαγωγή απόσπάσματων σε αρχεία</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Περισσότερα</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Δεν επιλέξατε κάποιο απόσπασμα</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Μη απόθηκευμένα απόσπάσματα</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>Το απόσπασμα [%1] έχει αλλάξει. θέλετε να απόθηκεύσεται τις αλλαγές ή να της απόρρίψετε;</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Διαγραφή απόσπάσματος</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε το απόσπασμα [%1]?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Φόρτωση απόσπασμάτων</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Απέτυχε να ανοίξει [%1]. Μήπως δεν έχετε δικαίωμα ανάγνωσης;</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Εξαγωγή απόσπασμάτων</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Εξαγωγή απόσπασμάτων: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Δεν μπόρεσε να γίνει η εγραφή στο [%1]. Έχετε δικαίωμα εγγραφής;</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>Το όνομα απόσπάσματος δεν μπορεί να είναι άδειο.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Διαμάχη όνομα απόσπασμάτων</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>Το όνομα &quot;%1&quot; είναι ίδη σε χρήση. Θέλετε να το παρακάμψετε; (Το παλιό απόσπασμα με αυτό το όνομα θα διαγραφεί)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>Το όνομα &quot;%1&quot; χρησιμοποιείτε ίδη.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Εισαγωγή απόσπάσματος</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Νέο όνομα απόσπάσματος:</translation>
     </message>
@@ -682,93 +618,68 @@ Build time: %4
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Ελεγκτής ανάγνωσης</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
-        <location filename="../src/Core/Checker.cpp" line="99"/>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
-        <location filename="../src/Core/Checker.cpp" line="301"/>
-        <location filename="../src/Core/Checker.cpp" line="302"/>
-        <location filename="../src/Core/Checker.cpp" line="303"/>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Ελεγκτής</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Απέτυχε να διμιουργηθεί προσωρινός φάκελος</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Ανάγνωση testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Αποθήκευση testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Υπήρξε σφάλμα κατά την σύνταξη του ελέγκτη:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Ελεγκτής[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>Ο ελεγκτής έκλεισε με τον κωδικό%1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>Ο ελεγκτής έκλεισε με άγνωστο κωδικό %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Ξεπεράστηκε το χρονικό περιθώριο (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>Το %1 από τις τρεχόμενες διεργασίες των δοκιμών #%2 περιέχει περισσότερο από %3 χαρακτήρες, που είναι περισσότερο από το όριο εξόδου, οπότε η διεργασία τερματίστηκε. Μπορείτε να αλλάξετε το όριο εξόδου στο %4.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>Ο ελεγκτής σταμάτησε</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Ξεκίνησε η σύνταξη του ελεγκτή</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>Ο ελεγκτής συντάχθηκε</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Απέτυχε να συνταχθή ο ελεκγτής: %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>Ο πηγαίος κώδικας του ελεγκτή άλλαξε, επαναμεταγλώτιση...</translation>
     </message>
@@ -776,22 +687,18 @@ Build time: %4
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>Το πηγαίο αρχείο [%1] δεν υπάρχει</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Μη υποστηριζόμενη γλώσσα προγραμματισμού &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>απότυχία να ξεκινήσει ο μεταγλωττιστής. Παρακαλώ ελέξτε το %1 ή εισάγεται την διαδρομή του μεταγλωττιστή στην μεταβλητή του περιβάλλοντος.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 είναι άδειο</translation>
     </message>
@@ -799,39 +706,32 @@ Build time: %4
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>Το πηγαίο αρχείο %1 δεν υπάρχει.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Απέτυχε να διαβαστεί η εντολή run. Μάλλον είναι λογικό πρόβλημα στο λογισμικό.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Απέτυχε να ξεκινήσει. Παρακαλώ τρέξτε το μεταγλωττιστή ξανά.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>Το πρόγραμμα τελειώσε με τον κωδικό %1
 Πατήστε οποιοδήποτε κουμπί για να βγείτε</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Απέτυχε να ξεκινήσει η απόμωνομένη εκτέλεση. Παρακαλώ δείτε τις ρυθμίσεις του εξομοιωτή τερματικό %1.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>Η απόμονωμένη εκτέκεση δεν υποστηρύζεται στην πλατφόρμα σας</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>Απέτυχε η δημιουργία του προσωρινού αρχείου.</translation>
     </message>
@@ -839,12 +739,10 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Επαναφορά τελευταίας συνεδρίας</translation>
     </message>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Επαναφέρεται: [%1]</translation>
     </message>
@@ -852,52 +750,42 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">η `new` δεν δέχεται όρισμα ή πρέπει να είναι ένα από &apos;cpp&apos;, &apos;java&apos; και &apos;python&apos;, ελήφθη [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">το [%1] δεν είναι αρχείο πηγαίου C++, Python ή Java</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">το [%1] δεν υπάρχει. Για να ανοίξετε καρτέλα με ανύπαρκτο αρχείο, χρησιμοποιήστε `open!`</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">το [%1] δεν είναι αριθμός</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">το %1 είναι εκτός εύρους [1, %2]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">Δ/Υ</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">το [%1] δεν είναι έγκυρη λειτουργία προβολής. Πρέπει να είναι &apos;split&apos; ή &apos;edit&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">το %1 δεν είναι έγκυρο όνομα γλώσσας. Πρέπει να είναι &apos;cpp&apos;, &apos;java&apos; ή &apos;python&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">Δεν υπάρχει ενεργή καρτέλα για εκκαθάριση μηνυμάτων</translation>
     </message>
@@ -905,63 +793,42 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF εργαλείο</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>Το CF εργαλείο τερματίστηκε</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>Ο κωδικός του προβλήματος είναι 0, τώρα χρησιμοποιήστε το Α αυτόματα. Αν ο κωδικός προβλήματος δεν είναι το Α, παρακαλώ ορίστε το κώδικα του προβλήματος στο δεξιό κομμάτι του μενού της τρέχουσας καρτέλας.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Απέτυχε να φορτώσουμε την έκδωση του CF εργαλείου. Μήπως δεν βάλατε την διαδρομή του CF εργαλείου στις προτιμήσεις;</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>Το CF εργαλείο ξεκίνησε</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Απέτυχε η εκκίνηση του CF εργαλείου σε 2 δευτερόλεπτα. Έχετε ρυθμίση την διαδρομή του CF εργαλείου στις προτιμήσεις;</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Απέτυχε η ανάλυση του URL [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>Το CF εργαλείο απέτυχε</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>Το CF εργαλείο έκλεισε με μη μηδενικό κωδικό %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Διαγωνισμός %1 πρόβλημα %2</translation>
     </message>
@@ -969,50 +836,34 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Μορφοποιητής</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Απέτυχε η δημιουργία προσωρινού φακέλου</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Τελείωσε η μορφοποίηση</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Μορφοποιητής[stdout]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Μορφοποιητής[stderr]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>Η εντολή μορφοποίησης [%1 %2] τελείωσε με τον κωδικό %3.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>Η διεργασία μορφοποίησης δεν τελείωσε σε 2 δευτερόλεπτα. Αυτό μάλλον είναι γιατί το %1 πρόγραμμα δεν βρέθηκε από το CP συντάκτη. Μπορείτε να ρυθμίσετε την διαδρομή του προγράμματος στο %2.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>Η έξοδος της μορφοποίησης της διεργασίας είναι άδεια. Παρακαλώ δείτε αν υπάρχει όχι στην μετατροπή στις ρυθμίσεις σχετικά με την μορφοποίηση.</translation>
     </message>
@@ -1020,39 +871,32 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>Ο server είναι κλειστός</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>Η θύρα είναι ρυθμισμένει στην %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Υπήρξε σφάλμα με την ανάγνωση στην θύρα %1. Μήπως κάποια άλλη διεργασία χρησιμοποιεί την θύρα;</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Σταμάτησε ο server</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>Ο JSON αναλυτής ανέφερε προβλήματα:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>Η αίτηση που παραλήφθηκε δεν είναι σε μορφή JSON</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>Η %1 αίτηση λήφθηκε και αγνοήθηκε</translation>
     </message>
@@ -1060,42 +904,30 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Server γλώσσας [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Ο server γλώσσας έστειλε ένα σφάλμα. Παρακαλώ δείτε τους καταλόγους για λεπτομέριες.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Απέτυχε η εκκίνηση της LSP διεργασίας. Εισάγατε την διαδρομή του server γλώσσας στο %1;</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Η διεργασία LSP ξεπέρασε το χρονικό περιθώριο</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Η LSP διεργασία έχει πρόβλημα εισόδου / εξόδου</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Η LSP διεργασία έχει πρόβλημα εγγραφής</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Ένα άγνωστο σφάλμα συνέβη στην διεργασία του LSP</translation>
     </message>
@@ -1104,50 +936,50 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation type="vanished">Εύρημα / Αντικατάσταση</translation>
+        <translation>Εύρημα / Αντικατάσταση</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Φόρμα</translation>
+        <translation>Φόρμα</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation type="vanished">Εύρημα:</translation>
+        <translation>Εύρημα:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation type="vanished">Αντικατάσταση με:</translation>
+        <translation>Αντικατάσταση με:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation type="vanished">errorLabel</translation>
+        <translation>errorLabel</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="vanished">Κατεύθηνση</translation>
+        <translation>Κατεύθηνση</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="vanished">Πάνω</translation>
+        <translation>Πάνω</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="vanished">Κάτω</translation>
+        <translation>Κάτω</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">Επιλογές</translation>
+        <translation>Επιλογές</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation type="vanished">Διάκρηση πεζών / κεφαλαίων</translation>
+        <translation>Διάκρηση πεζών / κεφαλαίων</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation type="vanished">Ολόκληρες λέξεις μόνο</translation>
+        <translation>Ολόκληρες λέξεις μόνο</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1158,7 +990,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1169,74 +1001,52 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation type="vanished">Κοινή έκφραση</translation>
+        <translation>Κοινή έκφραση</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation type="vanished">Εύρημα</translation>
+        <translation>Εύρημα</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="vanished">Αντικατάσταση</translation>
+        <translation>Αντικατάσταση</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation type="vanished">Αντικατάσταση όλων</translation>
+        <translation>Αντικατάσταση όλων</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="185"/>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Μεταγλωττιστής</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Παρακαλώ ορίστε την γλώσσα</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="218"/>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="242"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1492"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Δρομέας</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Λάθος γλώσσα, παρακαλώ εισάγεται την γλώσσα</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Όλοι οι είσοδοι είναι άδειοι, δεν υπάρχει τίποτα να εκτελεστή</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Παράδοση</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Είστε σίγουροι ότι θέλετε να το παραδώσετε</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1247,101 +1057,78 @@ p, li { white-space: pre-wrap; }
  Γλώσσα: %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="328"/>
-        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF εργαλείο</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Υπήρξε σφάλμα κατά την αποθήκευση του προσωρινού αρχείου, η απάντηση δεν παραδόθηκε.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Χωρίς τίτλο-%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Αποθήκευση ως</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Άνοιγμα προτύπου %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1017"/>
-        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>Το αρχείο [%1] περιέχει περισσότερο από %2 χαρακτήρες, οπότε δεν ανοίχτηκε. Μπορείτε να αλλάξετε το όριο του μήκους του αρχείου στο %3.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Αποθήκευση αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
-        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Προσωρινό αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Απέτυχε η δημιουργία του προσωρινού φακέλου</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Διαβάστε το πρότυπο %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Αποθήκευση αλλαγών</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>Αποθήκευση αλλαγών στο [%1] πρίν το κλείσιμο;</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Νέο αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Ορίστε γλώσσα στην καρτέλα</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Ορίστε την γλώσσα που θα χρησιμοποιείται στην τρέχουσα καρτέλα</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Επαναφόρτωση</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1352,180 +1139,150 @@ Do you want to reload it?</source>
 Είστε σίγουροι ότι θέλετε να το φορτώσετε πάλι;</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Γραμμή %1, στήλη %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>%1 γραμμές, %2 χαρακτήρες επιλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>%1 χαρακτήρες επιλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>Η μεταγλώττιση ξεκίνησε</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>Η μεταγλώττιση τελείωσε</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Προειδοποιήσεις μεταγλώττισης</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Υπήρξαν σφάλματα κατά την μεταγλώττιση</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1517"/>
-        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Σφάλματα μεταγλώττισης</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>Η μεταγλώττιση τερματίστηκε</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>απόσπασμένος δρομέας</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Δρομέας [%1]</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>Η εκτέλεση ξεκίνησε</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>Η εκτέλεση για τις δοκιμές #%1 τελείωσε σε %2ms</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>Η εκτέλεση για την δοκιμή #%1 τελείωσε με μη μηδενικό κωδικό %2 σε %3ms</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Ξεπεράστηκε το χρονικό περιθώριο (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>Η %1 από τις εκτελούμενες διεργασίες στην δοκιμή #%2 περιέχει περισσότερο από %3 χαρακτήρες, που είναι περισσότερο από το όριο εξόδου, οπότε η διεργασία τερματίστηκε. Μπορείτε να αλλάξετε το όριο στο %4.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 τερματίστηκε</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>απόσπασμένος δρομέας</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Δρομέας για την δοκιμή #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation type="vanished">CP συντάκτης</translation>
+        <translation>CP συντάκτης</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation type="vanished">Πληροφορίες κέρσορα</translation>
+        <translation>Πληροφορίες κέρσορα</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Μεταγλώττιση</translation>
+        <translation>Μεταγλώττιση</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Εκτέλεση</translation>
+        <translation>Εκτέλεση</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Μεταγλώττιση και εκτέλεση</translation>
+        <translation>Μεταγλώττιση και εκτέλεση</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation type="vanished">Μυνύματα</translation>
+        <translation>Μυνύματα</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="vanished">Καθαρισμός</translation>
+        <translation>Καθαρισμός</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="vanished">C++</translation>
+        <translation>C++</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Αυτόματη αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>Έχετε ορίσει ένα δεκτό όνομα για την κύρια κλάσση μέσα στην λύση σας; Αν όχι, ορίστε την στο %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Άγνωστο χαρακτηριστικό: [%1]. Παρακαλώ δείτε τα σχόλια των ρυθμίσεων στο  %2.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Ορίστε εντολή μεταγλωττιστή</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Προσαρμοσμένη εντολή μεταγλωττιστή για αυτήν την καρτέλα:</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Ορισμός χρονικού περιθωρίου</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Προσαρμοσμένο χρονικό περιθώριο για αυτήν την καρτέλα: (ms)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Πρέπει να εγκαταστήσετε το εργαλείο CF για να παραδώσετε τον κωδικό σας στο Codeforces. Αν το έχετε ήδη κάνει, εισάγεται το στην μεταβλητή περιβάλλοντος ή ελέγξτε τις ρυθμίσεις σας στο %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Απέτυχε να ξεκινήσει η μεταγλώττιση: %1</translation>
     </message>
@@ -1533,7 +1290,6 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1543,42 +1299,34 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 Παρενθέσεις</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Εισαγωγή</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Δεν επιλέχθηκε παρένθεση</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Νέα παρένθεση</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Εισάγετε μια παρένθεση (π.χ. {}):</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Διαγραφή παρένθεσης</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε την παρένθεση %1;</translation>
     </message>
@@ -1586,29 +1334,24 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Παρένθεση: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Επιτρέψτε %1 για %2 στο %3.
 Αν είναι εν μέρει επιλεγμένο, η παγκόσμια ρύθμιση στην επεξεργασία κώδικα θα χρησιμοποιηθεί.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Αυτόματη συμπλήρωση</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Αυτόματη διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Tab Jump Out</translation>
     </message>
@@ -1616,25 +1359,18 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="41"/>
-        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Επιλέξτε αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Εκτελέσιμα αρχεία</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="84"/>
-        <location filename="../src/Settings/PathItem.cpp" line="86"/>
-        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Επιλέξτε %1 πηγαίο κωδικα</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Επιλέξτε εκτελέσιμο αρχείο</translation>
     </message>
@@ -1642,42 +1378,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>Καλωσήρθατε στο συντάκτη CP! Ας ξεκινήσουμε.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Ρυθμίσεις συντάκτη κώδικα</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Εντολές μεταγλώττισης και εκτέλεσης С++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Εντολές μεταγλώττισης και εκτέλεσης Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Εντολές εκτέλεσης Python</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>Μπορείτε να διαβάσετε την &lt;a href=&quot;%1&quot;&gt;τεκμηρίωση&lt;/a&gt; ή να διαβάσετε τις ρυθμίσεις για περισσότερες πληροφορίες.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Ρυθμίσεις εμφάνισης</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Ρυθμίσεις γραμματοσειρά</translation>
     </message>
@@ -1685,42 +1413,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>Προκαθορισμένο</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Επαναφόρτωση</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Εφαρμογή</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Επαναφορά των προκαθορισμένων ρυθμίσεων στην τωρινή σελίδα. (Ctrl+D)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Διαγράψτε τις αλλαγές στην τορινή σελίδα. (Ctrl+R)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Αποθήκευση αλλαγών στην τωρινή σελίδα. (Ctrl+S)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Μη απόθηκευμένες αλλαγές</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>Η ρυθμίσεις έχουν αλλάξει. Θέλετε να απόθηκεύσετε τις αλλαγές ή να τις διαγράψετε;</translation>
     </message>
@@ -1728,280 +1448,239 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
-        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Προτιμήσεις</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Αναζήτηση...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Σπίτι</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Πήγαινε στην αρχική σελίδα</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation type="vanished">Σύνταξη κώδικα</translation>
+        <translation>Σύνταξη κώδικα</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Γλώσσα</translation>
+        <translation>Γλώσσα</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="vanished">Γενικά</translation>
+        <translation>Γενικά</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="vanished">Εμφάνιση</translation>
+        <translation>Εμφάνιση</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation type="vanished">Ενέργειες</translation>
+        <translation>Ενέργειες</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Αποθήκευση</translation>
+        <translation>Αποθήκευση</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation type="vanished">Δέσμευση αρχείου και προβλήματος</translation>
+        <translation>Δέσμευση αρχείου και προβλήματος</translation>
+    </message>
+    <message>
+        <source>Stopwatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stress Testing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generator Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation type="vanished">Επεκτάσεις</translation>
+        <translation>Επεκτάσεις</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation type="vanished">Clang Format</translation>
+        <translation>Clang Format</translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation type="vanished">Γλώσσα Server</translation>
+        <translation>Γλώσσα Server</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 Εντολές</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 Πρότυπο</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 απόσπάσματα</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 Παρενθέσεις</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>%1 Server</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation type="vanished">Competitive Companion</translation>
+        <translation>Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation type="vanished">CF εργαλείο</translation>
+        <translation>CF εργαλείο</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation type="vanished">Διαδρομή αρχείου</translation>
+        <translation>Διαδρομή αρχείου</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation type="vanished">Δοκιμές</translation>
+        <translation>Δοκιμές</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation type="vanished">URL προβλήματος</translation>
+        <translation>URL προβλήματος</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation type="vanished">Δέσμευση πλήκτρων</translation>
+        <translation>Δέσμευση πλήκτρων</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="vanished">Προχωρημένα</translation>
+        <translation>Προχωρημένα</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="vanished">Ενημέρωση</translation>
+        <translation>Ενημέρωση</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation type="vanished">Όρια</translation>
+        <translation>Όρια</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation type="vanished">Αυτόματη αποθήκευση</translation>
+        <translation>Αυτόματη αποθήκευση</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation type="vanished">Αποθήκευση συνεδρίασης</translation>
+        <translation>Αποθήκευση συνεδρίασης</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation type="vanished">Πληρεξούσιο δικτύου</translation>
+        <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation type="vanished">Προκαθορισμένη διαδρομή</translation>
+        <translation>Προκαθορισμένη διαδρομή</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation type="vanished">Φόρτωση αλλαγών εξωτερικών αρχείων</translation>
+        <translation>Φόρτωση αλλαγών εξωτερικών αρχείων</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation type="vanished">απόσπώμενη εκτέλεση</translation>
+        <translation>απόσπώμενη εκτέλεση</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="vanished">Γραμματοσειρά</translation>
+        <translation>Γραμματοσειρά</translation>
     </message>
     <message>
         <source>YAPF</source>
-        <translation type="vanished">YAPF</translation>
+        <translation>YAPF</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation type="vanished">Μορφοποίηση κώδικα</translation>
+        <translation>Μορφοποίηση κώδικα</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation type="vanished">Δοκιμές</translation>
+        <translation>Δοκιμές</translation>
     </message>
     <message>
         <source>WakaTime</source>
-        <translation type="vanished">WakaTime</translation>
+        <translation>WakaTime</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Πλάτος καρτέλας</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>Το πλάτος των χαρακτήρων σε καρτέλες ή ο αριθμός τον κενών σε μια εσοχή</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>Πλάτος κέρσορα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>Το πλάτος του κέρσορα σε εικονοκύτταρα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Γραμματοσειρά συντάκτη</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>Η γραμματοσειρά του συντάκτη κώδικα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Προκαθορισμένη γλώσσα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>Η προκαθορισμένη γλώσσα που θα χρησιμοποιείται όταν ανοίγουν νέες καρτέλες</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Διαδρομή</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Η διαδρομή του αρχείου μορφοποίησης Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Το στύλ μορφοποίησης Clang, έχει συνήθως την επέκταση.clang-format.
 Μπορείτε να μάθετε για την μορφοποίηση Clang εδώ &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>Το πρότυπο που θα χρησιμοποιηθεί όταν δημιουργείται αρχεία τύπου C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -2010,71 +1689,52 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 Ο κέρσορας θα είναι στο τέλος του προτύπου αν δεν υπάρχει καμια αναφορά στο regex.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Ανεξάρτητα αν το αντιστάθμισμα είναι σχετικό με την αρχή του regex ή το τέλος του regex.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>Το αντιστάθμισμα είναι σχετικό με τον αριθμό των χαρακτήρων στο regex, συμπεριλαμβάνονται και οι κενοί χαρακτήρες.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>Η εντολή που χρησιμοποιείται για την μεταγλώττιση της C ++. ΔΕΝ πρέπει να περιλαμβάνει την διαδρομή του πηγαίου αρχείου ή την παράμετρο &quot;-o &lt;output file&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Οι παράμετροι όταν εκτελείται ένα πρόγραμμα C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>Το πρότυπο που θα χρησιμοποιείτε με της δημιουργία ενός αρχείου Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>Η εντολή που θα χρησιμοποιείτε όταν μεταγλωττίζεται ένα αρχείο Java.
 ΔΕΝ πρέπει να περιέχει την διαδρομή του πηγαίου αρχείου ή την διαδρομή του μεταγγλωτισμένου αρχείου κλάσης.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Οι παράμετροι όταν εκτελείται ένα πρόγραμμα Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>Η εντολή εκκίνησης του προγράμματος Java. ΔΕΝ πρέπει να περιέχει &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 Εντολή εκτέλεσης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 Όνομα κλάσης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 Διαδρομή κλάσης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2087,84 +1747,68 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; ή &quot;${tempdir}&quot; για την απόλυτη διαδρομή του προσωρινού φακέλου.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>Το πρότυπο που θα χρησιμοποιηθεί με την δημιουργία ενός καινούργιου αρχείου Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Οι παράμετροι που θα χρησιμοποιηθούν στην εκτέλεση του Python προγράμματος</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>Η εντολή εκκίνησης του προγράμματος Python. ΔΕΝ πρέπει να περιέχει την διαδρομή του πηγαίου προγράμματος.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Θέμα συντάκτη</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>Θέμα ανάδειξεις σύνταξης του συντάκτη κώδικα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Αυτόματη ολοκλήρωση παρενθέσεων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Αυτόματη αφαίρεση παρενθέσεων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Αυτόματη εσοχή</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Εισαγωγή εσοχής όταν δημιουργείται νέα γραμμή μετά από τον χαρακτήρα &quot;{&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Επιτροπή αυτόματης αποθήκευσης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Αναδίπλωση κειμένου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Αναδήπλωση γραμμής σε αρκετές γραμμές αν δεν χωράνε στην οθόνη.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Χρησιμοποιείστε την beta έκδοση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Ελέγξτε για pre release ενημερώσεις. ΠΡΟΣΟΧΗ, αυτές οι εκδόσεις είναι ασταθείς αλλά έχουν περισσότερα χαρακτηριστικά.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Τα ζευγάρια τακτικών εκφράσεων χρησιμοποιούνται όταν προστίθενται ζευγάρια δοκιμών από αρχεία.
 Κάθε ζευγάρι τακτικής έκφρασης αναπαριστά μια δοκιμή.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -2172,76 +1816,34 @@ This can be overridden for each parenthesis in each language.</source>
 Αυτό μπορεί να αλλάξει για κάθε παράγραφο σε κάθε γλώσσα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 Διαδρομή προτύπου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>%1 Πρότυπο τοποθεσίας κέρσορα regex</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>%1 Πρότυπο τύπο αντισταθμίσματος τοποθεσίας κέρσορα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>%1 Πρότυπο αντισταθμίσματος τοποθεσίας κέρσορα χαρακτήρων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 Εντολή μεταγλώττισης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 Διαδρομή εκτελέσιμου αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2256,19 +1858,14 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; ή &quot;${tempdir}&quot; για την απόλυτη διαδρομή του προσωρινού φακέλου.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 Παράμετροι εκτέλεσης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>Το όνομα της κύριας κλάσης για την λύση σας.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -2276,12 +1873,10 @@ This can be overridden for each parenthesis in each language.</source>
 Αυτό μπορεί να παρακαμψεί κάθε παρένθεση σε κάθε γλώσσα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Βγείτε από ένα ζευγάρι παρενθέσεων πατώντας Tab</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -2289,325 +1884,250 @@ This can be overridden for each parenthesis in each language.</source>
 Αυτό μπορεί να παρακαμπμφθεί για κάθε παρένθεση για κάθε γλώσσα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Enable Ctrl+Scroll to change font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Χρησιμοποιήσει κενών εκτός από τον χαρακτήρα Tab.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Αντικατάσταση Tabs με κενά</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Αποθήκευση δοκιμών κατά την αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Αποθήκευση τον δοκιμών στον δίσκο όταν απόθηκεύεται κάποιο αρχείο, και φώρτοση τον παλιών δοκιμών όταν ανοίξει κάποιο αρχείο.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Έλεγχος για ενημερώσεις κατά την εκκίνηση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Έλεγχος αν υπάρχει νέα έκδοση του CP συντάκτη κατα την εκκίνηση.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Αδιαφάνεια</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>Η αδιαφάνεια του κυρίου παραθύρου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Enable Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Λήψει δεδομένων που απόστάλθηκαν από το Competitive Companion και φόρτωση τον δοκιμών.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Θύρα σύνδεσης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>Η θύρα που χρησιμοποιείται για λήψει δεδομένων από το Competitive Companion σας</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Άνοιγμα νέων καρτελών</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Άνοιγμα νέας καρτέλας για κάθε πρόβλημα του Competitive Companion σας.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Μορφοποίηση κωδικών</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Τερματισμός κάθε διεργασίας</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Μεταγλώττιση και εκτέλεση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Εκτέλεση μόνο</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Μεταγλώττιση μόνο</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Αλλαγή λειτουργία προβολής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Χρησιμοποίηση απόσπάσματος</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>Η διαδρομή του εκτελέσιμου CF εργαλείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Δείξε το &quot;Μεταγλώττιση και εκτέλεση&quot; μόνο</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Κρύψε το &quot;Μεταγλώττιση μόνο&quot; κουμπί και το &quot;Εκτέλεση μόνο&quot; κάτω από τον συντάκτη κώδικα στο κύριο παράθυρο.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Δείξε το EOLN στο Diff</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Χρησιμοποιήστε το χαρακτήρα &quot;¶&quot; για να αναφέρεται το \n χαρακτήρα μέσα στο HTML Diff Viewer.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Αποθήκευση αρχείων γρηγορότερα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Πάντα χρησιμοποίησε το QFile αντί του QSaveFile για αποθήκευση αρχείων.
 Αυτό θα είναι πιο γρήγορο για την αποθήκευση αρχείων αλλά υπάρχει μια πιθανότητα να χαθεί το αρχείο (η πιθανότητα είναι πολύ μικρή).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Όριο μήκους εξόδου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>Ο μέγιστος αριθμός χαρακτήρων για την έξοδο του προγράμματος.
 Το πρόγραμμα θα τερματιστή αν το stdout ή το stderr είναι πολύ μεγάλο.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Όριο μήκους μυνύματος</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>Ο μέγιστος αριθμός χαρακτήρων σε κάθε μύνυμα είναι στο πάνω δεξιά κομμάτι του κύριου παραθύρου.
 Το μύνημα θα εξαφανιστεί αν είναι πολύ μεγάλο.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>HTML Diff Viewer όριο μήκους</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>Ο μέγιστος αριθμός των χαρακτήρων μέσα στο HTML Diff Viewer.
 Το Diff Viewer θα χρησιμοποιήσει την κανονική γραμματοσειρά αν η έξοδος είναι πολύ μεγάλη.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Όριο μήκους άνοιγμα αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>Ο μέγιστος αριθμός χαρακτήρων του πηγαίου αρχείου που θα ανοιχθεί.
 Το πηγαίο αρχείο δεν θα ανεχθεί αν είναι πολύ μεγάλο.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Διαδρομή στο εκτελέσιμο LSP</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>Η διαδρομή στο C++ Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Η διαδρομή στο Java Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Η διαδρομή στο Python Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Χρησιμοποίησε Linting με το Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Εμφάνιση σφάλματος, προειδοποιήσεις και υποδείξεις στο συντάκτη κώδικα για την γλώσσα C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Εμφάνιση σφάλματος, προειδοποιήσεις και υποδείξεις στο συντάκτη κώδικα για την γλώσσα Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Εμφάνιση σφάλματος, προειδοποιήσεις και υποδείξεις στο συντάκτη κώδικα για την γλώσσα Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Χρησιμοποίησε αυτόματη ολοκλήρωση με το Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Χρησιμοποίησε τις απαντήσεις αυτόματης ολοκλήρωσης του Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Καθυστέρηση Linting σε ms</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Καθυστέρηση Linting σε ms μετά από την τελευταόα αλλαγή στον κώδικα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Παράμετροι για τον Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Παράμετροι που θα περάσουν στον Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Δοκιμές για τους κανόνες αντιστοίχισης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Είσοδος Regex</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>Η κοινή έκφραση που θα αντιστοιχηθούν σε όλη την είσοδο στο όνομα αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Απάντηση-Αντικατάσταση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Η έκφραση αντικατάστασης για την απάντηση του ονόματος αρχείου .
 Μπορείτε να χρησιμοποιήσετε &quot;\1&quot; για την πρώτη ομάδα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Είσοδος διαδρομής αποθήκευσης αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2622,12 +2142,10 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${0-index}&quot; Για τον δείκτη της δοκιμής που αρχίζει από το 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Απάντηση διαδρομής αποθήκευσης αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2642,171 +2160,138 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${0-index}&quot; Για τον δείκτη της δοκιμής που αρχίζει από το 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Προκαθορισμένες διαδρομές αρχείων για τα URLs των προβλημάτων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>Η προκαθορισμένη διαδρομή που θα απόθηκεύονται νέα αρχεία όσο υπάρχει το URL του προβλήματος</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL προβλήματος</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>Η κοινή έκφραση που θα αντιστοιχίσει το κομμάτι του URL προβλήματος</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Διαδρομή αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Η έκφραση αντικατάστασης για την διαδρομή αρχείου, χωρίς την επέκταση αρχείου.
 Μπορείτε να χρησιμοποιήσετε το &quot;\1&quot; για την πρώτη ομάδα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Γραμματοσειρά δοκιμών</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>Η γραμματοσειρά των δοκιμών</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Εισάγεται ένα περιθώριο στο κάτω μέρος του συντάκτη κώδικα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Εισάγεται περιθώριο με το ύψος της σελίδας στο κάτω κομμάτι του συντάκτη κώδικα.
 Λόγο ενός τεχνικού προβλήματος, η αλλαγή του περιθωρίου θα επηρεάσει την ιστορίας αναίρεσης.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Γραμματοσειρά καταγραφέας μηνυμάτων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>Η γραμματοσειρά του καταγραφέα μηνυματών</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Αποθήκευση αρχείου μετά την μεταγλώττιση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Αποθήκευση πηγαίου αρχείου κατα την μεταγλώττιση του. Το αρχείο δεν θα απόθηκευτή αν η καρτέλα δεν έχει όνομα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Αποθήκευση αρχείου μετά την εκτέλεση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Αποθήκευση του πηγαίου αρχείου κατά την εκτέλεση του. Δεν θα απόθηκευτή αν η καρτέλα δεν έχει όνομα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Επαναφορά του URL του προβλήματος όταν ανοίξει το αρχείο</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Αν το URL του προβλήματος έχει ρυθμιστεί σε ένα αρχείο, όταν ανοίξεται αυτο το αρχείο ξανά,
 το URL του προβλήματος θα επαναφορτωθεί.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Αν το URL του προβλήματος έχει ρυθμιστεί σε ένα αρχείο, όταν αναλύεται το πρόβλημα
 από ένα Competitive Companion πάλι, το παλιό αρχείο θα ανοιχθεί.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Άνοιτε το παλιό αρχείο όταν αναλύεται το παλιό URL πρόβλημα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>UI γλώσσα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>Η γλώσσα που εμφανίζεται στο UI.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>UI στύλ</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>Το στύλ της εφαρμογής.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Εκτελέστε τους κώδικες σας σε άδειες δοκιμές</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Εκτελέστε των κώδικα σε όλες τις κρυφές δοκιμές ακόμα και αν οι είσοδοι είναι άδειοι.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Ελέγξτε την απάντηση σας στις δοκιμές με άδειες εισόδους</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Ελέγξτε την απάντηση σας αν η έξοδος ή αν η αναμενόμενη έξοδο σας είναι άδεια.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Διάστημα αυτόματης αποθήκευσης (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>Το χρονικό διάστημα ανάμεσα σε μια τροποποίηση και σε αυτόματη αποθήκευση, ή ανάμεσα σε δύο αυτόματες απόθηκεύσης.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Τύπο αυτόματου διάστημα αποθήκευσης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2815,24 +2300,20 @@ Without modification: auto-save happens with a constant interval no matter there
 Χωρίς τροποποίηση μια αυτόματη αποθήκευση με σταθερό διάστημα ανεξαρτήτως αν υπάρχει τροποποίηση ή όχι.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Επαναφορά της τελευταίας συνεδρίασης κατά την εκκίνηση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Επαναφορά της τελευταίας συνεδρίασης κατά την εκκίνηση της εφαρμογής.
 Όταν αυτό είναι ενεργοποιημένο δεν θα σας ρωτάμε αν υπάρχουν αλλαγές που δεν έχουνε απόθηκευτεί.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Αυτόματη αποθήκευση τις τορινής συνεδρίασης περιοδικά</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2841,114 +2322,90 @@ kill the application with SIGKILL which could not be handled by the application.
 να κλείσετε την εφαρμογή.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Αυτόματη αποθήκευση συνεδρίασης περιοδικά</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>Το χρονικό διάστημα ανάμεσα σε δύο αυτόματες απόθηκεύσης της τορινής συνεδρίασης.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Μέγιστο ύψος δοκιμών</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>Το μέγιστο ύψος μιας δοκιμής χωρίς την γραμμή κύλισης σε εικονοστοιχεία.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Το πληρεξούσιο όνομα κεντρικού υπολογιστή π.χ. 127.0.0.1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Η θύρα του πληρεξούσιο π.χ. 1080</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Ο χρήστης του πληρεξούσιο server μπορεί να είναι άδειο αν ο πληρεξούσιος server δεν χεριάζεται αυθεντικοποίηση.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Ο κωδικός του πληρεξούσιο server μπορεί να είναι άδειο αν ο πληρεξούσιος server δεν χεριάζεται αυθεντικοποίηση.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Τύπος</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Όνομα κεντρικού υπολογιστή</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Θύρα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Χρήστης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Κωδικός</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Ο τύπος του πληρεξούσιου.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Χρησιμοποιήστε προσαρμοσμένη γραμματοσειρά για την εφαρμογή</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Χρησιμοποιήστε μια προσαρμοσμένη γραμματοσειρά για ολόκληρη την εφαρμογή αντιθέτος από την προκαθορισμένη γραμματοσειρά του συστηματός σας.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Εφαρμογή προσαρμοσμένης γραμματοσειράς</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>Η προσαρμοσμένη γραμματοσειρά ολόκληρης της εφαρμογής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 Έξοδος μεταγλωττιστή Codec</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Codec κειμένου για την έξοδο του μεταγλωττιστή (προβλήματα, προειδοποιήσεις κ.λ.π.)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Προκαθορισμένη διαδρομή για ονόματα και διαδρομές</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2957,185 +2414,98 @@ They can be either manually set or automatically changed after choosing a path f
 Μπορούν να οριστούν χειροκίνητα ή αυτόματα αφότου οριστεί μια διαδρομή για μια δράση.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Όνομα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>Το όνομα της προκαθορισμένης διαδρομής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>Η διαδρομή της προκαθορισμένης διαδρομής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>Η προκαθορισμένη διαδρομή χρησιμοποιείται όταν επιλέγεται μια διαδρομή για %1.
 Μπορείτε να χρησιμοποιήσετε ${&lt;default path name&gt;}.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Η προκαθορισμένες διαδρομές άλλαξαν αφότου διαλέξατε την διαδρομή %1.
 Είναι μια λίστα του &lt;default path name&gt;, χωρισμένο από κόμματα (επίσης, η λίστα μπορει να είναι άδεια).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Αποθήκευση αρχείου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Ανοιχτός διαγωνισμός</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Άνοιγμα αρχείου μιας δοκιμής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Εισάγεται ζευγάρια από δοκιμές</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Προσαρμοσμένος ελεγκτής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Εξαγωγή και εισαγωγή ρυθμίσεων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Εξαγωγή και φόρτωση συνεδρίασης</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Εξαγωγή και φόρτωση απόσπασμάτον</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Προκαθορισμένη διαδρομή που χρησιμοποιείται για %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Προκαθορισμένες διαδρομές άλλαξαν από %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Μπορεί να παρακαμπτεί από %1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Μορφοποίηση κώδικα από μη αυτόματη αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Μορφοποίηση κώδικα στην αυτόματη αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Αυτόματη φόρτωση εξωτερικών αλλαγμένων αρχείων αν δεν υπάρχουνε μη απόθηκευμένες τροποποίηση</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Αυτόματη φόρτωση τροποποιημένων αρχείων που δεν τροποποιήθηκαν στον συντάκτη CP αν δεν υπάρχουνε μη απόθηκευμένες τροποποιήσης στην συντάκτη CP.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Να φορτώσουμε τα τροποποιημένα εξωτερικά αρχεία</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -3146,39 +2516,32 @@ If this is disabled, external file changes will be ignored unless they are loade
 &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Όριο εξόδου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>Ο μέγιστος αριθμός των χαρακτήρων που μπορεί να εμφανίσει το πρόγραμμα.
 Αν η έξοδος είναι πολύ μεγάλη, τότε η έξοδος θα εξαφανιστεί.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Εμφάνιση μηνύματος για ετυμηγορίες υποβολής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Εμφάνιση μηνύματος όταν η ετυμηγορία της υποβολής είναι γνωστής. Μπορείτε να δείτε αυτό το μύνημα έξω από τον συνακτη CP.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Παράμετροι τερματικού</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Πρόγραμμα τερματικού</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -3187,7 +2550,6 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 Κάποιες πιθανές τιμές είναι konsole, gnome-terminal, xfce-terminal, xterm ή οποιοσδήποτε προσομοιωτής τερματικού.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -3196,15 +2558,10 @@ Consult your terminal emulator for the suitable arguments.</source>
 Ψάξτε τις κατάλληλες εντολές για το τερματικό σας.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Αποθήκευση δοκιμών σε ένα αρχείο</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -3215,12 +2572,10 @@ ${time}: ο χρόνος όταν αναλύεται το πρόβλημα
 ${json.X.Y}: αν η παράμετρος είναι από το Competitive Companion σας, μπορείτε να διαβάσετε παραπάνω στο https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Μορφοποίηση χρόνου για τα πάνω σχόλια</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -3231,368 +2586,281 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Προσθέστε &quot;Powered By CP Editor&quot; στα πάνω σχόλια</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Προσθέστε την γραμμή &quot;Powered By CP Editor&quot; στα πάνω σχόλια
 Αυτό δεν σασ κοστίζει τίποτα, αλλα βοηθάει άτομα να μάθουν τον συντάκτη CP.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Προκαθορισμένο χρονικό περιθώριο (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>Το προκαθορισμένο χρονικό περιθώριο κατα την εκτέλεση του προγράμματος.
 Το πρόγραμμα θα τερματιστεί αν δεν τερματιστεί μέσα στο χρονικό περιθώριο.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Χρησιμοποιήστε το χρονικό περιθώριο του Competitive Companion σας</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Χρησιμοποιήστε το χρονικό περιθώριο που αναλύθηκε από το Competitive Companion για το χρονικό περιθώριο την αντιστηχη καρτέλα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Εμφανίστε μόνο την Monospaced γραμματοσειρά</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Αλλαγή τοπικού</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Πρέπει να ξανανοίξεται τον συντάκτη CP για να οριστούνε οι αλλαγές.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Εμφάνιση μόνο monospaced γραμματοσειρών όταν επιλέγεται γραμματοσειρά</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Εμφάνιση μήκος δοκιμής</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Ο μέγιστος αριθμός των χαρακτήρων στη δοκιμή που είναι να εμφανιστεί.
 Η δοκιμή θα εξαφανιστεί και θα είναι μόνο για ανάγνωση αν είναι πολύ μεγάλη.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Πρόγραμμα μορφοποίησης Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Παράμετροι μορφοποίησης Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Η παράμετροι που θα περάσουν στην μορφοποίηση Clang ΔΕΝ ΠΡΕΠΕΙ να έχουνε την τιμή&quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Στύλ μορφοποίησης Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Πρόγραμμα YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>Το πρόγραμμα YAPF. Μπορεί να είναι &quot;yapf&quot; (που δεν χρειάζεται παραμέτρουσ) ή &quot;python&quot; (που χρειάζετε την παράμετρο &quot;-m yapf&quot;).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Παράμετροι YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Η παράμετροι που θα περάσουν στο πρόγραμμα YAPF ΔΕΝ ΠΡΕΠΕΙ να έχουνε την τιμή&quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Στύλ YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Οι ρυθμίσεις του στύλ YAPF έιναι συνήθως απόθηκευμένες σε ένα αρχείο με το όνομα .style.yapf ή setup.conf.
 Μπορείτε να μάθετε περισσότερα για το YAPF αν τρέξεται την εντολή &quot;yapf --style-help&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Να γίνεται μορφοποίηση κώδικα όταν τον απόθηκεύεται χειροκείνειτα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Να γίνεται μορφοποίηση κώδικα όταν απόθηκεύεται αυτόματα.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Περιεχόμενα τον πάνω σχολίων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Πληρεξούσιο δικτύου</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>Αυτόματη αναίρεση απόδεγμένων δοκιμών</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>Αυτόματη απόεπιλογή δοκιμών όταν γίνονται δεκτές.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>Η διαδρομή στο WakaTime εκτελέσιμο αρχείο</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Κλειδί API</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>Επιτροπή WakaTime</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>Επιτρέψτε την σύνδεση στο GitHub όσο ελέγχουμε για ενημερώσεις</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>Μπορεί να βρεθεί στο https://wakatime.com/settings/account.
 Μπορέι να είναι άδειο αν έχετε το παγκόσμιο αρχείο wakatime διαμόρφωση αρχείου ~/.wakatime.cfg.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>Χρησιμοποιήστε πληρεξούσιο</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>Χρησιμοποιήστε Προχωρημένα-&gt;Δίκτυο Πληρεξούσιου για απόστολή δεδομένων στο WakaTime.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>Επιτρέψτε το πληρεξούσιο για έλεγχο ενημερώσεων</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Η άγκυρα για την επιτροπή του μεταξούσιου για έλεγχο ενημερώσεις στην αντίστοίχη σελίδα https://cpeditor.org/docs/preferences</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Ενεργοποίηση εξομοίωσης Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Ενεργοποίηση εξομοίωσης Vim στον Επεξεργαστή Κώδικα</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Ρυθμίσεις Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Το περιεχόμενο του Vim RC. Φορτώνεται κάθε φορά που ξεκινά η εξομοίωση Vim.
@@ -3602,7 +2870,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Καθαρισμός συντόμευσης</translation>
     </message>
@@ -3610,52 +2877,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Εισαγωγή</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Εισαγωγή σειράς (Ctrl+N)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Αφαίρεση</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Διαγραφή της τορινής γραμμής (Ctrl+W)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Αφαίρεση αντικειμένου</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε την τωρινή σειρά;</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Μετακίνηση πάνω</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Μετακίνησης της τωρινής γραμμής πάνω (Ctrl+Shift+Up)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Μετακίνηση κάτω</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Μετακίνηση της τωρινής γραμμής κάτω (Ctrl+Shift+Down)</translation>
     </message>
@@ -3663,7 +2920,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Υποστήριξη / Προσφορά</translation>
     </message>
@@ -3671,42 +2927,34 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>Σας αρέσει ο συντάκτης CP;</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>Ευχαριστώ που χρησιμοποιείτε τον συντάκτη CP!</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Για να μας υποστειρίξετε μπορείτε να:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Μας δώσετε ένα αστέρι στο GitHub</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Μοιραστείτε τον συντάκτη CP στους φίλους σας</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Να μας υποστηρίξετε οικονομικά</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Να αναφέρεται τι μπορούμε να κάνουμε καλύτερα</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>Χρησιμοποιώ το @cpeditor_, είναι ένα IDE ειδικά σχεδιασμένο για competitive προγραμματιστές, που είναι τέλειο!</translation>
     </message>
@@ -3714,17 +2962,14 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>Δεν βρέθηκε η έκδοση.</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>Δεν βρέθηκε URL για την έκδοση [%1].</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Αυτό το πρόβλημα μάλλον είναι εξαιτίας της έλλιψης της βιβλιοθήκης OpenSSL. Μπορείτε να επησκεφθείτε την ιστοσελίδα &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; για να βρείτε μια βιβλιοθήκη να εγκαθαστείσετε. Πρέπει να εγκαταστείσετε μια εφαρμογή κατάλληλη με: [%1]</translation>
     </message>
@@ -3732,64 +2977,50 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="87"/>
-        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Απέτυχε να ανοίξει [%1]. Μήπως δεν έχετε άδεια εγγραφής;</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="97"/>
-        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Απέτυχε η αποθήκευση του [%1]. Έχετε άδεια εγγραφής;</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>Το αρχείο [%1] δεν υπάρχει</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Απέτυχε να ανοίξει [%1]. Μήπως δεν έχετε άδεια εγγραφής;</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Εμφάνιση %1 μέσα στο Finder</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Εμφάνιση %1 μέσα στον εξερευνητή</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Άνοιγμα φακέλου που περιέχει το %1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Εμφάνιση του %1 στον διαχειριστή αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3797,62 +3028,50 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Δημιουργία νέου διαγωνισμού</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Κύριος φάκελος</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Υποφάκελος</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Αριθμός προβλημάτων</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>Ο κύριος φάκελος δεν υπάρχει</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>Ο κύριος φάκελος [%1] δεν υπάρχει. Θέλετε να τον διμιουργήσετε και να συνεχίσετε;</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Απέτυχε η δημιουργία φακέλου</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Απέτυχε η δημιουργία φακέλου [%1].</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Λεπτομέρειες διαγωνισμού</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Αποθήκευση διαδρομής</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Επιλέξτε κύριο φάκελο</translation>
     </message>
@@ -3860,17 +3079,14 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Diff Viewer</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Αναμενόμενα</translation>
     </message>
@@ -3878,33 +3094,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation type="unfinished">Επαναφόρτωση</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3912,222 +3121,162 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Ανάγνωση testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Αποθήκευση testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Μεταγλωττιστής</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">Ξεπεράστηκε το χρονικό περιθώριο (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4135,72 +3284,58 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Είσοδος</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Αναμενόμενα</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Εκτέλεση</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Δοκιμή μιας δοκιμής</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Άνοιγμα του Diff Viewer</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Είσοδος #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Έξοδος #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Αναμενόμενο #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Διαγραφή δοκιμής</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε την δοκιμή #%1?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Diff Viewer[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>Η αναμενόμενη έξοδος μπορεί να είναι περισσότερο από %1 χαρακτήρες, ο HTML diff viewer είναι μη ενεργοποιημένος. Μπορείτε να αλλάξετε το όριο μήκους στο %2.</translation>
     </message>
@@ -4208,54 +3343,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Φόρτωση αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Τροποποίηση σε μεγαλύτερο παράθυρο</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Αλλαγή δοκιμής</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Είσοδος</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Αναμενόμενα</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Αποθήκευση σε αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Αποθήκευση δοκιμής σε αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Μόνο οι πρώτοι %1 χαρακτήρες εμφανίζονται. Τώρα ο συντάκτης δοκιμών είναι για ανάγνωση μόνο. Μπορείτε να αλλάξετε το όριο μήκους στο %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Αντιγραφή εξόδου στο αναμενόμενο</translation>
     </message>
@@ -4263,223 +3386,173 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Δοκιμές</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Ελεγκτής:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Εισάγεται δοκιμή</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Περισσότερα</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Εισαγωγή ελεγκτή</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Εισαγωγή προσαρμοσμένου testlib ελεκτή</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Εισάγετε ζευγάρια δοκιμών απο αρχεία</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Επιλογή αρχείων δοκιμών</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Φόρτωση δοκιμών</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Ένα ζευγάρι απο δοκιμές [%1] και [%2] είναι φορτωμένο</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Η είσοδος [%1] είναι φορτωμένη</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Τα παρακάτω αρχεία δεν φορτώθηκαν επειδή δεν έχουνε ταυτοποιηθή:%1. Μπορείτε να αλλάξετε τους κανόνες ταυτοποίησης στο %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε όλες τις δοκιμές;</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Αντιστροφή</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Αγνόηση επόμενων κενών</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Απαραίτητως τα ίδια</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Compare int64s</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Compare doubles, max error 1e-4</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Compare doubles, max error 1e-6</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Compare doubles, max error 1e-9</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Σύγκριση tokens</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Σύγκριση YES/NOs, case insensitive</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Εισαγωγή δοκιμής</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Υπάρχουνε ίδη οι %1 δοκιμές, δεν μπορείτε να προσθέσεται παραπάνω.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Εισαγωγή #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Αναμενόμενο #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Αποθήκευση εισόδου #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Αποθήκευση αναμενόμενων #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Φόρτωση %1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Δοκιμές</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>Μη αποδεκτές / Αποδεκτές / Συνολικά</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Τσεκάρισμα όλων</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Uncheck All</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Uncheck αποδεγμένα</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Διαγραφή όλων</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Διαγραφή άδειων</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Διαγραφεί τσεκαρισμένο</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε όλες τις τσεκαρισμένες δοκιμές;</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Αντιγραφή δοκιμών</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Επικόληση δοκιμών</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Αντιγραφή εξόδου στο αναμενόμενο</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Είστε σίγουροι ότι θέλετε να αντιγράψετε όλη την τσεκαρισμένη έξοδο στα αντοίστιχα αναμενόμενα;</translation>
@@ -4488,32 +3561,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Λήψη</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Υπάρχει νέα έκδοση</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>μια νέα %1 έκδωση &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; είναι διαθέσιμη. Δείτε παρακάτω για τις αλλαγε.&lt;br /&gt; Συστίνουμε να κρατήσετε τον συντάκτη ενημερομένο ώστε να μην χάσεται νέες λειτουργίες.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>Beta</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>Stable</translation>
     </message>
@@ -4521,37 +3588,30 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Κλείστε αυτόν τον κατάλογο και ματαιώσετε τον έλεγχο ενημερόσεων</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Ελεχτής ενημερόσεων</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Λήψη λίστα ενημερώσεων...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Σφάλμα: %1&lt;br /&gt;&lt;br /&gt; Ο ενημερωτής απέτυχε να ελέξη για ενημερώσης. Παρακαλώ δείτε χειροκίνιτα τις ενημερώσεις στο &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/ru/download&quot;&gt;https://cpeditor.org/ru/download&lt;/a&gt; ή &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translatorcomment>The most suitable translation</translatorcomment>
         <translation>Μπράβο, χρησομοποιήτε την τελευτέα έκδοση του CP συντάκτη.</translation>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -4,54 +4,67 @@
 <context>
     <name>AppWindow</name>
     <message>
+        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Abrir archivos recientes</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>No se ha abierto ningún archivo recientemente</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Borrar archivos recientes</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Salida rápida</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>En la última sesión, CP Editor ha finalizado de manera inesperada, ¿Desea restaurar la última sesión?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Mostrar ventana principal</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Abriendo archivos</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>Acerca de CP Editor %1</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; es un editor de código basado en Qt. Está especialmente diseñado para la programación competitiva, a diferencia de otros editores/IDEs que son principalmente para desarrolladores. Te ayuda a enfocarte en tu algoritmo y automatiza la compilación, ejecución y prueba. ¡Incluso obtiene casos de prueba por ti de diferentes plataformas, y envía soluciones a Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Ese es un software libre; vea el código fuente para las condiciones de copia. NO hay ninguna garantía; ni siquiera para COMERCIALIZACIÓN o ADECUACIÓN PARA UN PROPÓSITO PARTICULAR. El código fuente de CP Editor está disponible en &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Información de compilación</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -64,553 +77,604 @@ Tiempo de compilación: %4
 Sistema Operativo: %5</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Versión portable</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Versión de instalación</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Abrir archivos</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Guardar todo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Restablecer preferencias</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>¿Estás seguro de que quieres restablecer todas las preferencias a los valores predeterminados?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Exportar configuración a un archivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="779"/>
+        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Archivo de configuración de CP Editor</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Importar configuración</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Todas las configuraciones actuales se perderán después de importar configuraciones de un archivo. ¿Estás seguro de que deseas continuar?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Importar configuración desde un archivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Exportar sesión actual a un archivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="807"/>
+        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Archivo de sesión de CP Editor</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Exportar sesión</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Error al exportar la sesión actual a [%1]</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Cargar sesión</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Cargar una sesión desde un archivo cerrará todas las pestañas de la sesión actual sin guardar los archivos. ¿Estás seguro de que deseas continuar?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Cargar sesión desde un archivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: Un editor especialmente diseñado para programación competitiva</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1316"/>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>Snippets</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>No hay snippets para %1. Por favor, agregue snippets en la ventana de preferencias.</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Utilizar snippets</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Seleccione un snippet:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>No hay ningún snippet llamado %1 para %2</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>Cómo salir de pantalla completa</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>Presiona la tecla F11 para salir del modo pantalla completa.</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Cerrar otros</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Cerrar a la izquierda</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Cerrar a la derecha</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Cerrar guardado</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Cerrar todo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Duplicar pestaña</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Establecer comando de compilación</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Establecer límite de tiempo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Archivo de origen</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Archivo ejecutable</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Copiar ruta del archivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Abrir problema en el navegador</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Copiar URL del problema</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Establecer URL de Codeforces</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Establecer URL de CF</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Ingrese el ID del concurso:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Ingrese el código del problema (A-Z):</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1602"/>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Establecer URL del problema</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Ingrese la URL del nuevo problema:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Registrador de eventos</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Todos los registros, excepto la sesión actual, han sido eliminados</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation>Nuevo archivo</translation>
+        <translation type="vanished">Nuevo archivo</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation>Abrir una nueva pestaña en el editor</translation>
+        <translation type="vanished">Abrir una nueva pestaña en el editor</translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation>Guardar el archivo en el disco</translation>
+        <translation type="vanished">Guardar el archivo en el disco</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Guardar como...</translation>
+        <translation type="vanished">Guardar como...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation>Guardar como nuevo archivo</translation>
+        <translation type="vanished">Guardar como nuevo archivo</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation>Guardar todos los archivos abiertos</translation>
+        <translation type="vanished">Guardar todos los archivos abiertos</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation>Cerrar actual</translation>
+        <translation type="vanished">Cerrar actual</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation>Cerrar pestaña actual</translation>
+        <translation type="vanished">Cerrar pestaña actual</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation>Cerrar pestañas guardadas</translation>
+        <translation type="vanished">Cerrar pestañas guardadas</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation>Cerrar todas las pestañas</translation>
+        <translation type="vanished">Cerrar todas las pestañas</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation>Salir de la aplicación</translation>
+        <translation type="vanished">Salir de la aplicación</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation>Abrir archivo...</translation>
+        <translation type="vanished">Abrir archivo...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation>Abrir archivos</translation>
+        <translation type="vanished">Abrir archivos</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation>Abrir concurso...</translation>
+        <translation type="vanished">Abrir concurso...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation>Abrir un concurso</translation>
+        <translation type="vanished">Abrir un concurso</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation>Indentar</translation>
+        <translation type="vanished">Indentar</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation>Desindentar</translation>
+        <translation type="vanished">Desindentar</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation>Intercambiar línea arriba</translation>
+        <translation type="vanished">Intercambiar línea arriba</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation>Intercambiar línea abajo</translation>
+        <translation type="vanished">Intercambiar línea abajo</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation>Duplicar línea</translation>
+        <translation type="vanished">Duplicar línea</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation>Eliminar línea</translation>
+        <translation type="vanished">Eliminar línea</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation>Alternar comentarios</translation>
+        <translation type="vanished">Alternar comentarios</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation>Alternar comentario de bloque</translation>
+        <translation type="vanished">Alternar comentario de bloque</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Compilar</translation>
+        <translation type="vanished">Compilar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Compilar y ejecutar</translation>
+        <translation type="vanished">Compilar y ejecutar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Ejecutar</translation>
+        <translation type="vanished">Ejecutar</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation>Formatear código</translation>
+        <translation type="vanished">Formatear código</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation>Ejecutar desconectado</translation>
+        <translation type="vanished">Ejecutar desconectado</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation>Terminar procesos</translation>
+        <translation type="vanished">Terminar procesos</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation>Buscar y reemplazar</translation>
+        <translation type="vanished">Buscar y reemplazar</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation>Utilizar snippet...</translation>
+        <translation type="vanished">Utilizar snippet...</translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation>Preferencias</translation>
+        <translation type="vanished">Preferencias</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation>Reestablecer configuración</translation>
+        <translation type="vanished">Reestablecer configuración</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation>Exportar configuración...</translation>
+        <translation type="vanished">Exportar configuración...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation>Importar configuración...</translation>
+        <translation type="vanished">Importar configuración...</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation>Exportar sesión...</translation>
+        <translation type="vanished">Exportar sesión...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation>Cargar sesión...</translation>
+        <translation type="vanished">Cargar sesión...</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation>Manual</translation>
+        <translation type="vanished">Manual</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation>Reportar problemas</translation>
+        <translation type="vanished">Reportar problemas</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation>Acerca de Qt</translation>
+        <translation type="vanished">Acerca de Qt</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation>Buscar actualizaciones</translation>
+        <translation type="vanished">Buscar actualizaciones</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation>Apóyanos</translation>
+        <translation type="vanished">Apóyanos</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation>Modo editor</translation>
+        <translation type="vanished">Modo editor</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation>Modo E/S</translation>
+        <translation type="vanished">Modo E/S</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation>Modo dividido</translation>
+        <translation type="vanished">Modo dividido</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation>Pantalla completa</translation>
+        <translation type="vanished">Pantalla completa</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation>Mostar archivos de registro</translation>
+        <translation type="vanished">Mostar archivos de registro</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation>Borrar archivos de registro</translation>
+        <translation type="vanished">Borrar archivos de registro</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Archivo</translation>
+        <translation type="vanished">&amp;Archivo</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Editar</translation>
+        <translation type="vanished">&amp;Editar</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation>&amp;Acciones</translation>
+        <translation type="vanished">&amp;Acciones</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation>&amp;Visualizar</translation>
+        <translation type="vanished">&amp;Visualizar</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation>&amp;Opciones</translation>
+        <translation type="vanished">&amp;Opciones</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Ayuda</translation>
-    </message>
-    <message>
-        <source>Stress Testing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with generator template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New File From Template</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">&amp;Ayuda</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="unfinished">C++</translation>
-    </message>
-    <message>
-        <source>Open a new tab with C++ template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="unfinished">Java</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Java template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="unfinished">Python</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Python template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Eliminar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Renombrar snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Cargar snippets desde archivos</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Extraer snippets a archivos</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Ningún snippet seleccionado</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Snippet no guardado</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>El snippet [%1] ha sido modificado. ¿Desea guardarlo, o descartar los cambios?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Eliminar snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>¿Seguro que quiere eliminar el snippet [%1]?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Cargar snippets</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Error al abrir [%1]. ¿Tengo permiso de lectura?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Extraer snippets</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Extraer Snippets: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Error al escribir en [%1]. ¿Tengo permiso de escritura?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>El nombre del snippet no puede estar vacío.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Conflicto de nombre de snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>El nombre &quot;%1&quot; ya está en uso. ¿Quieres sobrescribirlo? (Se eliminará el viejo snippet con este nombre.)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>El nombre &quot;%1&quot; ya está en uso.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Añadir snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Nombre de nuevo snippet:</translation>
     </message>
@@ -618,68 +682,93 @@ Sistema Operativo: %5</translation>
 <context>
     <name>Core::Checker</name>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Verificador de lectura</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
+        <location filename="../src/Core/Checker.cpp" line="99"/>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
+        <location filename="../src/Core/Checker.cpp" line="301"/>
+        <location filename="../src/Core/Checker.cpp" line="302"/>
+        <location filename="../src/Core/Checker.cpp" line="303"/>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Verificador</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Error al crear directorio temporal</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Leer testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Guardar testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Inició la compilación del verificador</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>El verificador está compilado</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Se produjo un error al compilar el verificador:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Error al compilar el verificador: %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Límite de tiempo excedido</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>El verificador finalizó con el código de salida %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>El verificador finalizó con un código de salida desconocido %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>El %1 del proceso que se ejecuta en el caso de prueba #%2 contiene más de %3 caracteres, lo que es más largo que el límite de longitud de salida, por lo que se cancela el proceso. Puedes cambiar el límite de longitud de salida en %4.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>El verificador ha sido cancelado</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Verificador[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>El código fuente del verificador ha cambiado, recompilando...</translation>
     </message>
@@ -687,18 +776,22 @@ Sistema Operativo: %5</translation>
 <context>
     <name>Core::Compiler</name>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>El archivo de origen [%1] no existe</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 está vacío</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Lenguaje de programación no compatible &quot;%1&quot;</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>Error al iniciar el compilador. Compruebe %1 o agregue el compilador en la variable de entorno PATH.</translation>
     </message>
@@ -706,32 +799,39 @@ Sistema Operativo: %5</translation>
 <context>
     <name>Core::Runner</name>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>El archivo de origen %1 no existe.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Error al obtener el comando de ejecución. Probablemente sea un error.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>Error al crear el archivo temporal.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>El programa finalizó con el código de salida %1
 Presione cualquier tecla para salir</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>La ejecución desacoplada no es compatible con su plataforma</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Error al iniciar la ejecución desacoplada. Compruebe la configuración de su emulador de terminal en %1.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Error al iniciar la ejecución. Compile primero, por favor.</translation>
     </message>
@@ -739,10 +839,12 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Core::SessionManager</name>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Restaurando la última sesión</translation>
     </message>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Restaurando: [%1]</translation>
     </message>
@@ -750,42 +852,52 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` no requiere argumento o debe ser uno de &apos;cpp&apos;, &apos;java&apos; o &apos;python&apos;, se obtuvo [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] no es un archivo fuente de C++, Python o Java</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] no existe. Para abrir una pestaña con un archivo inexistente, use `open!`</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] no es un número</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 está fuera del rango [1, %2]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">N/D</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] no es un modo de vista válido. Debe ser &apos;split&apos; o &apos;edit&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 no es un nombre de lenguaje válido. Debe ser &apos;cpp&apos;, &apos;java&apos; o &apos;python&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">No hay pestaña activa para limpiar mensajes</translation>
     </message>
@@ -793,42 +905,63 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::CFTool</name>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>Se canceló CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>El código del problema es 0, ahora usa A automáticamente. Si el código del problema real no es A, establece el código del problema manualmente en el menú contextual de la pestaña actual.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Error al obtener la versión de CF Tool. ¿Has establecido la ruta correcta a CF Tool en Preferencias?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool ha comenzado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Error al iniciar CF Tool en 2 segundos. ¿Has establecido la ruta correcta a CF Tool en Preferencias?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Error al analizar la URL [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>CF Tool falló</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool finalizó con un código de salida diferente a cero %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Concurso %1 Problema %2</translation>
     </message>
@@ -836,34 +969,50 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Formateador</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Error al crear directorio temporal</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Formateo completado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>El proceso de formateo no se completó en 2 segundos. Esto es probablemente debido a que el programa %1 no se encuentra por CP Editor. Puedes establecer la ruta al programa en %2.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>El comando de formateo [%1 %2] finalizó con el código de salida %3.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Formateador[stdout]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Formateador[stderr]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>La salida del proceso de formateo está vacía. Asegúrese de que no haya ninguna opción de modificación en los argumentos de formateo.</translation>
     </message>
@@ -871,32 +1020,39 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>Se ha recibido y se ha ignorado una solicitud %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>La solicitud recibida no es JSON</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>El servidor está cerrado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>El puerto está configurado en %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Error al escuchar en el puerto %1. ¿Hay otro proceso escuchando?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>El analizador de JSON informó errores:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Servidor detenido</translation>
     </message>
@@ -904,30 +1060,42 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Servidor de lenguaje [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>El servidor de lenguaje envió un error. Consulte el registro para obtener más detalles.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Error al iniciar el proceso LSP. ¿Ha configurado la ruta al programa del servidor de lenguaje en %1?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Se agotó el tiempo de espera del proceso LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Error de lectura del proceso LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Error de escritura del proceso LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Ha ocurrido un error desconocido en el proceso LSP</translation>
     </message>
@@ -936,50 +1104,50 @@ Presione cualquier tecla para salir</translation>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation>Buscar/Reemplazar</translation>
+        <translation type="vanished">Buscar/Reemplazar</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation>Formulario</translation>
+        <translation type="vanished">Formulario</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation>Buscar:</translation>
+        <translation type="vanished">Buscar:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation>Reemplazar con:</translation>
+        <translation type="vanished">Reemplazar con:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation>Etiqueta de error</translation>
+        <translation type="vanished">Etiqueta de error</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation>Dirección</translation>
+        <translation type="vanished">Dirección</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation>Arriba</translation>
+        <translation type="vanished">Arriba</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation>Abajo</translation>
+        <translation type="vanished">Abajo</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Opciones</translation>
+        <translation type="vanished">Opciones</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation>Sensible a mayúsculas y minúsculas</translation>
+        <translation type="vanished">Sensible a mayúsculas y minúsculas</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation>Solo palabras completas</translation>
+        <translation type="vanished">Solo palabras completas</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -990,7 +1158,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1001,56 +1169,79 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation>Expresión regular</translation>
+        <translation type="vanished">Expresión regular</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation>Buscar</translation>
+        <translation type="vanished">Buscar</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation>Reemplazar</translation>
+        <translation type="vanished">Reemplazar</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation>Reemplazar todo</translation>
+        <translation type="vanished">Reemplazar todo</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Auto guardar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="185"/>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Compilador</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Por favor, establezca el idioma</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="218"/>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="242"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1492"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Ejecutor</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Idioma incorrecto, por favor establezca el idioma</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Todas las entradas están vacías, no hay nada para ejecutar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Enviar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Seguro de enviar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1061,102 +1252,131 @@ URL: %1
 Idioma: %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="328"/>
+        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Error al guardar el archivo temporal y la solución no se envía.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Necesita instalar CF Tool para enviar su código a Codeforces. Si ya está instalado, puede agregarlo en la variable de entorno PATH o verificar sus configuraciones en %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Sin título-%1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Atributo desconocido: [%1]. Por favor revise la configuración de comentarios de cabecera en %2.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Abrir plantilla de %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1017"/>
+        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>El archivo [%1] contiene más de %2 caracteres, por lo que no se abre. Puede cambiar el límite de longitud de archivo abierto en %3.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Guardar archivo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
+        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Archivo temporal</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Error al crear el archivo temporal</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Establecer comando de compilación</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Comando de compilación personalizado para esta pestaña:</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Establecer límite de tiempo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Límite de tiempo personalizado para esta pestaña: (ms)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Leer Plantilla de %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Guardar cambios</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>¿Guardar los cambios en [%1] antes de cerrar?</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Nuevo archivo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Establecer idioma de pestaña</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Establecer el idioma a utilizar en esta pestaña</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Recargar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1167,129 +1387,153 @@ ha sido cambiado en el disco.
 ¿Quieres recargarlo?</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Línea %1, Columna %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>%1 líneas, %2 caracteres seleccionados</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>%1 caracteres seleccionados</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>La compilación ha comenzado</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>La compilación ha terminado</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Advertencias de compilación</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Se produjo un error al compilar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1517"/>
+        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Errores de compilación</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>¿Has establecido un nombre adecuado para la clase principal en tu solución? Si no, puedes establecerlo en %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Error al iniciar la compilación: %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>La compilación es cancelada</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>Ejecutor desconectado</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Ejecutor[%1]</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>La ejecución ha comenzado</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>La ejecución para el caso de prueba #%1 ha terminado en %2ms</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Límite de tiempo excedido</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>La ejecución para el caso de prueba #%1 ha terminado con un código de salida diferente a cero %2 en %3ms</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>El %1 del proceso en ejecución en el caso de prueba #%2 contiene más de %3 caracteres, lo cual es más largo que el límite de longitud de salida, por lo que se cancela el proceso. Puede cambiar el límite de longitud de salida en %4.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 ha sido cancelado</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>Ejecutor desconectado</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Ejecutor para el caso de prueba #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation>CP Editor</translation>
+        <translation type="vanished">CP Editor</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation>información del cursor</translation>
+        <translation type="vanished">información del cursor</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Compilar</translation>
+        <translation type="vanished">Compilar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Ejecutar</translation>
+        <translation type="vanished">Ejecutar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Compilar y ejecutar</translation>
+        <translation type="vanished">Compilar y ejecutar</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation>Mensajes</translation>
+        <translation type="vanished">Mensajes</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Limpiar</translation>
+        <translation type="vanished">Limpiar</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation>C++</translation>
+        <translation type="vanished">C++</translation>
     </message>
 </context>
 <context>
     <name>MessageLogger</name>
     <message>
+        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1299,34 +1543,42 @@ ha sido cambiado en el disco.
 <context>
     <name>ParenthesesPage</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 Paréntesis</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Eliminar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Ningún paréntesis seleccionado</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Nuevo paréntesis</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Ingrese un paréntesis (por ejemplo, {}):</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Eliminar paréntesis</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>¿Seguro que quiere eliminar el paréntesis %1?</translation>
     </message>
@@ -1334,24 +1586,29 @@ ha sido cambiado en el disco.
 <context>
     <name>ParenthesisWidget</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Paréntesis: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Habilitar %1 para %2 en %3.
 Si está parcialmente marcado, la configuración global en Editar Código t se utilizará.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Autocompletar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Autoeliminar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Salir de la pestaña</translation>
     </message>
@@ -1359,18 +1616,25 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PathItem</name>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="41"/>
+        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Elige un archivo</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Archivos ejecutables</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="84"/>
+        <location filename="../src/Settings/PathItem.cpp" line="86"/>
+        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Elige un archivo de origen de %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Elige un archivo ejecutable</translation>
     </message>
@@ -1378,34 +1642,42 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PreferencesHomePage</name>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>¡Bienvenido a CP Editor! Comencemos.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Configuración del editor de código</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Comandos de compilación y ejecución de C++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Comandos de compilación y ejecución de Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Comandos de ejecución de Python</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Configuración de apariencia</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Configuración de fuente</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>Puedes leer la &lt;a href=&quot;%1&quot;&gt;documentación&lt;/a&gt; o revisar las configuraciones para obtener más información.</translation>
     </message>
@@ -1413,34 +1685,42 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PreferencesPage</name>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Restaurar la configuración predeterminada en la página actual. (Ctrl+D)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Descartar todos los cambios en la página actual. (Ctrl+R)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Guardar los cambios en la página actual. (Ctrl+S)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Configuración sin guardar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>La configuración ha cambiado. ¿Quieres guardar la configuración o descartarla?</translation>
     </message>
@@ -1448,321 +1728,413 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PreferencesWindow</name>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
+        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Inicio</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Ir a la página de inicio</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation>Editar código</translation>
+        <translation type="vanished">Editar código</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation>Idioma</translation>
+        <translation type="vanished">Idioma</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>General</translation>
+        <translation type="vanished">General</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 Comandos</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 Plantilla</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 Snippets</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 Paréntesis</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation>Apariencia</translation>
+        <translation type="vanished">Apariencia</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation>Fuente</translation>
+        <translation type="vanished">Fuente</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation>Acciones</translation>
+        <translation type="vanished">Acciones</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="vanished">Guardar</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation>Auto guardar</translation>
+        <translation type="vanished">Auto guardar</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation>Ejecución desconectada</translation>
+        <translation type="vanished">Ejecución desconectada</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation>Guardar sesión</translation>
+        <translation type="vanished">Guardar sesión</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation>Vincular archivo y problema</translation>
+        <translation type="vanished">Vincular archivo y problema</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation>Casos de prueba</translation>
+        <translation type="vanished">Casos de prueba</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation>Cargar cambios en archivo externo</translation>
+        <translation type="vanished">Cargar cambios en archivo externo</translation>
     </message>
     <message>
         <source>Stopwatch</source>
-        <translation>Cronómetro</translation>
+        <translation type="vanished">Cronómetro</translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation>Extensiones</translation>
+        <translation type="vanished">Extensiones</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation>Formato de código</translation>
+        <translation type="vanished">Formato de código</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation>Clang Format</translation>
+        <translation type="vanished">Clang Format</translation>
     </message>
     <message>
         <source>YAPF</source>
-        <translation>YAPF</translation>
+        <translation type="vanished">YAPF</translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation>Servidor de lenguaje</translation>
+        <translation type="vanished">Servidor de lenguaje</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>%1 Servidor</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation>Competitive Companion</translation>
+        <translation type="vanished">Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation>CF Tool</translation>
+        <translation type="vanished">CF Tool</translation>
     </message>
     <message>
         <source>WakaTime</source>
-        <translation>WakaTime</translation>
+        <translation type="vanished">WakaTime</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation>Ruta de archivo</translation>
+        <translation type="vanished">Ruta de archivo</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation>Casos de prueba</translation>
+        <translation type="vanished">Casos de prueba</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation>URL del problema</translation>
+        <translation type="vanished">URL del problema</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation>Rutas predeterminadas</translation>
+        <translation type="vanished">Rutas predeterminadas</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation>Asignaciones de teclas</translation>
+        <translation type="vanished">Asignaciones de teclas</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation>Avanzado</translation>
+        <translation type="vanished">Avanzado</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation>Actualizar</translation>
+        <translation type="vanished">Actualizar</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation>Límites</translation>
+        <translation type="vanished">Límites</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation>Proxy de red</translation>
-    </message>
-    <message>
-        <source>Stress Testing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator Template</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Proxy de red</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Ancho de tabulador</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>El ancho del carácter de tabulación o el número de espacios de una sangría</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>Ancho del cursor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>El ancho del cursor en píxeles</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Fuente del editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>La fuente del editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Usar fuente de aplicación personalizada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Usar una fuente personalizada para toda la aplicación en lugar de la fuente predeterminada del sistema.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Fuente de aplicación personalizada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>La fuente personalizada para toda la aplicación</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Idioma predeterminado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>El idioma predeterminado utilizado al abrir nuevas pestañas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Programa Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>La ruta del archivo ejecutable de Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Argumentos de Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Los argumentos pasados a clang-format. NO debe contener &quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Estilo de Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Las opciones de estilo de Clang Format, que suelen guardarse en un archivo de configuración .clang-format.
 Puede obtener más información en &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Programa YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>El programa de YAPF. Puede ser `yapf` (que no necesita argumentos) o `python` (que necesita `-m yapf` como argumentos).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Argumentos de YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Los argumentos pasados al programa YAPF. NO debe contener &quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Estilo de YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Las opciones de estilo de YAPF, que suelen guardarse en un archivo de configuración .style.yapf o setup.conf.
 Puede obtener más información sobre ellas ejecutando `yapf --style-help`.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Formatear código en guardado manual</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Formatear el código al guardarlo manualmente.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Formatear código en autoguardado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Formatear código al guardar automáticamente.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>Ruta de plantilla de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>La plantilla utilizada al crear un nuevo archivo de C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>Regex de posición del cursor en plantilla de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -1771,34 +2143,53 @@ Cuando se abre una plantilla, la posición del cursor es la posición de la expr
 El cursor estará al final de la plantilla si no hay coincidencia con la expresión regular.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>Tipo de desplazamiento de posición del cursor en plantilla de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Si el desplazamiento es relativo al inicio de la expresión regular o al final de la expresión regular.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>Caracteres de desplazamiento de posición del cursor en plantilla de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>El desplazamiento relativo a la coincidencia de la expresión regular en número de caracteres, incluyendo espacios en blanco.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>Comando de compilación de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>El comando utilizado para compilar C++. NO debe incluir la ruta al archivo fuente ni &quot;-o &lt;archivo de salida&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>Ruta del archivo ejecutable de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -1813,48 +2204,62 @@ Puede usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${tmpdir}&quot; o &quot;${tempdir}&quot; para la ruta absoluta del directorio temporal.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>Argumentos de ejecución de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Los argumentos utilizados al ejecutar un programa de C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>La plantilla utilizada al crear un nuevo archivo de Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>El comando utilizado para compilar Java.
 NO debe incluir la ruta al archivo fuente ni la ruta del archivo de clase compilado.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Los argumentos utilizados al ejecutar un programa de Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>Comando de ejecución de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>El comando para iniciar un programa de Java. NO debe incluir &quot;-classpath &lt;ruta&gt; &lt;nombre de clase&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>Nombre de clase %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>El nombre de la clase principal de su solución.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>Ruta de clase de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -1867,30 +2272,37 @@ Puede usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${tmpdir}&quot; o &quot;${tempdir}&quot; para la ruta absoluta del directorio temporal.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>La plantilla utilizada al crear un nuevo archivo de Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Los argumentos utilizados al ejecutar un programa de Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>El comando para iniciar un programa de Python. NO debe incluir la ruta al archivo fuente.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Tema del editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>El tema de resaltado de sintaxis del editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Programa de terminal</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -1899,10 +2311,12 @@ Este es normalmente el nombre o la ruta del emulador de terminal.
 Algunos valores posibles son konsole, gnome-terminal, xfce-terminal, xterm u otro programa de emulador de terminal.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Argumentos de terminal</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -1911,10 +2325,12 @@ Este es &quot;-e&quot; para la mayoría de los emuladores de terminal, incluyend
 Consulte a su emulador de terminal para conocer los argumentos adecuados.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Autocompletar paréntesis</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -1923,10 +2339,12 @@ y salir de él al escribir el elemento derecho.
 Esto se puede sobrescribir para cada paréntesis en cada idioma.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Autoeliminar paréntesis</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -1935,10 +2353,12 @@ el elemento izquierdo de él si los dos elementos están adyacentes.
 Esto se puede sobrescribir para cada paréntesis en cada idioma.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Salir de un paréntesis presionando Tab</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -1947,30 +2367,37 @@ paréntesis de cierre para salir de un paréntesis.
 Esto se puede sobrescribir para cada paréntesis en cada idioma.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Indentación automática</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Añade una indentación al introducir una nueva línea después de un &quot;{&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Habilitar Auto Guardado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Intervalo de auto-guardado (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>El intervalo de tiempo entre una modificación y un auto-guardado, o entre dos auto-guardados.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Tipo de intervalo de auto-guardado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -1979,90 +2406,122 @@ Después de la primera modificación: el cronómetro comenzará después de una 
 Sin modificación: la auto-guardado ocurre con un intervalo constante independientemente de si hay modificaciones o no.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Ajustar texto</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Ajusta una línea en varias líneas si no cabe en la pantalla.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Enable Ctrl+Scroll to change font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Usar la versión beta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Comprueba las actualizaciones marcadas como pre-lanzamientos, que se consideran no muy estables pero tienen más características.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Reemplazar tabulaciones por espacios</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Usa espacios en lugar de un carácter de tabulación.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Guardar casos de prueba al guardar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Guarda los casos de prueba en el disco al guardar un archivo y cargar los casos de prueba guardados al abrir un archivo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Comprobar actualizaciones al inicio</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Comprueba si hay una nueva versión de CP Editor al iniciar CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Opacidad</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>La opacidad de la ventana principal</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Habilitar Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Recibir los datos enviados por Competitive Companion y cargar los casos de prueba de ejemplo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Puerto de conexión</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>El puerto utilizado para recibir datos de Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Abrir nuevas pestañas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Abrir una nueva pestaña para cada problema analizado por Competitive Companion.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Utilizar el límite de tiempo de Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Utilizar el límite de tiempo analizado por Competitive Companion como el límite de tiempo de la pestaña correspondiente.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Contenido de los comentarios de cabecera</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2073,10 +2532,12 @@ ${time}: el momento en que se analiza el problema
 ${json.X.Y}: un atributo de los datos proporcionados por Competitive Companion, puedes leer más en https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Formato de tiempo para los comentarios de cabecera</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2087,58 +2548,71 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Añadir &quot;Powered By CP Editor&quot; en los comentarios de encabezado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Añade una línea que diga &quot;Powered By CP Editor&quot; en los comentarios de encabezado.
 Esto no le cuesta nada, pero ayuda a más personas a conocer CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Formatear código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Terminar todos los procesos</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Compilar y ejecutar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Sólo ejecutar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Sólo compilar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Cambiar modo de vista</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Utilizar snippets</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Restaurar la última sesión al inicio</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Restaurar la última sesión cuando se inicia la aplicación.
 Cuando esto está habilitado, no se le preguntará si desea guardar los archivos sin guardar al salir.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Auto-guardar la sesión actual periódicamente</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2147,214 +2621,280 @@ Esto es útil si su computadora se congela y tiene que cortar la energía o
 matar la aplicación con SIGKILL que no puede ser manejada por la aplicación.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Intervalo de auto-guardado de sesión</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>El intervalo de tiempo entre dos auto-guardados de la sesión actual.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Ruta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>La ruta del archivo ejecutable de CF Tool</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Mostrar notificaciones del sistema para los veredictos de envío</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Mostrar una notificación del sistema cuando se conoce el veredicto de un envío. Puede ver el mensaje fuera de CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Mostrar únicamente compilar y ejecutar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Ocultar el botón Solo compilar y el botón Solo ejecutar debajo del editor de código en la ventana principal.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Mostrar EOLN (Fin de línea) en diferencias</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Usar &quot;¶&quot; para representar el carácter de nueva línea en el visor de diferencias HTML.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Guardar archivos más rápido</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Siempre usa QFile en lugar de QSaveFile para guardar archivos.
 Esto será más rápido pero con un poco más de riesgo de perder el archivo (con una muy pequeña posibilidad).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Límite de tiempo predeterminado (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>El límite de tiempo predeterminado al ejecutar el programa.
 El programa será cancelado si no finaliza en el límite de tiempo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Límite de longitud de salida</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>El número máximo de caracteres en la salida del programa.
 El programa será cancelado si cualquiera de su stdout o stderr es demasiado largo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Límite de longitud de visualización de salida</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>El número máximo de caracteres que se mostrarán para la salida del programa.
 Si la salida es demasiado larga, se cortará.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Límite de longitud de mensaje</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>El número máximo de caracteres en cada mensaje en la esquina superior derecha de la ventana principal.
 El mensaje se cortará si es demasiado largo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>Límite de longitud del visualizador de diferencias HTML</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>El número máximo de caracteres en el visualizador de diferencias HTML.
 El visualizador de diferencias volverá al texto sin formato si la salida o la salida esperada son demasiado largas.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Límite de longitud de archivo abierto</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>El número máximo de caracteres en un archivo de origen para abrirlo.
 Un archivo de origen no se abrirá si es demasiado largo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Límite de longitud de visualización del caso de prueba</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>El número máximo de caracteres en un caso de prueba para ser mostrado.
 Un caso de prueba se cortará y sólo lectura si es demasiado largo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Ruta al ejecutable LSP</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>La ruta al ejecutable del servidor de lenguaje de C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>La ruta al ejecutable del servidor de lenguaje de Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>La ruta al ejecutable del servidor de lenguaje de Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Usar verificación de linting con el servidor de lenguaje</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Mostrar errores, advertencias, información y sugerencias en el editor de código para el lenguaje de C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Mostrar errores, advertencias, información y sugerencias en el editor de código para el lenguaje de Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Mostrar errores, advertencias, información y sugerencias en el editor de código para el lenguaje de Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Usar auto-completado con el servidor de lenguaje</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Usar resultados de autocompletar del servidor de lenguaje</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Retraso en verificación de linting (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Retraso en verificación de linting en milisegundos después de la última modificación al código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Argumentos para el servidor de lenguaje</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Argumentos para pasar al ejecutable del servidor de lenguaje</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Reglas de emparejamiento de casos de prueba</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Pares de expresiones regulares utilizadas al agregar pares de casos de prueba de archivos.
 Cada par de expresiones regulares representa un caso de prueba.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Regex de entrada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>La expresión regular que coincide con el nombre completo del archivo de entrada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Reemplazar respuesta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>La expresión de reemplazo para el nombre del archivo de respuesta.
 Puedes usar &quot;\1&quot; para el primer grupo capturado.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Ruta de guardado del archivo de entrada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2369,10 +2909,12 @@ Puedes usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${1-index}&quot; para el índice del caso de prueba que comienza en 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Ruta de guardado del archivo de respuesta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2387,232 +2929,289 @@ Puedes usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${1-index}&quot; para el índice del caso de prueba que comienza en 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Rutas de archivo predeterminadas para URLs de problemas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>La ruta de archivo predeterminada utilizada al guardar un nuevo archivo mientras se establece la URL del problema</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL del problema</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>La expresión regular que coincide con una parte de la URL del problema</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Ruta de archivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>La expresión de reemplazo para la ruta del archivo, sin sufijo de nombre de archivo.
 Puedes usar &quot;\1&quot; para el primer grupo capturado.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Fuente de casos de prueba</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>La fuente de los casos de prueba</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Añade un margen adicional en la parte inferior del editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Añade un margen adicional con la altura de una página en la parte inferior del editor de código.
 Por razones técnicas, cambiar la altura del margen afecta al historial de deshacer.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Fuente del registrador de mensajes</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>La fuente del registrador de mensajes</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Guardar archivo en compilación</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Guardar el archivo de origen al compilarlo. No se guardará si la pestaña no tiene título.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Guardar archivo en ejecución</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Guardar el archivo de origen al ejecutarlo. No se guardará si la pestaña no tiene título.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Restaurar la URL del problema al abrir un archivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Si se estableció una URL de problema para un archivo, al abrir
 ese archivo de nuevo, se restaurará la URL del problema.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Abrir el archivo antiguo al analizar una URL de problema antigua</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Si se estableció una URL de problema para un archivo, al analizar ese problema
 de nuevo desde Competitive Companion, se abrirá el archivo antiguo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>Idioma de la interfaz de usuario</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>El idioma mostrado en la interfaz de usuario.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Cambiar el idioma</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Es necesario reiniciar la aplicación para aplicar completamente el cambio de idioma.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>Estilo de la interfaz de usuario</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>El estilo de toda la aplicación.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Ejecutar tus códigos en casos de prueba vacíos</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Ejecuta tu código en todos los casos de prueba no ocultos, incluso si la entrada está vacía.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Comprueba tu respuesta en casos de prueba con salida vacía</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Comprueba tu respuesta incluso si tu salida o la salida esperada está vacía.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Altura máxima del caso de prueba</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>La altura máxima de un caso de prueba sin barra de desplazamiento en píxeles.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>Habilitar proxy para verificar actualizaciones</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>Habilitar proxy para conectarse a GitHub al verificar actualizaciones</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>El tipo de proxy. &quot;System&quot; para usar el proxy del sistema.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Nombre de host</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>El nombre de host del proxy, por ejemplo, 127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>El puerto del proxy, por ejemplo, 1080</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Usuario</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>El usuario del servidor proxy. Puede estar vacío si el servidor proxy no requiere autenticación.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>Códec de salida del compilador de %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Códec de texto de la salida del compilador (errores, advertencias, etc.)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Nombres y rutas de ruta predeterminadas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2621,30 +3220,38 @@ Se pueden usar en las rutas predeterminadas correspondientes de las acciones uti
 Se pueden configurar manualmente o cambiar automáticamente después de elegir una ruta para una acción.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>El nombre de una ruta predeterminada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>El nombre de una ruta predeterminada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Cargar automáticamente los cambios de archivos externos si no hay modificaciones sin guardar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Cargar automáticamente los cambios de archivo que no se realizan en CP Editor si no hay modificaciones sin guardar en CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Preguntar si se deben cargar los cambios de archivo externo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -2655,209 +3262,346 @@ Si esto está deshabilitado, los cambios de archivo externo se ignorarán a meno
 &quot;%1&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Mostrar solo fuente monoespaciada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Mostrar solo fuentes monoespaciadas al elegir una fuente</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>Desmarcar automáticamente los casos de prueba aceptados</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>Desmarcar automáticamente los casos de prueba cuando son aceptados.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>La ruta al archivo ejecutable de WakaTime</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Clave API</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>Se puede encontrar en https://wakatime.com/settings/account.
 Puede estar vacío si tiene el archivo de configuración global de wakatime ~/.wakatime.cfg.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>Habilitar WakaTime</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>Utilizar proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>Utilizar Avanzado-&gt;Proxy de red, para enviar datos a WakaTime.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation>Mostrar cronómetro</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation>Iniciar/detener el cronómetro al cambiar de pestaña</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation>Al cambiar a una pestaña diferente, iniciar automáticamente el cronómetro
 en la pestaña actual y pausar el cronómetro en la pestaña anterior.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation>Mostrar el resultado del cronómetro solo cuando se presiona el botón</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation>Ocultar el tiempo del cronómetro y solo mostrar el tiempo cuando se presiona el botón &quot;Mostrar&quot;.
 Esto puede reducir las distracciones causadas por las actualizaciones del cronómetro.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Ruta predeterminada utilzada para %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>La ruta predeterminada utilizada al elegir una ruta para %1.
 Puedes usar ${&lt;default path name&gt;} como marcador de posición.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Las rutas predeterminadas cambiadas por %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Las rutas predeterminadas cambiaron después de elegir una ruta para %1.
 Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y puede estar vacía.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Guardar archivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Puede ser anulado por %1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Abrir concurso</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Cargar un único caso de prueba</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Añadir pares de casos de prueba</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Guardar caso de prueba en un archivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Verificador personalizado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Exportar e importar configuraciones</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Exportar y cargar sesión</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Extraer y cargar snippets</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Habilitar emulación de Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Habilitar la emulación de Vim en el editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Configuración de Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Contenido del Vim RC. Se carga cada vez que se inicia la emulación de Vim.
@@ -2867,6 +3611,7 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>ShortcutItem</name>
     <message>
+        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Borrar el atajo</translation>
     </message>
@@ -2874,42 +3619,52 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>StringListsItem</name>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Insertar una fila (Ctrl+N)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Eliminar la fila actual (Ctrl+W)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Eliminar elemento</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>¿Realmente quieres eliminar la fila actual?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Mover la fila actual hacia arriba (Ctrl+Shift+Arriba)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Mover la fila actual hacia abajo (Ctrl+Shift+Abajo)</translation>
     </message>
@@ -2917,6 +3672,7 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>SupportEntry</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Donar</translation>
     </message>
@@ -2924,34 +3680,42 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>SupportUsDialog</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>¿Te gusta CP Editor?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>¡Gracias por usar CP Editor!</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Para apoyarnos, puedes:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Darnos una estrella en GitHub</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Compartir CP Editor con tus amigos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>¡Estoy usando @cpeditor_, un IDE especialmente diseñado para programadores competitivos, que es increíble!</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Apoyarnos financieramente</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Proporcionar algunas sugerencias para ayudarnos a hacerlo mejor</translation>
     </message>
@@ -2959,14 +3723,17 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Este error probablemente se debe a la falta de la biblioteca OpenSSL. Puede visitar &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; para encontrar un binario para instalar, o instalarlo a través de su administrador de paquetes preferido. Tiene que instalar una versión compatible con esta versión: [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>No se ha encontrado ningún lanzamiento.</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>No se ha encontrado la URL de descarga de la versión [%1].</translation>
     </message>
@@ -2974,50 +3741,64 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Util::FileUtil</name>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="87"/>
+        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Error al abrir [%1]. ¿Tengo permiso de escritura?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="97"/>
+        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Error al guardar en [%1]. ¿Tengo permiso de escritura?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>El archivo [%1] no existe</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Error al abrir [%1]. ¿Tengo permiso de lectura?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Abrir carpeta contenedora de %1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Mostrar %1 en buscador</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Mostrar %1 en Explorer</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Mostrar %1 en el administrador de archivos</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3025,50 +3806,62 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Crear un nuevo concurso</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Detalles del concurso</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Directorio principal</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Subdirectorio</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Guardar ruta</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Número de problemas</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>El directorio principal no existe</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>El directorio principal [%1] no existe. ¿Quieres crearlo y continuar?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Error al crear directorio</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Error al crear el directorio [%1].</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Elegir directorio principal</translation>
     </message>
@@ -3076,14 +3869,17 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Visualizador de diferencias</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Esperado</translation>
     </message>
@@ -3091,26 +3887,33 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation>Cronómetro</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation>Empezar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation>Pausar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation>Reanudar</translation>
     </message>
@@ -3118,162 +3921,222 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::StressTesting</name>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished">Empezar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">Error al crear directorio temporal</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Leer testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Guardar testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Compilador</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">Límite de tiempo excedido</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3281,58 +4144,72 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::TestCase</name>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Esperado</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Ejecutar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Eliminar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Probar en un único caso de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Abrir el visualizador de diferencias</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Salida #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Esperado #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Eliminar caso de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>¿Estás seguro de que deseas eliminar el caso de prueba #%1?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Visualizador de diferencias[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>La salida/esperada contiene más de %1 caracteres, el visor de diferencias HTML está deshabilitado. Puedes cambiar el límite de longitud en %2.</translation>
     </message>
@@ -3340,42 +4217,54 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Esperado</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Solo se muestran los primeros %1 caracteres. Ahora el editor de casos de prueba es de solo lectura. Puedes establecer el límite de longitud en %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Guardar en archivo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Guardar caso de prueba en archivo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Cargar desde un archivo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Editar en ventana más grande</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Editar caso de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar salida a esperado</translation>
     </message>
@@ -3383,174 +4272,224 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::TestCases</name>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Casos de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Verificador:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Añadir prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Añadir verificador</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>No aceptado / Aceptado / Total</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Añade un verificador personalizado de testlib</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Añadir pares de casos de prueba desde archivos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Elige archivos de casos de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Casos de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Cargar casos de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Se cargó un par de casos de prueba [%1] y [%2]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Se cargó una entrada [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Los siguientes archivos no se cargan porque no coinciden:%1. Puedes establecer las reglas de emparejamiento en %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Marcar todo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Desmarcar todo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Desmarcar aceptados</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Invertir</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Eliminar todo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>¿Estás seguro de que quieres eliminar todos los casos de prueba?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Eliminar vacíos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Eliminar marcados</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>¿Estás seguro de que quieres eliminar todos los casos de prueba marcados?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Copiar casos de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Pegar casos de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar salida a esperado</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>¿Estás seguro de que quieres copiar todas las salidas marcadas a sus correspondientes esperadas?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Ignorar espacios finales</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Estrictamente igual</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Comparar int64</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Comparar doubles, error máximo 1e-4</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Comparar doubles, error máximo 1e-6</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Comparar doubles, error máximo 1e-9</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Comparar tokens</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Comparar YES/NO, insensible a mayúsculas y minúsculas</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Añadir caso de prueba</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Ya hay %1 casos de prueba, no se pueden agregar más.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Esperado #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Guardar entrada #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Guardar esperado #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Cargar %1</translation>
     </message>
@@ -3558,26 +4497,32 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Descargar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Nueva actualización disponible</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>Está disponible una nueva actualización de %1 &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt;. Consulte a continuación el registro de cambios.&lt;br /&gt;Recomendamos encarecidamente que mantenga el editor actualizado para no perderse las increíbles nuevas funcionalidades y soluciones de errores.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>beta</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>estable</translation>
     </message>
@@ -3585,30 +4530,37 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Cerrar este cuadro de diálogo y cancelar la comprobación de actualizaciones</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Comprobador de actualizaciones</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Recopilando la lista de lanzamientos...</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Error: %1&lt;br /&gt;&lt;br /&gt;El actualizador no ha podido comprobar las actualizaciones. Compruebe manualmente las actualizaciones en&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; o &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation>¡Hurra! Ya estás utilizando la última versión de CP Editor.</translation>
     </message>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -4,67 +4,54 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Abrir archivos recientes</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>No se ha abierto ningún archivo recientemente</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Borrar archivos recientes</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Salida rápida</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>En la última sesión, CP Editor ha finalizado de manera inesperada, ¿Desea restaurar la última sesión?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Mostrar ventana principal</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Abriendo archivos</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>Acerca de CP Editor %1</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; es un editor de código basado en Qt. Está especialmente diseñado para la programación competitiva, a diferencia de otros editores/IDEs que son principalmente para desarrolladores. Te ayuda a enfocarte en tu algoritmo y automatiza la compilación, ejecución y prueba. ¡Incluso obtiene casos de prueba por ti de diferentes plataformas, y envía soluciones a Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Ese es un software libre; vea el código fuente para las condiciones de copia. NO hay ninguna garantía; ni siquiera para COMERCIALIZACIÓN o ADECUACIÓN PARA UN PROPÓSITO PARTICULAR. El código fuente de CP Editor está disponible en &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Información de compilación</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -77,604 +64,553 @@ Tiempo de compilación: %4
 Sistema Operativo: %5</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Versión portable</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Versión de instalación</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Abrir archivos</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Guardar todo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Restablecer preferencias</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>¿Estás seguro de que quieres restablecer todas las preferencias a los valores predeterminados?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Exportar configuración a un archivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="779"/>
-        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Archivo de configuración de CP Editor</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Importar configuración</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Todas las configuraciones actuales se perderán después de importar configuraciones de un archivo. ¿Estás seguro de que deseas continuar?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Importar configuración desde un archivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Exportar sesión actual a un archivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="807"/>
-        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Archivo de sesión de CP Editor</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Exportar sesión</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Error al exportar la sesión actual a [%1]</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Cargar sesión</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Cargar una sesión desde un archivo cerrará todas las pestañas de la sesión actual sin guardar los archivos. ¿Estás seguro de que deseas continuar?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Cargar sesión desde un archivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: Un editor especialmente diseñado para programación competitiva</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1316"/>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>Snippets</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>No hay snippets para %1. Por favor, agregue snippets en la ventana de preferencias.</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Utilizar snippets</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Seleccione un snippet:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>No hay ningún snippet llamado %1 para %2</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>Cómo salir de pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>Presiona la tecla F11 para salir del modo pantalla completa.</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Cerrar otros</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Cerrar a la izquierda</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Cerrar a la derecha</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Cerrar guardado</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Cerrar todo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Duplicar pestaña</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Establecer comando de compilación</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Establecer límite de tiempo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Archivo de origen</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Archivo ejecutable</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Copiar ruta del archivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Abrir problema en el navegador</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Copiar URL del problema</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Establecer URL de Codeforces</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Establecer URL de CF</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Ingrese el ID del concurso:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Ingrese el código del problema (A-Z):</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1602"/>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Establecer URL del problema</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Ingrese la URL del nuevo problema:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Registrador de eventos</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Todos los registros, excepto la sesión actual, han sido eliminados</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation type="vanished">Nuevo archivo</translation>
+        <translation>Nuevo archivo</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation type="vanished">Abrir una nueva pestaña en el editor</translation>
+        <translation>Abrir una nueva pestaña en el editor</translation>
+    </message>
+    <message>
+        <source>Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with generator template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with C++ template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Java template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Python template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation type="vanished">Guardar el archivo en el disco</translation>
+        <translation>Guardar el archivo en el disco</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation type="vanished">Guardar como...</translation>
+        <translation>Guardar como...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation type="vanished">Guardar como nuevo archivo</translation>
+        <translation>Guardar como nuevo archivo</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation type="vanished">Guardar todos los archivos abiertos</translation>
+        <translation>Guardar todos los archivos abiertos</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation type="vanished">Cerrar actual</translation>
+        <translation>Cerrar actual</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation type="vanished">Cerrar pestaña actual</translation>
+        <translation>Cerrar pestaña actual</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation type="vanished">Cerrar pestañas guardadas</translation>
+        <translation>Cerrar pestañas guardadas</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation type="vanished">Cerrar todas las pestañas</translation>
+        <translation>Cerrar todas las pestañas</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation type="vanished">Salir de la aplicación</translation>
+        <translation>Salir de la aplicación</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation type="vanished">Abrir archivo...</translation>
+        <translation>Abrir archivo...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation type="vanished">Abrir archivos</translation>
+        <translation>Abrir archivos</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation type="vanished">Abrir concurso...</translation>
+        <translation>Abrir concurso...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation type="vanished">Abrir un concurso</translation>
+        <translation>Abrir un concurso</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation type="vanished">Indentar</translation>
+        <translation>Indentar</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation type="vanished">Desindentar</translation>
+        <translation>Desindentar</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation type="vanished">Intercambiar línea arriba</translation>
+        <translation>Intercambiar línea arriba</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation type="vanished">Intercambiar línea abajo</translation>
+        <translation>Intercambiar línea abajo</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation type="vanished">Duplicar línea</translation>
+        <translation>Duplicar línea</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation type="vanished">Eliminar línea</translation>
+        <translation>Eliminar línea</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation type="vanished">Alternar comentarios</translation>
+        <translation>Alternar comentarios</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation type="vanished">Alternar comentario de bloque</translation>
+        <translation>Alternar comentario de bloque</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Compilar</translation>
+        <translation>Compilar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Compilar y ejecutar</translation>
+        <translation>Compilar y ejecutar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Ejecutar</translation>
+        <translation>Ejecutar</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation type="vanished">Formatear código</translation>
+        <translation>Formatear código</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation type="vanished">Ejecutar desconectado</translation>
+        <translation>Ejecutar desconectado</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation type="vanished">Terminar procesos</translation>
+        <translation>Terminar procesos</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation type="vanished">Buscar y reemplazar</translation>
+        <translation>Buscar y reemplazar</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation type="vanished">Utilizar snippet...</translation>
+        <translation>Utilizar snippet...</translation>
+    </message>
+    <message>
+        <source>Stress Testing...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation type="vanished">Preferencias</translation>
+        <translation>Preferencias</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation type="vanished">Reestablecer configuración</translation>
+        <translation>Reestablecer configuración</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation type="vanished">Exportar configuración...</translation>
+        <translation>Exportar configuración...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation type="vanished">Importar configuración...</translation>
+        <translation>Importar configuración...</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation type="vanished">Exportar sesión...</translation>
+        <translation>Exportar sesión...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation type="vanished">Cargar sesión...</translation>
+        <translation>Cargar sesión...</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation type="vanished">Manual</translation>
+        <translation>Manual</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation type="vanished">Reportar problemas</translation>
+        <translation>Reportar problemas</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation type="vanished">Acerca de Qt</translation>
+        <translation>Acerca de Qt</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation type="vanished">Buscar actualizaciones</translation>
+        <translation>Buscar actualizaciones</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation type="vanished">Apóyanos</translation>
+        <translation>Apóyanos</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation type="vanished">Modo editor</translation>
+        <translation>Modo editor</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation type="vanished">Modo E/S</translation>
+        <translation>Modo E/S</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation type="vanished">Modo dividido</translation>
+        <translation>Modo dividido</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation type="vanished">Pantalla completa</translation>
+        <translation>Pantalla completa</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation type="vanished">Mostar archivos de registro</translation>
+        <translation>Mostar archivos de registro</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation type="vanished">Borrar archivos de registro</translation>
+        <translation>Borrar archivos de registro</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Archivo</translation>
+        <translation>&amp;Archivo</translation>
+    </message>
+    <message>
+        <source>New File From Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="vanished">&amp;Editar</translation>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation type="vanished">&amp;Acciones</translation>
+        <translation>&amp;Acciones</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Visualizar</translation>
+        <translation>&amp;Visualizar</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation type="vanished">&amp;Opciones</translation>
+        <translation>&amp;Opciones</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="vanished">&amp;Ayuda</translation>
+        <translation>&amp;Ayuda</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="obsolete">C++</translation>
+        <translation type="unfinished">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="obsolete">Java</translation>
+        <translation type="unfinished">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="obsolete">Python</translation>
+        <translation type="unfinished">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Renombrar snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Cargar snippets desde archivos</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Extraer snippets a archivos</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Ningún snippet seleccionado</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Snippet no guardado</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>El snippet [%1] ha sido modificado. ¿Desea guardarlo, o descartar los cambios?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Eliminar snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>¿Seguro que quiere eliminar el snippet [%1]?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Cargar snippets</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Error al abrir [%1]. ¿Tengo permiso de lectura?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Extraer snippets</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Extraer Snippets: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Error al escribir en [%1]. ¿Tengo permiso de escritura?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>El nombre del snippet no puede estar vacío.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Conflicto de nombre de snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>El nombre &quot;%1&quot; ya está en uso. ¿Quieres sobrescribirlo? (Se eliminará el viejo snippet con este nombre.)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>El nombre &quot;%1&quot; ya está en uso.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Añadir snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Nombre de nuevo snippet:</translation>
     </message>
@@ -682,93 +618,68 @@ Sistema Operativo: %5</translation>
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Verificador de lectura</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
-        <location filename="../src/Core/Checker.cpp" line="99"/>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
-        <location filename="../src/Core/Checker.cpp" line="301"/>
-        <location filename="../src/Core/Checker.cpp" line="302"/>
-        <location filename="../src/Core/Checker.cpp" line="303"/>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Verificador</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Error al crear directorio temporal</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Leer testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Guardar testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Inició la compilación del verificador</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>El verificador está compilado</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Se produjo un error al compilar el verificador:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Error al compilar el verificador: %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Límite de tiempo excedido</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>El verificador finalizó con el código de salida %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>El verificador finalizó con un código de salida desconocido %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>El %1 del proceso que se ejecuta en el caso de prueba #%2 contiene más de %3 caracteres, lo que es más largo que el límite de longitud de salida, por lo que se cancela el proceso. Puedes cambiar el límite de longitud de salida en %4.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>El verificador ha sido cancelado</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Verificador[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>El código fuente del verificador ha cambiado, recompilando...</translation>
     </message>
@@ -776,22 +687,18 @@ Sistema Operativo: %5</translation>
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>El archivo de origen [%1] no existe</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 está vacío</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Lenguaje de programación no compatible &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>Error al iniciar el compilador. Compruebe %1 o agregue el compilador en la variable de entorno PATH.</translation>
     </message>
@@ -799,39 +706,32 @@ Sistema Operativo: %5</translation>
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>El archivo de origen %1 no existe.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Error al obtener el comando de ejecución. Probablemente sea un error.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>Error al crear el archivo temporal.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>El programa finalizó con el código de salida %1
 Presione cualquier tecla para salir</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>La ejecución desacoplada no es compatible con su plataforma</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Error al iniciar la ejecución desacoplada. Compruebe la configuración de su emulador de terminal en %1.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Error al iniciar la ejecución. Compile primero, por favor.</translation>
     </message>
@@ -839,12 +739,10 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Core::SessionManager</name>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Restaurando la última sesión</translation>
     </message>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Restaurando: [%1]</translation>
     </message>
@@ -852,52 +750,42 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` no requiere argumento o debe ser uno de &apos;cpp&apos;, &apos;java&apos; o &apos;python&apos;, se obtuvo [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] no es un archivo fuente de C++, Python o Java</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] no existe. Para abrir una pestaña con un archivo inexistente, use `open!`</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] no es un número</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 está fuera del rango [1, %2]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">N/D</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] no es un modo de vista válido. Debe ser &apos;split&apos; o &apos;edit&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 no es un nombre de lenguaje válido. Debe ser &apos;cpp&apos;, &apos;java&apos; o &apos;python&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">No hay pestaña activa para limpiar mensajes</translation>
     </message>
@@ -905,63 +793,42 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>Se canceló CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>El código del problema es 0, ahora usa A automáticamente. Si el código del problema real no es A, establece el código del problema manualmente en el menú contextual de la pestaña actual.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Error al obtener la versión de CF Tool. ¿Has establecido la ruta correcta a CF Tool en Preferencias?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool ha comenzado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Error al iniciar CF Tool en 2 segundos. ¿Has establecido la ruta correcta a CF Tool en Preferencias?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Error al analizar la URL [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>CF Tool falló</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool finalizó con un código de salida diferente a cero %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Concurso %1 Problema %2</translation>
     </message>
@@ -969,50 +836,34 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Formateador</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Error al crear directorio temporal</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Formateo completado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>El proceso de formateo no se completó en 2 segundos. Esto es probablemente debido a que el programa %1 no se encuentra por CP Editor. Puedes establecer la ruta al programa en %2.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>El comando de formateo [%1 %2] finalizó con el código de salida %3.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Formateador[stdout]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Formateador[stderr]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>La salida del proceso de formateo está vacía. Asegúrese de que no haya ninguna opción de modificación en los argumentos de formateo.</translation>
     </message>
@@ -1020,39 +871,32 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>Se ha recibido y se ha ignorado una solicitud %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>La solicitud recibida no es JSON</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>El servidor está cerrado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>El puerto está configurado en %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Error al escuchar en el puerto %1. ¿Hay otro proceso escuchando?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>El analizador de JSON informó errores:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Servidor detenido</translation>
     </message>
@@ -1060,42 +904,30 @@ Presione cualquier tecla para salir</translation>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Servidor de lenguaje [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>El servidor de lenguaje envió un error. Consulte el registro para obtener más detalles.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Error al iniciar el proceso LSP. ¿Ha configurado la ruta al programa del servidor de lenguaje en %1?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Se agotó el tiempo de espera del proceso LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Error de lectura del proceso LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Error de escritura del proceso LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Ha ocurrido un error desconocido en el proceso LSP</translation>
     </message>
@@ -1104,50 +936,50 @@ Presione cualquier tecla para salir</translation>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation type="vanished">Buscar/Reemplazar</translation>
+        <translation>Buscar/Reemplazar</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulario</translation>
+        <translation>Formulario</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation type="vanished">Buscar:</translation>
+        <translation>Buscar:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation type="vanished">Reemplazar con:</translation>
+        <translation>Reemplazar con:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation type="vanished">Etiqueta de error</translation>
+        <translation>Etiqueta de error</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="vanished">Dirección</translation>
+        <translation>Dirección</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="vanished">Arriba</translation>
+        <translation>Arriba</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="vanished">Abajo</translation>
+        <translation>Abajo</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opciones</translation>
+        <translation>Opciones</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation type="vanished">Sensible a mayúsculas y minúsculas</translation>
+        <translation>Sensible a mayúsculas y minúsculas</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation type="vanished">Solo palabras completas</translation>
+        <translation>Solo palabras completas</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1158,7 +990,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1169,79 +1001,56 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation type="vanished">Expresión regular</translation>
+        <translation>Expresión regular</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation type="vanished">Buscar</translation>
+        <translation>Buscar</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="vanished">Reemplazar</translation>
+        <translation>Reemplazar</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation type="vanished">Reemplazar todo</translation>
+        <translation>Reemplazar todo</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Auto guardar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="185"/>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Compilador</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Por favor, establezca el idioma</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="218"/>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="242"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1492"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Ejecutor</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Idioma incorrecto, por favor establezca el idioma</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Todas las entradas están vacías, no hay nada para ejecutar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Seguro de enviar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1252,131 +1061,102 @@ URL: %1
 Idioma: %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="328"/>
-        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Error al guardar el archivo temporal y la solución no se envía.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Necesita instalar CF Tool para enviar su código a Codeforces. Si ya está instalado, puede agregarlo en la variable de entorno PATH o verificar sus configuraciones en %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Sin título-%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Atributo desconocido: [%1]. Por favor revise la configuración de comentarios de cabecera en %2.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Abrir plantilla de %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1017"/>
-        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>El archivo [%1] contiene más de %2 caracteres, por lo que no se abre. Puede cambiar el límite de longitud de archivo abierto en %3.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Guardar archivo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
-        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Archivo temporal</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Error al crear el archivo temporal</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Establecer comando de compilación</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Comando de compilación personalizado para esta pestaña:</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Establecer límite de tiempo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Límite de tiempo personalizado para esta pestaña: (ms)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Leer Plantilla de %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Guardar cambios</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>¿Guardar los cambios en [%1] antes de cerrar?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Nuevo archivo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Establecer idioma de pestaña</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Establecer el idioma a utilizar en esta pestaña</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1387,153 +1167,129 @@ ha sido cambiado en el disco.
 ¿Quieres recargarlo?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Línea %1, Columna %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>%1 líneas, %2 caracteres seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>%1 caracteres seleccionados</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>La compilación ha comenzado</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>La compilación ha terminado</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Advertencias de compilación</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Se produjo un error al compilar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1517"/>
-        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Errores de compilación</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>¿Has establecido un nombre adecuado para la clase principal en tu solución? Si no, puedes establecerlo en %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Error al iniciar la compilación: %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>La compilación es cancelada</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>Ejecutor desconectado</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Ejecutor[%1]</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>La ejecución ha comenzado</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>La ejecución para el caso de prueba #%1 ha terminado en %2ms</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Límite de tiempo excedido</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>La ejecución para el caso de prueba #%1 ha terminado con un código de salida diferente a cero %2 en %3ms</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>El %1 del proceso en ejecución en el caso de prueba #%2 contiene más de %3 caracteres, lo cual es más largo que el límite de longitud de salida, por lo que se cancela el proceso. Puede cambiar el límite de longitud de salida en %4.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 ha sido cancelado</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>Ejecutor desconectado</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Ejecutor para el caso de prueba #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation type="vanished">CP Editor</translation>
+        <translation>CP Editor</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation type="vanished">información del cursor</translation>
+        <translation>información del cursor</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Compilar</translation>
+        <translation>Compilar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Ejecutar</translation>
+        <translation>Ejecutar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Compilar y ejecutar</translation>
+        <translation>Compilar y ejecutar</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation type="vanished">Mensajes</translation>
+        <translation>Mensajes</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="vanished">Limpiar</translation>
+        <translation>Limpiar</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="vanished">C++</translation>
+        <translation>C++</translation>
     </message>
 </context>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1543,42 +1299,34 @@ ha sido cambiado en el disco.
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 Paréntesis</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Ningún paréntesis seleccionado</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Nuevo paréntesis</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Ingrese un paréntesis (por ejemplo, {}):</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Eliminar paréntesis</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>¿Seguro que quiere eliminar el paréntesis %1?</translation>
     </message>
@@ -1586,29 +1334,24 @@ ha sido cambiado en el disco.
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Paréntesis: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Habilitar %1 para %2 en %3.
 Si está parcialmente marcado, la configuración global en Editar Código t se utilizará.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Autocompletar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Autoeliminar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Salir de la pestaña</translation>
     </message>
@@ -1616,25 +1359,18 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="41"/>
-        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Elige un archivo</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Archivos ejecutables</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="84"/>
-        <location filename="../src/Settings/PathItem.cpp" line="86"/>
-        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Elige un archivo de origen de %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Elige un archivo ejecutable</translation>
     </message>
@@ -1642,42 +1378,34 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>¡Bienvenido a CP Editor! Comencemos.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Configuración del editor de código</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Comandos de compilación y ejecución de C++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Comandos de compilación y ejecución de Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Comandos de ejecución de Python</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Configuración de apariencia</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Configuración de fuente</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>Puedes leer la &lt;a href=&quot;%1&quot;&gt;documentación&lt;/a&gt; o revisar las configuraciones para obtener más información.</translation>
     </message>
@@ -1685,42 +1413,34 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Restaurar la configuración predeterminada en la página actual. (Ctrl+D)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Descartar todos los cambios en la página actual. (Ctrl+R)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Guardar los cambios en la página actual. (Ctrl+S)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Configuración sin guardar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>La configuración ha cambiado. ¿Quieres guardar la configuración o descartarla?</translation>
     </message>
@@ -1728,413 +1448,321 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
-        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Ir a la página de inicio</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation type="vanished">Editar código</translation>
+        <translation>Editar código</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Idioma</translation>
+        <translation>Idioma</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="vanished">General</translation>
+        <translation>General</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 Comandos</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 Plantilla</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 Snippets</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 Paréntesis</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="vanished">Apariencia</translation>
+        <translation>Apariencia</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="vanished">Fuente</translation>
+        <translation>Fuente</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation type="vanished">Acciones</translation>
+        <translation>Acciones</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Guardar</translation>
+        <translation>Guardar</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation type="vanished">Auto guardar</translation>
+        <translation>Auto guardar</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation type="vanished">Ejecución desconectada</translation>
+        <translation>Ejecución desconectada</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation type="vanished">Guardar sesión</translation>
+        <translation>Guardar sesión</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation type="vanished">Vincular archivo y problema</translation>
+        <translation>Vincular archivo y problema</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation type="vanished">Casos de prueba</translation>
+        <translation>Casos de prueba</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation type="vanished">Cargar cambios en archivo externo</translation>
+        <translation>Cargar cambios en archivo externo</translation>
     </message>
     <message>
         <source>Stopwatch</source>
-        <translation type="vanished">Cronómetro</translation>
+        <translation>Cronómetro</translation>
+    </message>
+    <message>
+        <source>Stress Testing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generator Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation type="vanished">Extensiones</translation>
+        <translation>Extensiones</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation type="vanished">Formato de código</translation>
+        <translation>Formato de código</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation type="vanished">Clang Format</translation>
+        <translation>Clang Format</translation>
     </message>
     <message>
         <source>YAPF</source>
-        <translation type="vanished">YAPF</translation>
+        <translation>YAPF</translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation type="vanished">Servidor de lenguaje</translation>
+        <translation>Servidor de lenguaje</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>%1 Servidor</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation type="vanished">Competitive Companion</translation>
+        <translation>Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation type="vanished">CF Tool</translation>
+        <translation>CF Tool</translation>
     </message>
     <message>
         <source>WakaTime</source>
-        <translation type="vanished">WakaTime</translation>
+        <translation>WakaTime</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation type="vanished">Ruta de archivo</translation>
+        <translation>Ruta de archivo</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation type="vanished">Casos de prueba</translation>
+        <translation>Casos de prueba</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation type="vanished">URL del problema</translation>
+        <translation>URL del problema</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation type="vanished">Rutas predeterminadas</translation>
+        <translation>Rutas predeterminadas</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation type="vanished">Asignaciones de teclas</translation>
+        <translation>Asignaciones de teclas</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="vanished">Avanzado</translation>
+        <translation>Avanzado</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="vanished">Actualizar</translation>
+        <translation>Actualizar</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation type="vanished">Límites</translation>
+        <translation>Límites</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation type="vanished">Proxy de red</translation>
+        <translation>Proxy de red</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Ancho de tabulador</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>El ancho del carácter de tabulación o el número de espacios de una sangría</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>Ancho del cursor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>El ancho del cursor en píxeles</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Fuente del editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>La fuente del editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Usar fuente de aplicación personalizada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Usar una fuente personalizada para toda la aplicación en lugar de la fuente predeterminada del sistema.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Fuente de aplicación personalizada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>La fuente personalizada para toda la aplicación</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Idioma predeterminado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>El idioma predeterminado utilizado al abrir nuevas pestañas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Programa Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>La ruta del archivo ejecutable de Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Argumentos de Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Los argumentos pasados a clang-format. NO debe contener &quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Estilo de Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Las opciones de estilo de Clang Format, que suelen guardarse en un archivo de configuración .clang-format.
 Puede obtener más información en &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Programa YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>El programa de YAPF. Puede ser `yapf` (que no necesita argumentos) o `python` (que necesita `-m yapf` como argumentos).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Argumentos de YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Los argumentos pasados al programa YAPF. NO debe contener &quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Estilo de YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Las opciones de estilo de YAPF, que suelen guardarse en un archivo de configuración .style.yapf o setup.conf.
 Puede obtener más información sobre ellas ejecutando `yapf --style-help`.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Formatear código en guardado manual</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Formatear el código al guardarlo manualmente.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Formatear código en autoguardado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Formatear código al guardar automáticamente.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>Ruta de plantilla de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>La plantilla utilizada al crear un nuevo archivo de C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>Regex de posición del cursor en plantilla de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -2143,53 +1771,34 @@ Cuando se abre una plantilla, la posición del cursor es la posición de la expr
 El cursor estará al final de la plantilla si no hay coincidencia con la expresión regular.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>Tipo de desplazamiento de posición del cursor en plantilla de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Si el desplazamiento es relativo al inicio de la expresión regular o al final de la expresión regular.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>Caracteres de desplazamiento de posición del cursor en plantilla de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>El desplazamiento relativo a la coincidencia de la expresión regular en número de caracteres, incluyendo espacios en blanco.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>Comando de compilación de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>El comando utilizado para compilar C++. NO debe incluir la ruta al archivo fuente ni &quot;-o &lt;archivo de salida&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>Ruta del archivo ejecutable de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2204,62 +1813,48 @@ Puede usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${tmpdir}&quot; o &quot;${tempdir}&quot; para la ruta absoluta del directorio temporal.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>Argumentos de ejecución de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Los argumentos utilizados al ejecutar un programa de C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>La plantilla utilizada al crear un nuevo archivo de Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>El comando utilizado para compilar Java.
 NO debe incluir la ruta al archivo fuente ni la ruta del archivo de clase compilado.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Los argumentos utilizados al ejecutar un programa de Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>Comando de ejecución de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>El comando para iniciar un programa de Java. NO debe incluir &quot;-classpath &lt;ruta&gt; &lt;nombre de clase&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>Nombre de clase %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>El nombre de la clase principal de su solución.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>Ruta de clase de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2272,37 +1867,30 @@ Puede usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${tmpdir}&quot; o &quot;${tempdir}&quot; para la ruta absoluta del directorio temporal.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>La plantilla utilizada al crear un nuevo archivo de Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Los argumentos utilizados al ejecutar un programa de Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>El comando para iniciar un programa de Python. NO debe incluir la ruta al archivo fuente.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Tema del editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>El tema de resaltado de sintaxis del editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Programa de terminal</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -2311,12 +1899,10 @@ Este es normalmente el nombre o la ruta del emulador de terminal.
 Algunos valores posibles son konsole, gnome-terminal, xfce-terminal, xterm u otro programa de emulador de terminal.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Argumentos de terminal</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -2325,12 +1911,10 @@ Este es &quot;-e&quot; para la mayoría de los emuladores de terminal, incluyend
 Consulte a su emulador de terminal para conocer los argumentos adecuados.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Autocompletar paréntesis</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -2339,12 +1923,10 @@ y salir de él al escribir el elemento derecho.
 Esto se puede sobrescribir para cada paréntesis en cada idioma.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Autoeliminar paréntesis</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -2353,12 +1935,10 @@ el elemento izquierdo de él si los dos elementos están adyacentes.
 Esto se puede sobrescribir para cada paréntesis en cada idioma.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Salir de un paréntesis presionando Tab</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -2367,37 +1947,30 @@ paréntesis de cierre para salir de un paréntesis.
 Esto se puede sobrescribir para cada paréntesis en cada idioma.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Indentación automática</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Añade una indentación al introducir una nueva línea después de un &quot;{&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Habilitar Auto Guardado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Intervalo de auto-guardado (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>El intervalo de tiempo entre una modificación y un auto-guardado, o entre dos auto-guardados.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Tipo de intervalo de auto-guardado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2406,122 +1979,98 @@ Después de la primera modificación: el cronómetro comenzará después de una 
 Sin modificación: la auto-guardado ocurre con un intervalo constante independientemente de si hay modificaciones o no.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Ajustar texto</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Ajusta una línea en varias líneas si no cabe en la pantalla.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Enable Ctrl+Scroll to change font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Usar la versión beta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Comprueba las actualizaciones marcadas como pre-lanzamientos, que se consideran no muy estables pero tienen más características.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Reemplazar tabulaciones por espacios</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Usa espacios en lugar de un carácter de tabulación.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Guardar casos de prueba al guardar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Guarda los casos de prueba en el disco al guardar un archivo y cargar los casos de prueba guardados al abrir un archivo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Comprobar actualizaciones al inicio</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Comprueba si hay una nueva versión de CP Editor al iniciar CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Opacidad</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>La opacidad de la ventana principal</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Habilitar Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Recibir los datos enviados por Competitive Companion y cargar los casos de prueba de ejemplo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Puerto de conexión</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>El puerto utilizado para recibir datos de Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Abrir nuevas pestañas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Abrir una nueva pestaña para cada problema analizado por Competitive Companion.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Utilizar el límite de tiempo de Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Utilizar el límite de tiempo analizado por Competitive Companion como el límite de tiempo de la pestaña correspondiente.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Contenido de los comentarios de cabecera</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2532,12 +2081,10 @@ ${time}: el momento en que se analiza el problema
 ${json.X.Y}: un atributo de los datos proporcionados por Competitive Companion, puedes leer más en https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Formato de tiempo para los comentarios de cabecera</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2548,71 +2095,58 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Añadir &quot;Powered By CP Editor&quot; en los comentarios de encabezado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Añade una línea que diga &quot;Powered By CP Editor&quot; en los comentarios de encabezado.
 Esto no le cuesta nada, pero ayuda a más personas a conocer CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Formatear código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Terminar todos los procesos</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Compilar y ejecutar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Sólo ejecutar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Sólo compilar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Cambiar modo de vista</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Utilizar snippets</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Restaurar la última sesión al inicio</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Restaurar la última sesión cuando se inicia la aplicación.
 Cuando esto está habilitado, no se le preguntará si desea guardar los archivos sin guardar al salir.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Auto-guardar la sesión actual periódicamente</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2621,280 +2155,214 @@ Esto es útil si su computadora se congela y tiene que cortar la energía o
 matar la aplicación con SIGKILL que no puede ser manejada por la aplicación.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Intervalo de auto-guardado de sesión</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>El intervalo de tiempo entre dos auto-guardados de la sesión actual.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Ruta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>La ruta del archivo ejecutable de CF Tool</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Mostrar notificaciones del sistema para los veredictos de envío</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Mostrar una notificación del sistema cuando se conoce el veredicto de un envío. Puede ver el mensaje fuera de CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Mostrar únicamente compilar y ejecutar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Ocultar el botón Solo compilar y el botón Solo ejecutar debajo del editor de código en la ventana principal.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Mostrar EOLN (Fin de línea) en diferencias</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Usar &quot;¶&quot; para representar el carácter de nueva línea en el visor de diferencias HTML.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Guardar archivos más rápido</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Siempre usa QFile en lugar de QSaveFile para guardar archivos.
 Esto será más rápido pero con un poco más de riesgo de perder el archivo (con una muy pequeña posibilidad).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Límite de tiempo predeterminado (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>El límite de tiempo predeterminado al ejecutar el programa.
 El programa será cancelado si no finaliza en el límite de tiempo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Límite de longitud de salida</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>El número máximo de caracteres en la salida del programa.
 El programa será cancelado si cualquiera de su stdout o stderr es demasiado largo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Límite de longitud de visualización de salida</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>El número máximo de caracteres que se mostrarán para la salida del programa.
 Si la salida es demasiado larga, se cortará.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Límite de longitud de mensaje</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>El número máximo de caracteres en cada mensaje en la esquina superior derecha de la ventana principal.
 El mensaje se cortará si es demasiado largo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>Límite de longitud del visualizador de diferencias HTML</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>El número máximo de caracteres en el visualizador de diferencias HTML.
 El visualizador de diferencias volverá al texto sin formato si la salida o la salida esperada son demasiado largas.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Límite de longitud de archivo abierto</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>El número máximo de caracteres en un archivo de origen para abrirlo.
 Un archivo de origen no se abrirá si es demasiado largo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Límite de longitud de visualización del caso de prueba</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>El número máximo de caracteres en un caso de prueba para ser mostrado.
 Un caso de prueba se cortará y sólo lectura si es demasiado largo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Ruta al ejecutable LSP</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>La ruta al ejecutable del servidor de lenguaje de C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>La ruta al ejecutable del servidor de lenguaje de Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>La ruta al ejecutable del servidor de lenguaje de Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Usar verificación de linting con el servidor de lenguaje</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Mostrar errores, advertencias, información y sugerencias en el editor de código para el lenguaje de C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Mostrar errores, advertencias, información y sugerencias en el editor de código para el lenguaje de Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Mostrar errores, advertencias, información y sugerencias en el editor de código para el lenguaje de Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Usar auto-completado con el servidor de lenguaje</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Usar resultados de autocompletar del servidor de lenguaje</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Retraso en verificación de linting (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Retraso en verificación de linting en milisegundos después de la última modificación al código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Argumentos para el servidor de lenguaje</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Argumentos para pasar al ejecutable del servidor de lenguaje</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Reglas de emparejamiento de casos de prueba</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Pares de expresiones regulares utilizadas al agregar pares de casos de prueba de archivos.
 Cada par de expresiones regulares representa un caso de prueba.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Regex de entrada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>La expresión regular que coincide con el nombre completo del archivo de entrada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Reemplazar respuesta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>La expresión de reemplazo para el nombre del archivo de respuesta.
 Puedes usar &quot;\1&quot; para el primer grupo capturado.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Ruta de guardado del archivo de entrada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2909,12 +2377,10 @@ Puedes usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${1-index}&quot; para el índice del caso de prueba que comienza en 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Ruta de guardado del archivo de respuesta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2929,289 +2395,232 @@ Puedes usar &quot;${filename}&quot; para el nombre completo del archivo,
 &quot;${1-index}&quot; para el índice del caso de prueba que comienza en 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Rutas de archivo predeterminadas para URLs de problemas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>La ruta de archivo predeterminada utilizada al guardar un nuevo archivo mientras se establece la URL del problema</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL del problema</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>La expresión regular que coincide con una parte de la URL del problema</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Ruta de archivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>La expresión de reemplazo para la ruta del archivo, sin sufijo de nombre de archivo.
 Puedes usar &quot;\1&quot; para el primer grupo capturado.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Fuente de casos de prueba</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>La fuente de los casos de prueba</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Añade un margen adicional en la parte inferior del editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Añade un margen adicional con la altura de una página en la parte inferior del editor de código.
 Por razones técnicas, cambiar la altura del margen afecta al historial de deshacer.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Fuente del registrador de mensajes</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>La fuente del registrador de mensajes</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Guardar archivo en compilación</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Guardar el archivo de origen al compilarlo. No se guardará si la pestaña no tiene título.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Guardar archivo en ejecución</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Guardar el archivo de origen al ejecutarlo. No se guardará si la pestaña no tiene título.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Restaurar la URL del problema al abrir un archivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Si se estableció una URL de problema para un archivo, al abrir
 ese archivo de nuevo, se restaurará la URL del problema.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Abrir el archivo antiguo al analizar una URL de problema antigua</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Si se estableció una URL de problema para un archivo, al analizar ese problema
 de nuevo desde Competitive Companion, se abrirá el archivo antiguo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>Idioma de la interfaz de usuario</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>El idioma mostrado en la interfaz de usuario.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Cambiar el idioma</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Es necesario reiniciar la aplicación para aplicar completamente el cambio de idioma.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>Estilo de la interfaz de usuario</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>El estilo de toda la aplicación.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Ejecutar tus códigos en casos de prueba vacíos</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Ejecuta tu código en todos los casos de prueba no ocultos, incluso si la entrada está vacía.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Comprueba tu respuesta en casos de prueba con salida vacía</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Comprueba tu respuesta incluso si tu salida o la salida esperada está vacía.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Altura máxima del caso de prueba</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>La altura máxima de un caso de prueba sin barra de desplazamiento en píxeles.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>Habilitar proxy para verificar actualizaciones</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>Habilitar proxy para conectarse a GitHub al verificar actualizaciones</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>El tipo de proxy. &quot;System&quot; para usar el proxy del sistema.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Nombre de host</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>El nombre de host del proxy, por ejemplo, 127.0.0.1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>El puerto del proxy, por ejemplo, 1080</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Usuario</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>El usuario del servidor proxy. Puede estar vacío si el servidor proxy no requiere autenticación.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Contraseña</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>proxy-de-red</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>Códec de salida del compilador de %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Códec de texto de la salida del compilador (errores, advertencias, etc.)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Nombres y rutas de ruta predeterminadas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -3220,38 +2629,30 @@ Se pueden usar en las rutas predeterminadas correspondientes de las acciones uti
 Se pueden configurar manualmente o cambiar automáticamente después de elegir una ruta para una acción.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>El nombre de una ruta predeterminada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>El nombre de una ruta predeterminada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Cargar automáticamente los cambios de archivos externos si no hay modificaciones sin guardar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Cargar automáticamente los cambios de archivo que no se realizan en CP Editor si no hay modificaciones sin guardar en CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Preguntar si se deben cargar los cambios de archivo externo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -3262,346 +2663,209 @@ Si esto está deshabilitado, los cambios de archivo externo se ignorarán a meno
 &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Mostrar solo fuente monoespaciada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Mostrar solo fuentes monoespaciadas al elegir una fuente</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>Desmarcar automáticamente los casos de prueba aceptados</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>Desmarcar automáticamente los casos de prueba cuando son aceptados.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>La ruta al archivo ejecutable de WakaTime</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Clave API</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>Se puede encontrar en https://wakatime.com/settings/account.
 Puede estar vacío si tiene el archivo de configuración global de wakatime ~/.wakatime.cfg.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>Habilitar WakaTime</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>Utilizar proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>Utilizar Avanzado-&gt;Proxy de red, para enviar datos a WakaTime.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation>Mostrar cronómetro</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation>Iniciar/detener el cronómetro al cambiar de pestaña</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation>Al cambiar a una pestaña diferente, iniciar automáticamente el cronómetro
 en la pestaña actual y pausar el cronómetro en la pestaña anterior.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation>Mostrar el resultado del cronómetro solo cuando se presiona el botón</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation>Ocultar el tiempo del cronómetro y solo mostrar el tiempo cuando se presiona el botón &quot;Mostrar&quot;.
 Esto puede reducir las distracciones causadas por las actualizaciones del cronómetro.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Ruta predeterminada utilzada para %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>La ruta predeterminada utilizada al elegir una ruta para %1.
 Puedes usar ${&lt;default path name&gt;} como marcador de posición.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Las rutas predeterminadas cambiadas por %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Las rutas predeterminadas cambiaron después de elegir una ruta para %1.
 Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y puede estar vacía.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Guardar archivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Puede ser anulado por %1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Abrir concurso</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Cargar un único caso de prueba</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Añadir pares de casos de prueba</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Guardar caso de prueba en un archivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Verificador personalizado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Exportar e importar configuraciones</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Exportar y cargar sesión</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Extraer y cargar snippets</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Habilitar emulación de Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Habilitar la emulación de Vim en el editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Configuración de Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Contenido del Vim RC. Se carga cada vez que se inicia la emulación de Vim.
@@ -3611,7 +2875,6 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Borrar el atajo</translation>
     </message>
@@ -3619,52 +2882,42 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Insertar una fila (Ctrl+N)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Eliminar la fila actual (Ctrl+W)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Eliminar elemento</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>¿Realmente quieres eliminar la fila actual?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Mover la fila actual hacia arriba (Ctrl+Shift+Arriba)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Mover la fila actual hacia abajo (Ctrl+Shift+Abajo)</translation>
     </message>
@@ -3672,7 +2925,6 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>SupportEntry</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Donar</translation>
     </message>
@@ -3680,42 +2932,34 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>SupportUsDialog</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>¿Te gusta CP Editor?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>¡Gracias por usar CP Editor!</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Para apoyarnos, puedes:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Darnos una estrella en GitHub</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Compartir CP Editor con tus amigos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>¡Estoy usando @cpeditor_, un IDE especialmente diseñado para programadores competitivos, que es increíble!</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Apoyarnos financieramente</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Proporcionar algunas sugerencias para ayudarnos a hacerlo mejor</translation>
     </message>
@@ -3723,17 +2967,14 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Este error probablemente se debe a la falta de la biblioteca OpenSSL. Puede visitar &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; para encontrar un binario para instalar, o instalarlo a través de su administrador de paquetes preferido. Tiene que instalar una versión compatible con esta versión: [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>No se ha encontrado ningún lanzamiento.</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>No se ha encontrado la URL de descarga de la versión [%1].</translation>
     </message>
@@ -3741,64 +2982,50 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="87"/>
-        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Error al abrir [%1]. ¿Tengo permiso de escritura?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="97"/>
-        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Error al guardar en [%1]. ¿Tengo permiso de escritura?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>El archivo [%1] no existe</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Error al abrir [%1]. ¿Tengo permiso de lectura?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Abrir carpeta contenedora de %1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Mostrar %1 en buscador</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Mostrar %1 en Explorer</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Mostrar %1 en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3806,62 +3033,50 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Crear un nuevo concurso</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Detalles del concurso</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Directorio principal</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Subdirectorio</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Guardar ruta</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Número de problemas</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>El directorio principal no existe</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>El directorio principal [%1] no existe. ¿Quieres crearlo y continuar?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Error al crear directorio</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Error al crear el directorio [%1].</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Elegir directorio principal</translation>
     </message>
@@ -3869,17 +3084,14 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Visualizador de diferencias</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Esperado</translation>
     </message>
@@ -3887,33 +3099,26 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation>Cronómetro</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation>Empezar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation>Pausar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation>Reanudar</translation>
     </message>
@@ -3921,222 +3126,162 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::StressTesting</name>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished">Empezar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">Error al crear directorio temporal</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Leer testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Guardar testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Compilador</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">Límite de tiempo excedido</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4144,72 +3289,58 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Esperado</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Ejecutar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Probar en un único caso de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Abrir el visualizador de diferencias</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Salida #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Esperado #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Eliminar caso de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>¿Estás seguro de que deseas eliminar el caso de prueba #%1?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Visualizador de diferencias[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>La salida/esperada contiene más de %1 caracteres, el visor de diferencias HTML está deshabilitado. Puedes cambiar el límite de longitud en %2.</translation>
     </message>
@@ -4217,54 +3348,42 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Esperado</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Solo se muestran los primeros %1 caracteres. Ahora el editor de casos de prueba es de solo lectura. Puedes establecer el límite de longitud en %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Guardar en archivo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Guardar caso de prueba en archivo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Cargar desde un archivo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Editar en ventana más grande</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Editar caso de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar salida a esperado</translation>
     </message>
@@ -4272,224 +3391,174 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Casos de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Verificador:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Añadir prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Añadir verificador</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>No aceptado / Aceptado / Total</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Añade un verificador personalizado de testlib</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Añadir pares de casos de prueba desde archivos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Elige archivos de casos de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Casos de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Cargar casos de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Se cargó un par de casos de prueba [%1] y [%2]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Se cargó una entrada [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Los siguientes archivos no se cargan porque no coinciden:%1. Puedes establecer las reglas de emparejamiento en %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Marcar todo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Desmarcar todo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Desmarcar aceptados</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Invertir</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Eliminar todo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>¿Estás seguro de que quieres eliminar todos los casos de prueba?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Eliminar vacíos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Eliminar marcados</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>¿Estás seguro de que quieres eliminar todos los casos de prueba marcados?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Copiar casos de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Pegar casos de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar salida a esperado</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>¿Estás seguro de que quieres copiar todas las salidas marcadas a sus correspondientes esperadas?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Ignorar espacios finales</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Estrictamente igual</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Comparar int64</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Comparar doubles, error máximo 1e-4</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Comparar doubles, error máximo 1e-6</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Comparar doubles, error máximo 1e-9</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Comparar tokens</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Comparar YES/NO, insensible a mayúsculas y minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Añadir caso de prueba</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Ya hay %1 casos de prueba, no se pueden agregar más.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Esperado #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Guardar entrada #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Guardar esperado #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Cargar %1</translation>
     </message>
@@ -4497,32 +3566,26 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Descargar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Nueva actualización disponible</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>Está disponible una nueva actualización de %1 &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt;. Consulte a continuación el registro de cambios.&lt;br /&gt;Recomendamos encarecidamente que mantenga el editor actualizado para no perderse las increíbles nuevas funcionalidades y soluciones de errores.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>beta</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>estable</translation>
     </message>
@@ -4530,37 +3593,30 @@ No todos los comandos de Vim están soportados, consulte https://github.com/cped
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Cerrar este cuadro de diálogo y cancelar la comprobación de actualizaciones</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Comprobador de actualizaciones</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Recopilando la lista de lanzamientos...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Error: %1&lt;br /&gt;&lt;br /&gt;El actualizador no ha podido comprobar las actualizaciones. Compruebe manualmente las actualizaciones en&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; o &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation>¡Hurra! Ya estás utilizando la última versión de CP Editor.</translation>
     </message>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -4,465 +4,438 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Saída</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>Na última sessão, o CP Editor foi encerrado abruptamente, quer restaurar a última sessão?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Mostrar a janela principal</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Abrir arquivos</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>Sobre o CP Editor %1</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Ο CP Editor&lt;/b&gt; é um editor de código baseado em Qt. É especialmente projetado para programação competitiva, diferente de outros editores/IDEs voltados para desenvolvedores. Serve para concentrar o foco no algoritmo e na automatização da compilação, execução e teste. Pode até mesmo verificar casos de testes em diferentes plataformas e submeter soluções para o Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Esse é um software livre; ver o código fonte para conhecer as condições para cópia. NÃO há qualquer garantia; nem para a comercialização ou ajuste a um uso particular. O código fonte para o CP editor está disponível em &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Abrir arquivos</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Restaurar preferências</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>Deseja restaurar todas as preferências para seus valores padrões?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1316"/>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>Snippets</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>Não há snippets para %1. Favor adicionar snippets na janela de preferências.</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Usar snippets</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Escolher snippet:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>Não há snippet com o nome %1 para %2</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Fechar outros</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Fechar à esquerda</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Fechar à direita</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Copiar caminho para o arquivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Copiar URL do problema</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Definir URL do Codeforces</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Definir URL do CF</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Entrar com o ID da competição:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Entrar com o código do problema (Α-Z):</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1602"/>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Definir URL do problema</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Entrar com a URL do novo problema:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Registrador de eventos</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Todos os registros exceto os da sessão atual foram apagados</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: Um editor especialmente projetado para programação competitiva</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation type="vanished">Salvar como...</translation>
+        <translation>Salvar como...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation type="vanished">Salvar como um arquivo novo</translation>
+        <translation>Salvar como um arquivo novo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Salvar todos</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation type="vanished">Salvar todos os arquivos abertos</translation>
+        <translation>Salvar todos os arquivos abertos</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation type="vanished">Fechar atual</translation>
+        <translation>Fechar atual</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation type="vanished">Fechar aba atual</translation>
+        <translation>Fechar aba atual</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Fechar o salvo</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation type="vanished">Fechar as abas salvas</translation>
+        <translation>Fechar as abas salvas</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Fechar todos</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation type="vanished">Fechar todas as abas</translation>
+        <translation>Fechar todas as abas</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Sair</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation type="vanished">Sair da aplicação</translation>
+        <translation>Sair da aplicação</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation type="vanished">Abrir arquivo...</translation>
+        <translation>Abrir arquivo...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation type="vanished">Abrir arquivos</translation>
+        <translation>Abrir arquivos</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation type="vanished">Abrir competição...</translation>
+        <translation>Abrir competição...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation type="vanished">Abrir uma competição</translation>
+        <translation>Abrir uma competição</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation type="vanished">Indentar</translation>
+        <translation>Indentar</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation type="vanished">Remover indentação</translation>
+        <translation>Remover indentação</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation type="vanished">Trocar linha acima</translation>
+        <translation>Trocar linha acima</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation type="vanished">Trocar linha abaixo</translation>
+        <translation>Trocar linha abaixo</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation type="vanished">Duplicar linha</translation>
+        <translation>Duplicar linha</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation type="vanished">Remover linha</translation>
+        <translation>Remover linha</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation type="vanished">Alternar comentário</translation>
+        <translation>Alternar comentário</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation type="vanished">Alternar bloco de comentário</translation>
+        <translation>Alternar bloco de comentário</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Compilar</translation>
+        <translation>Compilar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Compilar e executar</translation>
+        <translation>Compilar e executar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Executar</translation>
+        <translation>Executar</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation type="vanished">Formatar código</translation>
+        <translation>Formatar código</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation type="vanished">Executar em separado</translation>
+        <translation>Executar em separado</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation type="vanished">Encerrar processos</translation>
+        <translation>Encerrar processos</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation type="vanished">Procurar e substituir</translation>
+        <translation>Procurar e substituir</translation>
+    </message>
+    <message>
+        <source>Stress Testing...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation type="vanished">Preferências</translation>
+        <translation>Preferências</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation type="vanished">Sobre Qt</translation>
+        <translation>Sobre Qt</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Informação para montagem</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation type="vanished">Verificar atualizações</translation>
+        <translation>Verificar atualizações</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation type="vanished">Novo arquivo</translation>
+        <translation>Novo arquivo</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation type="vanished">Abrir uma nova aba no editor</translation>
+        <translation>Abrir uma nova aba no editor</translation>
+    </message>
+    <message>
+        <source>Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with generator template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with C++ template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Java template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Python template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation type="vanished">Salvar o arquivo em disco</translation>
+        <translation>Salvar o arquivo em disco</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation type="vanished">Usar snippet...</translation>
+        <translation>Usar snippet...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation type="vanished">Exportar escolhas...</translation>
+        <translation>Exportar escolhas...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation type="vanished">Importar escolhas...</translation>
+        <translation>Importar escolhas...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation type="vanished">Restaurar padrões</translation>
+        <translation>Restaurar padrões</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation type="vanished">Manual</translation>
+        <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation type="vanished">Modo Editor</translation>
+        <translation>Modo Editor</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation type="vanished">Modo E/S</translation>
+        <translation>Modo E/S</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation type="vanished">Modo dividido</translation>
+        <translation>Modo dividido</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation type="vanished">Mostrar arquivos com registros</translation>
+        <translation>Mostrar arquivos com registros</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation type="vanished">Apagar arquivos com registros</translation>
+        <translation>Apagar arquivos com registros</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Arquivo</translation>
+        <translation>&amp;Arquivo</translation>
+    </message>
+    <message>
+        <source>New File From Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="vanished">&amp;Editar</translation>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation type="vanished">&amp;Ações</translation>
+        <translation>&amp;Ações</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Visualizar</translation>
+        <translation>&amp;Visualizar</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation type="vanished">&amp;Opções</translation>
+        <translation>&amp;Opções</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="vanished">&amp;Ajuda</translation>
+        <translation>&amp;Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Exportar escolhas para arquivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Importar escolhas de arquivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Exportar a sessão atual para arquivo</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Exportar sessão</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Falha ao exportar a sessão atual para [%1]</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Carregar sessão</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Ao carregar a sessão de arquivo todas as abas da sessão atual serão fechadas sem serem guardadas em arquivos. Continuar?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Carregar sessão de arquivo</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation type="vanished">Exportar sessão...</translation>
+        <translation>Exportar sessão...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation type="vanished">Carregar sessão...</translation>
+        <translation>Carregar sessão...</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="779"/>
-        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Escolhas para o CP Editor</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="807"/>
-        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Arquivo da sessão do CP Editor</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation type="vanished">Relatar problemas</translation>
+        <translation>Relatar problemas</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Importar escolhas</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Todas as escolhas atuais serão perdidas ao importar outras de arquivo. Continuar?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Duplicar aba</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -475,206 +448,169 @@ Build time: %4
 Sistema Operacional: %5</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Versão portátil</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Versão para instalar</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Abrir arquivos recentes</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>Nenhum arquivo aberto recentemente</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Limpar arquivos recentes</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Arquivo fonte</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Arquivo executável</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Abrir problema no navegador</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Defini comando para a compilação</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Definir o limite de tempo</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation type="vanished">Usar a tela inteira</translation>
+        <translation>Usar a tela inteira</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation type="vanished">Apoiar-nos</translation>
+        <translation>Apoiar-nos</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>Como sair da tela inteira</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>Pressionar a tecla F11 para sair do modo de tela inteira.</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="obsolete">C++</translation>
+        <translation type="unfinished">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="obsolete">Java</translation>
+        <translation type="unfinished">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="obsolete">Python</translation>
+        <translation type="unfinished">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Procurar...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Acrescentar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Renomear snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Carregar snippets de arquivo</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Extrair snippets para arquivo</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Nenhum snippet selecionado</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Snippets não salvos</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>O snippet [%1] foi alterado. Quer salvar ou descartar as alterações?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Remover snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>Quer mesmo remover o snippet [%1]?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Carregar snippets</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Falha ao abrir [%1]. Tem permissão para ler?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Extrair snippets</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Extrair snippet: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Falha ao gravar em [%1]. Tem permissão para gravar?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>O nome do snippet não pode ser vazio.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Conflito com o nome do snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>O nome &quot;%1&quot; está em uso. Quer sobrescrever? (O antigo será removido.)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>O nome &quot;%1&quot; está em uso.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Acrescentar snippet</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Novo nome para o snippet:</translation>
     </message>
@@ -682,93 +618,68 @@ Sistema Operacional: %5</translation>
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Ler verificador</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
-        <location filename="../src/Core/Checker.cpp" line="99"/>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
-        <location filename="../src/Core/Checker.cpp" line="301"/>
-        <location filename="../src/Core/Checker.cpp" line="302"/>
-        <location filename="../src/Core/Checker.cpp" line="303"/>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Verificador</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Falha ao criar diretório temporário</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Ler testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Salvar testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Erro durante a compilação do verificador:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Verificador [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>Verificador encerrado com o código de saída %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>Verificador encerrado com código de saída desconhecido %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Limite de tempo excedido (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>O %1 do processo executado no caso de teste #%2 contém mais do que %3 caracteres, o que é maior que o tamanho permitido para a saída, por isso o processo foi abortado. O limite da saída poderá ser alterado em %4.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>O verificador foi abortado</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Iniciada a compilação do verificador</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>O verificador está compilado</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Falha ao compilar o verificador: %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>O código fonte do verificador foi alterado, recompilar...</translation>
     </message>
@@ -776,22 +687,18 @@ Sistema Operacional: %5</translation>
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>O arquivo fonte [%1] não existe</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Sem suporte para a linguagem de programação &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>Falha ao iniciar o compilador. Favor verificar %1 ou acrescentar o compilador na variável de ambiente PATH.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 está vazio</translation>
     </message>
@@ -799,39 +706,32 @@ Sistema Operacional: %5</translation>
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>O arquivo fonte %1 não existe.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Falha ao executar o comando. Provavelmente é um problema.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Falha ao iniciar a execução. Favor compilar primeiro.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>Programa encerrado com código de saída %1
 Pressionar qualquer tecla para sair</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Falha ao iniciar a execução em separdo. Favor verificar as escolhas para o emulador de terminal em %1.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>A execução em separado não tem suporte nessa plataforma</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>Falha ao criar arquivo temporário.</translation>
     </message>
@@ -839,12 +739,10 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Core::SessionManager</name>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Restaurar a última sessão</translation>
     </message>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Restaurar: [%1]</translation>
     </message>
@@ -852,52 +750,42 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` não requer argumento ou deve ser um entre &apos;cpp&apos;, &apos;java&apos; e &apos;python&apos;, recebido [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] não é um arquivo fonte C++, Python ou Java</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] não existe. Para abrir uma aba com um arquivo inexistente, use `open!`</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] não é um número</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 está fora do intervalo [1, %2]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">N/D</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] não é um modo de visualização válido. Deve ser &apos;split&apos; ou &apos;edit&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 não é um nome de linguagem válido. Deve ser &apos;cpp&apos;, &apos;java&apos; ou &apos;python&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">Nenhuma aba ativa para limpar mensagens</translation>
     </message>
@@ -905,63 +793,42 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>CF Tool abortado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>O código do problema é 0, usar A automaticamente. Se o código do problema atual não for A, favor definir manualmente o código com o acionamento do menu com o botão da direita na aba atual .</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Falha ao obter a versão do CF Tool. O caminho para a CF Tool está definido corretamente em Preferências?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool iniciado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Falha ao iniciar CF Tool em 2 segundos. O caminho para a CF Tool está definido corretamente em Preferências?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Falha ao processar a URL [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>Falha na CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>Falha na CF Tool com código se saída diferente de zero %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Competição %1 Problema %2</translation>
     </message>
@@ -969,50 +836,34 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Formatador</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Falha ao criar diretório temporário</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Formatação completa</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Formatador[stdout]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Formatador[stderr]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>O comando de formatação [%1 %2] encerrou com código de saída %3.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>O processo de formatação não encerrou em 2 segundos. Provavelmente devido ao programa %1 não ter sido encontrado pelo CP editor. O caminho para o programa poderá ser definido em %2.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>A saída do processo de formatação está vazia. Favor garantir de que não há opção para se modificar os argumentos da formatação.</translation>
     </message>
@@ -1020,39 +871,32 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>Servidor fechado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>A porta está definida para %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Falha ao receber na porta %1. Há outro processo na recepção?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Servidor parado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>O verificador JSON relatou erros:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>A requisição recebida não é JSON</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>A requisição %1 foi recebida e ignorada</translation>
     </message>
@@ -1060,42 +904,30 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Servidor da linguagem [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Servidor da linguagem enviou um erro. Favor verificar registros para detalhes.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Falha ao iniciar o processo LSP. O caminho para o programa do servidor da lingugagem está definido em %1?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Processo LSP com tempo esgotado</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Erro de leitura do processo LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Erro de gravação do processo LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Ocorrência de erro desconhecido no processo LSP</translation>
     </message>
@@ -1104,50 +936,50 @@ Pressionar qualquer tecla para sair</translation>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation type="vanished">Procurar/Substituir</translation>
+        <translation>Procurar/Substituir</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Formulário</translation>
+        <translation>Formulário</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation type="vanished">Procurar:</translation>
+        <translation>Procurar:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation type="vanished">Substituir por:</translation>
+        <translation>Substituir por:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation type="vanished">Indicador de erro</translation>
+        <translation>Indicador de erro</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="vanished">Direção</translation>
+        <translation>Direção</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="vanished">Para cima</translation>
+        <translation>Para cima</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="vanished">Para baixo</translation>
+        <translation>Para baixo</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">Opções</translation>
+        <translation>Opções</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation type="vanished">Maiúsculas / minúsculas</translation>
+        <translation>Maiúsculas / minúsculas</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation type="vanished">Somente palavras inteiras</translation>
+        <translation>Somente palavras inteiras</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1158,7 +990,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1169,74 +1001,52 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation type="vanished">Expressão regular</translation>
+        <translation>Expressão regular</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation type="vanished">Procurar</translation>
+        <translation>Procurar</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="vanished">Substituir</translation>
+        <translation>Substituir</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation type="vanished">Substituir todas</translation>
+        <translation>Substituir todas</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="185"/>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Compilador</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Favor definir a linguagem</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="218"/>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="242"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1492"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Executor</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Linguagem errada, favor definir a linguagem</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Todas as entradas estão vazias, nada a fazer</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Confirmar o envio</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1247,101 +1057,78 @@ p, li { white-space: pre-wrap; }
  Γλώσσα: %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="328"/>
-        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Falha ao salvar o arquivo temporário, e a solução não foi enviada.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Sem título-%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Salvar como</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Abrir modelo %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1017"/>
-        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>O arquivo [%1] contém mais do que %2 caracteres, por isso não foi aberto. Poderá alterar o limite de tamanho para a abertura de arquivo em %3.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Salvar arquivo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
-        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Arquivo temporário</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Falha ao criar o diretório temporário</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Ler o modelo %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Salvar alterações</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>Salvar alterações em [%1] antes de fechar?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Novo arquivo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Definir linguagem da aba</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Defininr a linguagem a ser usada nessa aba</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Recarregar</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1352,180 +1139,150 @@ foi alterado em disco.
 Quer recarregar?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Linha %1, Coluna %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>%1 linhas, %2 caracteres selecionados</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>%1 caracteres selecionados</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>Compilação iniciada</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>Compilação encerrada</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Avisos da compilação</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Erro ocorrido durante a compilação</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1517"/>
-        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Erros de compilação</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>Compilação abortada</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>Separar a execução</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Executar [%1]</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>Execução iniciada</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>Execução para o caso de teste #%1 encerrada em %2 (ms)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>Execução para o cado de teste #%1 encerrada com código de saída diferente de zero %2 em %3 (ms)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Limite de tempo excedido (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>O %1 do processo em execução no caso de teste #%2 possui mais do que %3 caracteres, o que excede o limite de tamanho da saída, por isso o processo foi abortado. Poderá alterar o limite de tamanho da saída em %4.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 abortado</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>Separar a execução</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Execução para o caso de teste #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation type="vanished">CP Editor</translation>
+        <translation>CP Editor</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation type="vanished">Informação do cursor</translation>
+        <translation>Informação do cursor</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Compilar</translation>
+        <translation>Compilar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Executar</translation>
+        <translation>Executar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Compilar e executar</translation>
+        <translation>Compilar e executar</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation type="vanished">Mensagens</translation>
+        <translation>Mensagens</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="vanished">Limpar</translation>
+        <translation>Limpar</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="vanished">C++</translation>
+        <translation>C++</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Salvamento automático</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>Definido um nome apropriado para a classe principal da solução? Se não, poderá definir em %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Atributo desconhecido: [%1]. Favor verificar as escolhas dos comentários iniciais em %2.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Definir o comando para compilação</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Personlizar o comando para compilação nessa aba:</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Definir o limite de tempo</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Personalizar o tempo limite para essa aba: (ms)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Necessário instalar a CF Tool para enviar código para o Codeforces. Se já estiver instalada, poderá acrescentá-la à variável de ambiente PATH ou conferir suas escolhas em %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Falha ao iniciar a compilação: %1</translation>
     </message>
@@ -1533,7 +1290,6 @@ Quer recarregar?</translation>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1543,42 +1299,34 @@ Quer recarregar?</translation>
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>Parênteses %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Acrescentar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Nenhum parênteses selecionado</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Novo parênteses</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Inserir parênteses (ex. {}):</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Remover parênteses</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>Quer mesmo remover os parênteses %1?</translation>
     </message>
@@ -1586,29 +1334,24 @@ Quer recarregar?</translation>
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Parênteses: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Habilitar %1 para %2 em %3.
 Se for parcialmente desejada, a escolha em Editar Código será usada.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Completar automaticamente</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Remover automaticamente</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Sair da aba</translation>
     </message>
@@ -1616,25 +1359,18 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="41"/>
-        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Escolher um arquivo</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Executar arquivos</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="84"/>
-        <location filename="../src/Settings/PathItem.cpp" line="86"/>
-        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Escolher um arquivo fonte %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Escolher um arquivo executável</translation>
     </message>
@@ -1642,42 +1378,34 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>Bem-vindo ao CP Editor! Iniciar.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Escolher o editor de códigos</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Comandos para compilar e executar С++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Comandos para compilar e executar Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Comandos para executar Python</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>É possível ler &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; ou através das opções para maiores informações.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Escolher a aparência</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Escolher a fonte</translation>
     </message>
@@ -1685,42 +1413,34 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Restaurar as escolhas padrões para a página atual. (Ctrl+D)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Descartar todas as alterações na página atual. (Ctrl+R)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Salvar as alterações na página atual. (Ctrl+S)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Escolhas não salvas</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>As escolhas foram alteradas. Quer salvar ou descartar?</translation>
     </message>
@@ -1728,284 +1448,239 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
-        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Preferências</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Procurar...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Inicial</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Visitar a página</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation type="vanished">Editar código</translation>
+        <translation>Editar código</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Linguagem</translation>
+        <translation>Linguagem</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="vanished">Geral</translation>
+        <translation>Geral</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="vanished">Aparência</translation>
+        <translation>Aparência</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation type="vanished">Ações</translation>
+        <translation>Ações</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Salvar</translation>
+        <translation>Salvar</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation type="vanished">Associar arquivo e problema</translation>
+        <translation>Associar arquivo e problema</translation>
+    </message>
+    <message>
+        <source>Stress Testing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generator Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation type="vanished">Extensões</translation>
+        <translation>Extensões</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation type="vanished">Formato Clang</translation>
+        <translation>Formato Clang</translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation type="vanished">Servidor de linguagem</translation>
+        <translation>Servidor de linguagem</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>Comandos %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>Modelos %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>Snippets %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>Parênteses %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>Servidor %1</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation type="vanished">Competitive Companion</translation>
+        <translation>Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation type="vanished">CF Tool</translation>
+        <translation>CF Tool</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation type="vanished">Caminho para o arquivo</translation>
+        <translation>Caminho para o arquivo</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation type="vanished">Casos de testes</translation>
+        <translation>Casos de testes</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation type="vanished">URL do problema</translation>
+        <translation>URL do problema</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation type="vanished">Associação de teclas</translation>
+        <translation>Associação de teclas</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="vanished">Avançado</translation>
+        <translation>Avançado</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="vanished">Atualizar</translation>
+        <translation>Atualizar</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation type="vanished">Limites</translation>
+        <translation>Limites</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation type="vanished">Salvar sessão</translation>
+        <translation>Salvar sessão</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation type="vanished">Proxy</translation>
+        <translation>Proxy</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation type="vanished">Caminhos padrões</translation>
+        <translation>Caminhos padrões</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation type="vanished">Carregar alterações de arquivo externo</translation>
+        <translation>Carregar alterações de arquivo externo</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation type="vanished">Separar execução</translation>
+        <translation>Separar execução</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="vanished">Fonte</translation>
+        <translation>Fonte</translation>
     </message>
     <message>
         <source>YAPF</source>
-        <translation type="vanished">YAPF</translation>
+        <translation>YAPF</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation type="vanished">Formatação</translation>
+        <translation>Formatação</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation type="vanished">Casos de testes</translation>
+        <translation>Casos de testes</translation>
     </message>
     <message>
         <source>WakaTime</source>
-        <translation type="vanished">WakaTime</translation>
+        <translation>WakaTime</translation>
     </message>
     <message>
         <source>Stopwatch</source>
-        <translation type="vanished">Cronômetro</translation>
+        <translation>Cronômetro</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation type="vanished">Salvamento automático</translation>
+        <translation>Salvamento automático</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Largura da tabulação</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>A largura para a tabulação, ou o número de espaços para indentação</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>Largura do cursor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>Largura do cursor em pixels</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Fonte do editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>Fonte do editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Linguagem padrão</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>Linguagem padrão a ser usada ao abrir novas abas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Caminho</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Caminho para o arquivo executável para a formatação Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Opções de estilo para formatação Clang, normalmente salvas em arquivo de configuração .clang-format.
 Poderá conhecer mais em &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>Modelo a ser usado ao criar um novo arquivo C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -2014,71 +1689,52 @@ Ao abrir um modelo, a posição do cursor será aquela da regex com um deslocame
 O cursor estará no final do modelo se não houver reconhecimento pela regex.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Se o deslocamento for relativo ao início ou ao final da regex.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>O deslocamento relativo ao reconhecimento da regex em número de caracteres, incluindo espaços em branco.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>Comando a ser usado para compilar C++. NÃO deverá incluir o caminho para o arquivo fonte ou &quot;-o &lt;arquivo de saída&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Argumentos para execução do programa C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>Modelo a ser usado ao criar um novo arquivo Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>Comando para usar ao compilar Java.
 NÃO deverá incluir o caminho do arquivo fonte ou o arquivo compilado da classe.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Argumentos para execução do programa Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>Comando para iniciar o programa Java. NÃO deverá incluir &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>Comando para executar %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>Nome da classe %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>Caminho da classe %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2091,84 +1747,68 @@ Poderá usar &quot;${filename}&quot; para o nome completo do arquivo,
 &quot;${tmpdir}&quot; ou &quot;${tempdir}&quot; para o caminho absoluto do diretório temporário.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>Modelo a ser usado ao criar um novo arquivo Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Argumentos para execução do programa Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>Comandos para iniciar programa em Python. NÃO deverá incluir o caminho para o arquivo fonte.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Tema do editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>Tema para o destaque de sintaxe do editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Completar automaticamente parênteses</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Remover automaticamente parênteses</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Indentar automaticamente</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Acrescentar indentação ao inserir uma nova linha após &quot;{&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Habilitar salvamento automático</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Quebra de texto</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Quebra de linha em várias se não couber na tela.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Usar versão beta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Verificar atualizações marcadas como pré-lançamentos, consideradas não muito estáveis embora recursos adicionais.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Pares de expressões regulares a serem usados ao se adicionarem casos de testes de arquivos.
 Cada par de expressões regulares representa um caso de teste.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -2176,76 +1816,34 @@ This can be overridden for each parenthesis in each language.</source>
 e deslocar-se ao digitar o elemento mais à direita.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>Caminho para o modelo %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>Regex para a posição do cursor do modelo %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>Tipo de deslocamento de posição do cursor do modelo %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>Caracteres para o deslocamento de posição do cursor de modelo %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>Comando do compilador %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>Caminho do arquivo executável%1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2260,19 +1858,14 @@ Poderá usar &quot;${filename}&quot; para completar o nome do arquivo,
 &quot;${tmpdir}&quot; ou &quot;${tempdir}&quot; para o caminho absoluto do diretório temporário.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>Argumentos para execução %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>Nome da classe principal para a solução.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -2281,12 +1874,10 @@ o elemento mais à esquerda se os dois forem adjacentes.
 Isso poderá ser substituído pelo símbolo correspondente em cada linguagem.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Sair de um parênteses ao pressionar Tab</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -2295,325 +1886,250 @@ os parênteses ao sair.
 Isso poderá ser substituído pelo símbolo correspondente em cada linguagem.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Enable Ctrl+Scroll to change font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Usar espaços em lugar do caractere de tabulação.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Substituir tabulações por espaços</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Salvar casos de testes também ao gravar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Salvar os casos de testes em disco ao gravar arquivo, e recuperar esses casos de testes ao ler o arquivo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Verificar atualizações ao iniciar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Verificar se há uma nova versão do CP Editor ao iniciar.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Opacidade</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>Opacidade da janela principal</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Habilitar Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Receber dados enviados pelo Competitive Companion e carregar os casos de testes.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Porta para a conexão</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>Porta a ser usada para receber dados do Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Abrir novas abas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Abrir uma nova aba para cada problema tratado pelo Competitive Companion.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Códigos para a formatação</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Abortar todos os processos</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Compilar e executar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Executar apenas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Compilar apenas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Alterar o modo de visualização</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Usar snippets</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>Caminho para o arquivo executável da CF Tool</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Mostrar compilar e executar apenas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Ocultar os botões para apenas compilar e apenas executar embaixo do editor de códigos na janela principal.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Mostrar EOLN no diff</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Usar &quot;¶&quot; para representar um caractere de mudança de linha na visualização do diff.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Salbar arquivos mais rápido</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Usar sempre o QFile em lugar de QSaveFile ao salvar arquivos.
 Isso será mais rápido embora com um pouco mais de riscos em perder o arquivo (com possibilidade diminuta).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Limite de tamanho da saída</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>Número máximo de caracteres na saída do programa.
 O programa irá abortar se stdout ou stderr forem muito extensos.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Limite de tamanho da mensagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>Número máximo de caracteres em cada mensagem no canto superior direito da janela principal.
 A mensagem será truncada se for muito extensa.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>Limite de tamanho da visualização do diff</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>Número máximo de caracteres na visualização do diff.
 A visualização se reduzirá a texto puro se a saída prevista ou a obtida for muito extensa.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Limite de tamanho do arquivo a ser aberto</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>Número máximo de caracteres no arquivo fonte a ser aberto.
 O arquivo fonte não será aberto se for muito extenso.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Caminho para o LSP executável</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>Caminho para o executável do servidor de linguagem C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Caminho para o executável do servidor de linguagem Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Caminho para o executável do servidor de linguagem Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Usar &quot;linting&quot; com o servidor de linguagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Exibir erros, avisos, informações e dicas no editor de código para linguagem C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Exibir erros, avisos, informações e dicas no editor de código para linguagem Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Exibir erros, avisos, informações e dicas no editor de código para linguagem Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Usar o completar automaticamente no servidor de linguagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Usar o completar automaticamente os resultados do servidor de linguagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Atraso no &quot;linting&quot; (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Atraso no &quot;linting&quot; (ms) após a última modificação de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Argumentos para o servidor de linguagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Argumentos a serem passados ao executável do servidor de linguagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Regras para verificar os casos de testes</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Regex da entrada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>Expressão regurar a ser verificada no nome de todo arquivo de entrada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Substituir resposta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Expressão para substituir o nome do arquivo de resposta.
 Poderá usar &quot;\1&quot; para o primeiro grupo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Caminho para salvar o arquivo de entrada</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2628,12 +2144,10 @@ Poderá usar &quot;${filename}&quot; para o nome completo do arquivo,
 &quot;${1-index}&quot; para o índice do caso de teste começando em 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Caminho para salvar o arquivo de resposta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2648,104 +2162,84 @@ Poderá usar &quot;${filename}&quot; para o nome completo do arquivo,
 &quot;${1-index}&quot; para o índice do caso de teste começando em 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Caminhos padrões para as URLs dos problemas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>Caminho padrão a ser usado ao salvar arquivo novo enquanto a URL do problema for definida</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL do problema</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>Expressão regular para verificar parte da URL do problema</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Caminho do arquivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Expressão para substituir o caminho do arquivo, sem a extensão.
 Poderá usar &quot;\1&quot; para o primeiro grupo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Fonte dos casos de testes</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>Fonte dos casos de testes</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Adicionar margem extra embaixo do editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Acrescentar uma margem extra com a altura de uma página embaixo do editor de código
 Por razões técnicas, ao alterar a altura da margem afeta-se o desfazer do histórico.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Fonte para o registro de mensagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>Fonte para o registro de mensagem</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Salvar arquivo ao compilar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Salvar arquivo ao compilar. Não será salvo se a aba não tiver título.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Salvar arquivo ao executar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Salvar arquivo ao executar. Não será salvo se a aba não tiver título.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Restaurar a URL do problema ao abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Se a URL do problema estiver definida para usar arquivo,
 quando esse for aberto novamente, a URL do problema será restaurada.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Se a URL do problema estiver definida para usar arquivo,
@@ -2753,67 +2247,54 @@ quando houver verificação desse programa a partir do Competitive Companion,
 o arquivo antigo será aberto.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Abrir o arquivo antigo ao verificar a URL do problema também antiga</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>Linguagem da UI</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>Linguagem a ser usada na UI.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>Estilo da UI</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>Estilo de toda a aplicação.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Executar os códigos sobre casos de testes vazios</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Executar o código em todos os casos de testes em evidência mesmo se a entrada for vazia.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Verificar a resposta nos casos de testes com saída vazia</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Verificar a resposta mesmo se a saída normal ou a prevista estiver vazia.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Intervalo para o salvamento automático (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>Intervalo de tempo entre uma alteração e o salvamento automático, ou entre dois salvamentos automáticos..</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Tipo de intervalo para o salvamento automático</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2821,24 +2302,20 @@ Without modification: auto-save happens with a constant interval no matter there
 Sem alteração: o salvamento automático ocorrerá em intervalo constante mesmo sem alteração durante período.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Restaurar a última sessão ao iniciar</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Restaurar a última sessão quando a aplicação iniciar.
 Quando habilitado, não irá perguntar se é para salvar arquivos ao sair.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Salvamento automático da sessão atual periodicamente</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2847,114 +2324,90 @@ Isso será útil caso o computador congelar e tiver que ser desligado ou
 ter a aplicação abortada usando SIGKILL não tratado por ela.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Intervalo da sessão para salvamento automático</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>Intervalo de tempo entre dois salvamentos da sessão atual.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Altura máxima do caso de teste</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>Altura máxima em pixels de caso de teste sem barra de rolagem.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Identificador do proxy, ex. 127.0.0.1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Porta do proxy, ex. 1080</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Usuário do servidor proxy. Pode ser vazio se o servidor proxy não exigir autenticação.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Senha do servidor proxy. Pode ser vazia se o servidor proxy não exigir autenticação.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Usuário</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Senha</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Tipo do proxy. &quot;System&quot; se usar o do sistema.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Usar fonte personalizada da aplicação</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Usar fonte personalizada para toda a aplicação ao invés da fonte padrão do sistema.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Fonte personalizada da aplicação</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>Fonte personalizada para toda a aplicação</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>Codec de saída do compilador %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Codec do texto de saída do compilador (erros, avisos etc.)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Caminhos e nomes de caminhos padrões</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2963,185 +2416,98 @@ Poderão ser usados em ações correspondendo aos padrões com o uso de ${&lt;de
 Poderão ser definidos manualmente ou alterados automaticamente após escolher o caminho para uma ação.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>Nome do caminho padrão</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>Caminho padrão</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>Caminho padrão a ser usado quando escolher o caminho para %1.
 Poderá usar ${&lt;default path name&gt;} como marcação.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Caminhos padrões mudarão após escolher o caminho para %1.
 Lista de nomes para &lt;default path name&gt;, separados por vírgulas, podendo ser vazia.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Salvar arquivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Abrir competição</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Carregar caso de teste unitário</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Acrescentar pares de casos de testes</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Verificador personalizado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Exportar e importar escolhas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Exportar e carregar sessão</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Extrair e carregar snippets</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Caminho padrão a ser usado para %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Caminhos padrões alterados por %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Pode ser substituído por %1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Formatar código ao salvar manualmente</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Formatar código em salvamento automático</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Carregar automaticamente alterações de arquivo externo se ainda houver modificações não salvas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Carregar automaticamente alterações de arquivo que não foram feitas no CP Editor se ainda houver modificações não salvas nesse.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Perguntar se é para carregar alterações de arquivo externo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -3152,39 +2518,32 @@ Se for desabilitado, as alterações de arquivo externo serão ignoradas a não 
 &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Limite de tamanho da saída</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>Número máximo de caracteres a serem exibidos como saída do programa.
 Se a saída for muito extensa, será truncada.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Exibir mensagens sobre as avaliações das submissões</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Exibir mensagem quando a avaliação da submissão for conhecida. Essa mensagem poderá ser vista fora do CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Argumentos do terminal</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Programa do terminal</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -3193,7 +2552,6 @@ Geralmente é o nome ou o caminho do emulador de terminal.
 Alguns dos valores possíveis são konsle, gnome-terminal, xfce-terminal, xterm ou qualquer outro.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -3202,15 +2560,10 @@ Geralmente &quot;-e&quot; para a maioria dos emuladores, incluindo konsole, xter
 Consultar o seu emulador de terminal para os argumentos adequados.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Salvar caso de teste em arquivo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -3221,12 +2574,10 @@ ${time}: o tempo para tratar o problema
 ${json.X.Y}: atributo de dados fornecido pelo Competitive Companion, conforme https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Formato do tempo para os comentários de cabeçalho</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -3237,370 +2588,283 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Acrescentar &quot;Powered By CP Editor&quot; nos comentários de cabeçalho</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Acrescentar linha com &quot;Powered By CP Editor&quot; nos comentários de cabeçalho.
 Não lhe custará nada, mas ajudará mais pessoas a conhecerem o CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Limite de tempo padrão (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>Limite de tempo padrão ao executar o programa.
 O programa irá abortar se não terminar dentro do limite de tempo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Usar o limite de tempo fornecido pelo Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Usar o limite de tempo fornecido pelo Competitive Companion ao verificar a aba correspondente ao limite de tempo.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Exibir fonte somente com espaçamento fixo</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Alterar definição regional (locale)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Necessário reiniciar a aplicação para efetivar completamente as alterações regionais.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Exibir somente fontes com espaçamento fixo ao escolher fonte</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Exibir limite de tamanho para o caso de teste</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Número máximo de caracteres a serem exibidos em caso de teste.
 O caso de teste será truncado e apenas de leitura se for muito extenso.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Programa para formatação Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Argumentos para formatação Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Argumentos a serem passados ao clang-format.  NÃO deverá conter &quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Estido para a formatação Clang</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Programa YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>Programa YAPF. Poderá ser &quot;yapf&quot; (se não necessitar argumentos) ou &quot;python&quot; (que necessitará como argumento &quot;-m yapf&quot;).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Argumentos YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Argumentos a serem passados ao programa. NÃO deverá conter &quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Estilo YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Opções de estilo do YAPF, geralmente salvas em .style.yapf ou setup.conf.
 Poderá aprender mais sobre isso ao executar &quot;yapf --style-help&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Formatar código ao salvar manualmente.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Formatar código ao salvar automaticamente.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Conteúdo dos comentários de cabeçalho</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de tipo correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de local correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de porta correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de usuário correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de senha correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>Desmarcar automaticamente casos de testes aceitos</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>Desmarcar automaticamente casos de testes ao serem aceitos.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>Caminho para o arquivo executável do WakaTime</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Chave da API</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>Habilitar WakaTime</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>Habilitar proxy para conectar ao Github enquanto verificar se há atualizações</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>Poderá ser encontrado em https://wakatime.com/settings/account.
 Poderá ser vazio se tiver o arquivo de configuração global ~/.wakatime.cfg.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>Usar proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>Use Advanced-&gt;Network Proxy para enviar dados para WakaTime.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>Habilitar proxy para verificar atualizações</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação para habilitar proxy para verificar atualizações na página correspondente em https://cpeditor.org/docs/preferences</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation>Exibir cronômetro</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation>Iniciar/Parar cronômetro ao trocar abas</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation>Ao passar para outra aba, iniciar automaticamente o cronômetro 
 na aba atual e pará-lo na aba anterior.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation>Exibir o resultado do cronômetro apenas quando o botão for pressionado</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation>Ocultar o tempo do cronômetro e apenas exibir o tempo quando o botão para mostrar for pressionado.
 Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Habilitar emulação do Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Habilitar a emulação do Vim no editor de código</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Configuração do Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Conteúdo do Vim RC. É carregado toda vez que a emulação do Vim é iniciada.
@@ -3610,7 +2874,6 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Limpar atalho</translation>
     </message>
@@ -3618,52 +2881,42 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Acrescentar</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Acrescentar linha (Ctrl+N)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Apagar a linha atual (Ctrl+W)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Remover item</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>Quer mesmo apagar a linha atual?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Mover para cima</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Mover a linha atual para cima (Ctrl+Shift+Up)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Mover para baixo</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Mover a linha atual para baixo (Ctrl+Shift+Down)</translation>
     </message>
@@ -3671,7 +2924,6 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>SupportEntry</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Doação</translation>
     </message>
@@ -3679,42 +2931,34 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>SupportUsDialog</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>Agrada-lhe o CP Editor?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>Obrigado pr usar o CP Editor!</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Para nos apoiar, poderá:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Conceder-nos uma estrela no GitHub</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Compartilhar o CP Editor com seus colegas</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Fornecer apoio financeiro</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Enviar sugestões para fazermos ainda melhor</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>Uso o @cpeditor_, uma IDE especialmente projetada para programadores competitivos, que é extraordinário!</translation>
     </message>
@@ -3722,17 +2966,14 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>Nenhum lançamento encontrado.</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>Nenhuma URL encontrada para download a versão [%1].</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Esse erro provavelmente foi causado por falta da biblioteca OpenSSL. Poderá visitar &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; para encontrar o instalador, ou proceder a instalação por meio de seu gerenciador de pacotes favorito. Terá que instalar a versão compatível com essa: [%1]</translation>
     </message>
@@ -3740,64 +2981,50 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="87"/>
-        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Falha ao abrir [%1]. Tem permissão para gravar?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="97"/>
-        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Falha ao salvar [%1]. Tem permissão para gravar?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>Arquivo [%1] não existe</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Falha ao abrir [%1]. Tem permissão para ler?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Apresentar %1 no Finder</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Apresentar %1 no Navegador</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Abrir pasta que contém %1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Apresentar %1 no Gerenciador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3805,62 +3032,50 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Criar uma nova competição</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Diretório principal</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Subdiretório</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Número de problemas</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>Diretório principal não existe</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>Diretório principal [%1] não existe. Quer criar e prosseguir?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Falha ao criar o diretório</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Falha ao criar o diretório [%1].</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Detalhes da competição</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Salvar caminho</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Linguagem</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Escolher diretório principal</translation>
     </message>
@@ -3868,17 +3083,14 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>diff</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Saída</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Expectativa</translation>
     </message>
@@ -3886,33 +3098,26 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation>Cronômetro</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation>Cronômetro</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
@@ -3920,222 +3125,162 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::StressTesting</name>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished">Cronômetro</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">Falha ao criar diretório temporário</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Ler testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Salvar testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Compilador</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">Limite de tempo excedido (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4143,72 +3288,58 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Saída</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Expectativa</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Executar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Testar em um caso de teste</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Abrir diff</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Saída #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Expectativa #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Apagar teste de caso</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>Quer mesmo apagar o cado de teste #%1?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>diff [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>A saída/esperada contéma mais do que %1 caracteres, ο diff está desabilitado. Poderá alterar o limite de tamanho em %2.</translation>
     </message>
@@ -4216,54 +3347,42 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Carregar do arquivo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Editar em tela inteira</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Editar teste de caso</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Saída</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Expectativa</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Salvar em arquivo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Salvar teste de caso em arquivo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Apenas os %1 primeiros caracteres serão mostrados. O caso de teste agora é para apenas leitura. Poderá alterar o limite de tamanho em %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar a saída para aquela esperada</translation>
     </message>
@@ -4271,223 +3390,173 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Casos de testes</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Verificador:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Adicionar teste</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Acrescentar verificador</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Acrescentar verificador personalizado de testlib</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Acrescentar pares de casos de testes de arquivos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Escolher arquivos com casos de testes</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Carregar casos de testes</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Par de casos de testes [%1] e [%2] carregados</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Entrada [%1] carregada</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Os seguintes arquivos não foram carregados porque não coincidem:%1. Poderá definir as regras para verificação em %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>Quer mesmo apagar todos os casos de testes?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Inverter</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Ignorar espaços em branco excedentes</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Estritamente o mesmo</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Comparar int64s</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Comparar doubles, erro máximo 1e-4</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Comparar doubles, erro máximo 1e-6</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Comparar doubles, erro máximo 1e-9</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Comparar tokens</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Comparar SIM/NÃO, sem maiúscula e minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Acrescentar teste de caso</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Há %1 casos de testes, não é possível ter mais.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Expectativa #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Salvar entrada #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Salvar expectativa #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Carregar %1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Casos de testes</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>Rejeitado / Aceito / Total</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Verificar todos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Desmarcar todos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Desmarcar aceitos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Apagar todos</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Apagar vazio</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Apagar marcado</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>Quer mesmo apagar todos os casos de testes marcados?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Copiar casos de testes</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Colar casos de testes</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar saída para expectativa</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Quer mesmo copiar todas as saídas marcadas por suas expectativas correspondentes?</translation>
@@ -4496,32 +3565,26 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Baixar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Nova atualização disponível</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>Nova atualização %1 disponível em &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt;. Ver abaixo as alterações.&lt;br /&gt; Recomendamos manter o editor atualizado a fim de aproveitar os novos recursos.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>Beta</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>Estável</translation>
     </message>
@@ -4529,37 +3592,30 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Fechar esse diálogo e abortar a verificação de atualizações</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Atualizar verificador</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Buscar a lista de lançamentos...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Erro: %1&lt;br /&gt;&lt;br /&gt; Falha em verificar se há atualizações. Favor verificar manualmente se há atualizações em &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/ru/download&quot;&gt;https://cpeditor.org/ru/download&lt;/a&gt; ή &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translatorcomment>The most suitable translation</translatorcomment>
         <translation>Pronto! A última versão do CP Editor está à disposição para uso.</translation>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -4,410 +4,465 @@
 <context>
     <name>AppWindow</name>
     <message>
+        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Saída</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>Na última sessão, o CP Editor foi encerrado abruptamente, quer restaurar a última sessão?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Mostrar a janela principal</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Abrir arquivos</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>Sobre o CP Editor %1</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Ο CP Editor&lt;/b&gt; é um editor de código baseado em Qt. É especialmente projetado para programação competitiva, diferente de outros editores/IDEs voltados para desenvolvedores. Serve para concentrar o foco no algoritmo e na automatização da compilação, execução e teste. Pode até mesmo verificar casos de testes em diferentes plataformas e submeter soluções para o Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Esse é um software livre; ver o código fonte para conhecer as condições para cópia. NÃO há qualquer garantia; nem para a comercialização ou ajuste a um uso particular. O código fonte para o CP editor está disponível em &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Abrir arquivos</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Restaurar preferências</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>Deseja restaurar todas as preferências para seus valores padrões?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1316"/>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>Snippets</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>Não há snippets para %1. Favor adicionar snippets na janela de preferências.</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Usar snippets</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Escolher snippet:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>Não há snippet com o nome %1 para %2</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Fechar outros</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Fechar à esquerda</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Fechar à direita</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Copiar caminho para o arquivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Copiar URL do problema</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Definir URL do Codeforces</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Definir URL do CF</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Entrar com o ID da competição:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Entrar com o código do problema (Α-Z):</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1602"/>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Definir URL do problema</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Entrar com a URL do novo problema:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Registrador de eventos</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Todos os registros exceto os da sessão atual foram apagados</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: Um editor especialmente projetado para programação competitiva</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Salvar como...</translation>
+        <translation type="vanished">Salvar como...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation>Salvar como um arquivo novo</translation>
+        <translation type="vanished">Salvar como um arquivo novo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Salvar todos</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation>Salvar todos os arquivos abertos</translation>
+        <translation type="vanished">Salvar todos os arquivos abertos</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation>Fechar atual</translation>
+        <translation type="vanished">Fechar atual</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation>Fechar aba atual</translation>
+        <translation type="vanished">Fechar aba atual</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Fechar o salvo</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation>Fechar as abas salvas</translation>
+        <translation type="vanished">Fechar as abas salvas</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Fechar todos</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation>Fechar todas as abas</translation>
+        <translation type="vanished">Fechar todas as abas</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Sair</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation>Sair da aplicação</translation>
+        <translation type="vanished">Sair da aplicação</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation>Abrir arquivo...</translation>
+        <translation type="vanished">Abrir arquivo...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation>Abrir arquivos</translation>
+        <translation type="vanished">Abrir arquivos</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation>Abrir competição...</translation>
+        <translation type="vanished">Abrir competição...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation>Abrir uma competição</translation>
+        <translation type="vanished">Abrir uma competição</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation>Indentar</translation>
+        <translation type="vanished">Indentar</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation>Remover indentação</translation>
+        <translation type="vanished">Remover indentação</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation>Trocar linha acima</translation>
+        <translation type="vanished">Trocar linha acima</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation>Trocar linha abaixo</translation>
+        <translation type="vanished">Trocar linha abaixo</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation>Duplicar linha</translation>
+        <translation type="vanished">Duplicar linha</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation>Remover linha</translation>
+        <translation type="vanished">Remover linha</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation>Alternar comentário</translation>
+        <translation type="vanished">Alternar comentário</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation>Alternar bloco de comentário</translation>
+        <translation type="vanished">Alternar bloco de comentário</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Compilar</translation>
+        <translation type="vanished">Compilar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Compilar e executar</translation>
+        <translation type="vanished">Compilar e executar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Executar</translation>
+        <translation type="vanished">Executar</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation>Formatar código</translation>
+        <translation type="vanished">Formatar código</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation>Executar em separado</translation>
+        <translation type="vanished">Executar em separado</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation>Encerrar processos</translation>
+        <translation type="vanished">Encerrar processos</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation>Procurar e substituir</translation>
+        <translation type="vanished">Procurar e substituir</translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation>Preferências</translation>
+        <translation type="vanished">Preferências</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation>Sobre Qt</translation>
+        <translation type="vanished">Sobre Qt</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Informação para montagem</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation>Verificar atualizações</translation>
+        <translation type="vanished">Verificar atualizações</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation>Novo arquivo</translation>
+        <translation type="vanished">Novo arquivo</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation>Abrir uma nova aba no editor</translation>
+        <translation type="vanished">Abrir uma nova aba no editor</translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation>Salvar o arquivo em disco</translation>
+        <translation type="vanished">Salvar o arquivo em disco</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation>Usar snippet...</translation>
+        <translation type="vanished">Usar snippet...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation>Exportar escolhas...</translation>
+        <translation type="vanished">Exportar escolhas...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation>Importar escolhas...</translation>
+        <translation type="vanished">Importar escolhas...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation>Restaurar padrões</translation>
+        <translation type="vanished">Restaurar padrões</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation>Manual</translation>
+        <translation type="vanished">Manual</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation>Modo Editor</translation>
+        <translation type="vanished">Modo Editor</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation>Modo E/S</translation>
+        <translation type="vanished">Modo E/S</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation>Modo dividido</translation>
+        <translation type="vanished">Modo dividido</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation>Mostrar arquivos com registros</translation>
+        <translation type="vanished">Mostrar arquivos com registros</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation>Apagar arquivos com registros</translation>
+        <translation type="vanished">Apagar arquivos com registros</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Arquivo</translation>
+        <translation type="vanished">&amp;Arquivo</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Editar</translation>
+        <translation type="vanished">&amp;Editar</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation>&amp;Ações</translation>
+        <translation type="vanished">&amp;Ações</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation>&amp;Visualizar</translation>
+        <translation type="vanished">&amp;Visualizar</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation>&amp;Opções</translation>
+        <translation type="vanished">&amp;Opções</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Ajuda</translation>
+        <translation type="vanished">&amp;Ajuda</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Exportar escolhas para arquivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Importar escolhas de arquivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Exportar a sessão atual para arquivo</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Exportar sessão</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Falha ao exportar a sessão atual para [%1]</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Carregar sessão</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Ao carregar a sessão de arquivo todas as abas da sessão atual serão fechadas sem serem guardadas em arquivos. Continuar?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Carregar sessão de arquivo</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation>Exportar sessão...</translation>
+        <translation type="vanished">Exportar sessão...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation>Carregar sessão...</translation>
+        <translation type="vanished">Carregar sessão...</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="779"/>
+        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Escolhas para o CP Editor</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="807"/>
+        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Arquivo da sessão do CP Editor</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation>Relatar problemas</translation>
+        <translation type="vanished">Relatar problemas</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Importar escolhas</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Todas as escolhas atuais serão perdidas ao importar outras de arquivo. Continuar?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Duplicar aba</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -420,197 +475,206 @@ Build time: %4
 Sistema Operacional: %5</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Versão portátil</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Versão para instalar</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Abrir arquivos recentes</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>Nenhum arquivo aberto recentemente</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Limpar arquivos recentes</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Arquivo fonte</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Arquivo executável</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Abrir problema no navegador</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Defini comando para a compilação</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Definir o limite de tempo</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation>Usar a tela inteira</translation>
+        <translation type="vanished">Usar a tela inteira</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation>Apoiar-nos</translation>
+        <translation type="vanished">Apoiar-nos</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>Como sair da tela inteira</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>Pressionar a tecla F11 para sair do modo de tela inteira.</translation>
     </message>
     <message>
-        <source>Stress Testing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with generator template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New File From Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C++</source>
-        <translation type="unfinished">C++</translation>
-    </message>
-    <message>
-        <source>Open a new tab with C++ template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="unfinished">Java</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Java template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="unfinished">Python</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Python template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Procurar...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Acrescentar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Apagar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Renomear snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Carregar snippets de arquivo</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Extrair snippets para arquivo</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Nenhum snippet selecionado</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Snippets não salvos</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>O snippet [%1] foi alterado. Quer salvar ou descartar as alterações?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Remover snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>Quer mesmo remover o snippet [%1]?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Carregar snippets</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Falha ao abrir [%1]. Tem permissão para ler?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Extrair snippets</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Extrair snippet: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Falha ao gravar em [%1]. Tem permissão para gravar?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>O nome do snippet não pode ser vazio.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Conflito com o nome do snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>O nome &quot;%1&quot; está em uso. Quer sobrescrever? (O antigo será removido.)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>O nome &quot;%1&quot; está em uso.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Acrescentar snippet</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Novo nome para o snippet:</translation>
     </message>
@@ -618,68 +682,93 @@ Sistema Operacional: %5</translation>
 <context>
     <name>Core::Checker</name>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Ler verificador</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
+        <location filename="../src/Core/Checker.cpp" line="99"/>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
+        <location filename="../src/Core/Checker.cpp" line="301"/>
+        <location filename="../src/Core/Checker.cpp" line="302"/>
+        <location filename="../src/Core/Checker.cpp" line="303"/>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Verificador</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Falha ao criar diretório temporário</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Ler testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Salvar testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Erro durante a compilação do verificador:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Verificador [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>Verificador encerrado com o código de saída %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>Verificador encerrado com código de saída desconhecido %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Limite de tempo excedido (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>O %1 do processo executado no caso de teste #%2 contém mais do que %3 caracteres, o que é maior que o tamanho permitido para a saída, por isso o processo foi abortado. O limite da saída poderá ser alterado em %4.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>O verificador foi abortado</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Iniciada a compilação do verificador</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>O verificador está compilado</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Falha ao compilar o verificador: %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>O código fonte do verificador foi alterado, recompilar...</translation>
     </message>
@@ -687,18 +776,22 @@ Sistema Operacional: %5</translation>
 <context>
     <name>Core::Compiler</name>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>O arquivo fonte [%1] não existe</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Sem suporte para a linguagem de programação &quot;%1&quot;</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>Falha ao iniciar o compilador. Favor verificar %1 ou acrescentar o compilador na variável de ambiente PATH.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 está vazio</translation>
     </message>
@@ -706,32 +799,39 @@ Sistema Operacional: %5</translation>
 <context>
     <name>Core::Runner</name>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>O arquivo fonte %1 não existe.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Falha ao executar o comando. Provavelmente é um problema.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Falha ao iniciar a execução. Favor compilar primeiro.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>Programa encerrado com código de saída %1
 Pressionar qualquer tecla para sair</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Falha ao iniciar a execução em separdo. Favor verificar as escolhas para o emulador de terminal em %1.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>A execução em separado não tem suporte nessa plataforma</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>Falha ao criar arquivo temporário.</translation>
     </message>
@@ -739,10 +839,12 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Core::SessionManager</name>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Restaurar a última sessão</translation>
     </message>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Restaurar: [%1]</translation>
     </message>
@@ -750,42 +852,52 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` não requer argumento ou deve ser um entre &apos;cpp&apos;, &apos;java&apos; e &apos;python&apos;, recebido [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] não é um arquivo fonte C++, Python ou Java</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] não existe. Para abrir uma aba com um arquivo inexistente, use `open!`</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] não é um número</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 está fora do intervalo [1, %2]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">N/D</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] não é um modo de visualização válido. Deve ser &apos;split&apos; ou &apos;edit&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 não é um nome de linguagem válido. Deve ser &apos;cpp&apos;, &apos;java&apos; ou &apos;python&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">Nenhuma aba ativa para limpar mensagens</translation>
     </message>
@@ -793,42 +905,63 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::CFTool</name>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>CF Tool abortado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>O código do problema é 0, usar A automaticamente. Se o código do problema atual não for A, favor definir manualmente o código com o acionamento do menu com o botão da direita na aba atual .</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Falha ao obter a versão do CF Tool. O caminho para a CF Tool está definido corretamente em Preferências?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool iniciado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Falha ao iniciar CF Tool em 2 segundos. O caminho para a CF Tool está definido corretamente em Preferências?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Falha ao processar a URL [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>Falha na CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>Falha na CF Tool com código se saída diferente de zero %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Competição %1 Problema %2</translation>
     </message>
@@ -836,34 +969,50 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Formatador</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Falha ao criar diretório temporário</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Formatação completa</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Formatador[stdout]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Formatador[stderr]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>O comando de formatação [%1 %2] encerrou com código de saída %3.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>O processo de formatação não encerrou em 2 segundos. Provavelmente devido ao programa %1 não ter sido encontrado pelo CP editor. O caminho para o programa poderá ser definido em %2.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>A saída do processo de formatação está vazia. Favor garantir de que não há opção para se modificar os argumentos da formatação.</translation>
     </message>
@@ -871,32 +1020,39 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>Servidor fechado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>A porta está definida para %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Falha ao receber na porta %1. Há outro processo na recepção?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Servidor parado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>O verificador JSON relatou erros:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>A requisição recebida não é JSON</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>A requisição %1 foi recebida e ignorada</translation>
     </message>
@@ -904,30 +1060,42 @@ Pressionar qualquer tecla para sair</translation>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Servidor da linguagem [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Servidor da linguagem enviou um erro. Favor verificar registros para detalhes.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Falha ao iniciar o processo LSP. O caminho para o programa do servidor da lingugagem está definido em %1?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Processo LSP com tempo esgotado</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Erro de leitura do processo LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Erro de gravação do processo LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Ocorrência de erro desconhecido no processo LSP</translation>
     </message>
@@ -936,50 +1104,50 @@ Pressionar qualquer tecla para sair</translation>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation>Procurar/Substituir</translation>
+        <translation type="vanished">Procurar/Substituir</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation>Formulário</translation>
+        <translation type="vanished">Formulário</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation>Procurar:</translation>
+        <translation type="vanished">Procurar:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation>Substituir por:</translation>
+        <translation type="vanished">Substituir por:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation>Indicador de erro</translation>
+        <translation type="vanished">Indicador de erro</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation>Direção</translation>
+        <translation type="vanished">Direção</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation>Para cima</translation>
+        <translation type="vanished">Para cima</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation>Para baixo</translation>
+        <translation type="vanished">Para baixo</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Opções</translation>
+        <translation type="vanished">Opções</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation>Maiúsculas / minúsculas</translation>
+        <translation type="vanished">Maiúsculas / minúsculas</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation>Somente palavras inteiras</translation>
+        <translation type="vanished">Somente palavras inteiras</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -990,7 +1158,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1001,52 +1169,74 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation>Expressão regular</translation>
+        <translation type="vanished">Expressão regular</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation>Procurar</translation>
+        <translation type="vanished">Procurar</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation>Substituir</translation>
+        <translation type="vanished">Substituir</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation>Substituir todas</translation>
+        <translation type="vanished">Substituir todas</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../src/mainwindow.cpp" line="185"/>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Compilador</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Favor definir a linguagem</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="218"/>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="242"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1492"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Executor</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Linguagem errada, favor definir a linguagem</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Todas as entradas estão vazias, nada a fazer</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Enviar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Confirmar o envio</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1057,78 +1247,101 @@ p, li { white-space: pre-wrap; }
  Γλώσσα: %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="328"/>
+        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Falha ao salvar o arquivo temporário, e a solução não foi enviada.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Sem título-%1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Salvar como</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Abrir modelo %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1017"/>
+        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>O arquivo [%1] contém mais do que %2 caracteres, por isso não foi aberto. Poderá alterar o limite de tamanho para a abertura de arquivo em %3.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Salvar arquivo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
+        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Arquivo temporário</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Falha ao criar o diretório temporário</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Ler o modelo %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Salvar alterações</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>Salvar alterações em [%1] antes de fechar?</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Novo arquivo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Definir linguagem da aba</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Defininr a linguagem a ser usada nessa aba</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Recarregar</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1139,150 +1352,180 @@ foi alterado em disco.
 Quer recarregar?</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Linha %1, Coluna %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>%1 linhas, %2 caracteres selecionados</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>%1 caracteres selecionados</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>Compilação iniciada</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>Compilação encerrada</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Avisos da compilação</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Erro ocorrido durante a compilação</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1517"/>
+        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Erros de compilação</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>Compilação abortada</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>Separar a execução</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Executar [%1]</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>Execução iniciada</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>Execução para o caso de teste #%1 encerrada em %2 (ms)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>Execução para o cado de teste #%1 encerrada com código de saída diferente de zero %2 em %3 (ms)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Limite de tempo excedido (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>O %1 do processo em execução no caso de teste #%2 possui mais do que %3 caracteres, o que excede o limite de tamanho da saída, por isso o processo foi abortado. Poderá alterar o limite de tamanho da saída em %4.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 abortado</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>Separar a execução</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Execução para o caso de teste #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation>CP Editor</translation>
+        <translation type="vanished">CP Editor</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation>Informação do cursor</translation>
+        <translation type="vanished">Informação do cursor</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Compilar</translation>
+        <translation type="vanished">Compilar</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Executar</translation>
+        <translation type="vanished">Executar</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Compilar e executar</translation>
+        <translation type="vanished">Compilar e executar</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation>Mensagens</translation>
+        <translation type="vanished">Mensagens</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Limpar</translation>
+        <translation type="vanished">Limpar</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation>C++</translation>
+        <translation type="vanished">C++</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Salvamento automático</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>Definido um nome apropriado para a classe principal da solução? Se não, poderá definir em %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Atributo desconhecido: [%1]. Favor verificar as escolhas dos comentários iniciais em %2.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Definir o comando para compilação</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Personlizar o comando para compilação nessa aba:</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Definir o limite de tempo</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Personalizar o tempo limite para essa aba: (ms)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Necessário instalar a CF Tool para enviar código para o Codeforces. Se já estiver instalada, poderá acrescentá-la à variável de ambiente PATH ou conferir suas escolhas em %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Falha ao iniciar a compilação: %1</translation>
     </message>
@@ -1290,6 +1533,7 @@ Quer recarregar?</translation>
 <context>
     <name>MessageLogger</name>
     <message>
+        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1299,34 +1543,42 @@ Quer recarregar?</translation>
 <context>
     <name>ParenthesesPage</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>Parênteses %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Acrescentar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Apagar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Nenhum parênteses selecionado</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Novo parênteses</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Inserir parênteses (ex. {}):</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Remover parênteses</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>Quer mesmo remover os parênteses %1?</translation>
     </message>
@@ -1334,24 +1586,29 @@ Quer recarregar?</translation>
 <context>
     <name>ParenthesisWidget</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Parênteses: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Habilitar %1 para %2 em %3.
 Se for parcialmente desejada, a escolha em Editar Código será usada.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Completar automaticamente</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Remover automaticamente</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Sair da aba</translation>
     </message>
@@ -1359,18 +1616,25 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PathItem</name>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="41"/>
+        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Escolher um arquivo</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Executar arquivos</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="84"/>
+        <location filename="../src/Settings/PathItem.cpp" line="86"/>
+        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Escolher um arquivo fonte %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Escolher um arquivo executável</translation>
     </message>
@@ -1378,34 +1642,42 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PreferencesHomePage</name>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>Bem-vindo ao CP Editor! Iniciar.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Escolher o editor de códigos</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Comandos para compilar e executar С++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Comandos para compilar e executar Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Comandos para executar Python</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>É possível ler &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; ou através das opções para maiores informações.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Escolher a aparência</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Escolher a fonte</translation>
     </message>
@@ -1413,34 +1685,42 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PreferencesPage</name>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Restaurar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Restaurar as escolhas padrões para a página atual. (Ctrl+D)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Descartar todas as alterações na página atual. (Ctrl+R)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Salvar as alterações na página atual. (Ctrl+S)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Escolhas não salvas</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>As escolhas foram alteradas. Quer salvar ou descartar?</translation>
     </message>
@@ -1448,239 +1728,284 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
 <context>
     <name>PreferencesWindow</name>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
+        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Preferências</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Procurar...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Inicial</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Visitar a página</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation>Editar código</translation>
+        <translation type="vanished">Editar código</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation>Linguagem</translation>
+        <translation type="vanished">Linguagem</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Geral</translation>
+        <translation type="vanished">Geral</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation>Aparência</translation>
+        <translation type="vanished">Aparência</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation>Ações</translation>
+        <translation type="vanished">Ações</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Salvar</translation>
+        <translation type="vanished">Salvar</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation>Associar arquivo e problema</translation>
+        <translation type="vanished">Associar arquivo e problema</translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation>Extensões</translation>
+        <translation type="vanished">Extensões</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation>Formato Clang</translation>
+        <translation type="vanished">Formato Clang</translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation>Servidor de linguagem</translation>
+        <translation type="vanished">Servidor de linguagem</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>Comandos %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>Modelos %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>Snippets %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>Parênteses %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>Servidor %1</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation>Competitive Companion</translation>
+        <translation type="vanished">Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation>CF Tool</translation>
+        <translation type="vanished">CF Tool</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation>Caminho para o arquivo</translation>
+        <translation type="vanished">Caminho para o arquivo</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation>Casos de testes</translation>
+        <translation type="vanished">Casos de testes</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation>URL do problema</translation>
+        <translation type="vanished">URL do problema</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation>Associação de teclas</translation>
+        <translation type="vanished">Associação de teclas</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation>Avançado</translation>
+        <translation type="vanished">Avançado</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation>Atualizar</translation>
+        <translation type="vanished">Atualizar</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation>Limites</translation>
+        <translation type="vanished">Limites</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation>Salvar sessão</translation>
+        <translation type="vanished">Salvar sessão</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation>Proxy</translation>
+        <translation type="vanished">Proxy</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation>Caminhos padrões</translation>
+        <translation type="vanished">Caminhos padrões</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation>Carregar alterações de arquivo externo</translation>
+        <translation type="vanished">Carregar alterações de arquivo externo</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation>Separar execução</translation>
+        <translation type="vanished">Separar execução</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation>Fonte</translation>
+        <translation type="vanished">Fonte</translation>
     </message>
     <message>
         <source>YAPF</source>
-        <translation>YAPF</translation>
+        <translation type="vanished">YAPF</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation>Formatação</translation>
+        <translation type="vanished">Formatação</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation>Casos de testes</translation>
+        <translation type="vanished">Casos de testes</translation>
     </message>
     <message>
         <source>WakaTime</source>
-        <translation>WakaTime</translation>
+        <translation type="vanished">WakaTime</translation>
     </message>
     <message>
         <source>Stopwatch</source>
-        <translation>Cronômetro</translation>
+        <translation type="vanished">Cronômetro</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation>Salvamento automático</translation>
-    </message>
-    <message>
-        <source>Stress Testing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator Template</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Salvamento automático</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Largura da tabulação</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>A largura para a tabulação, ou o número de espaços para indentação</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>Largura do cursor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>Largura do cursor em pixels</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Fonte do editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>Fonte do editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Linguagem padrão</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>Linguagem padrão a ser usada ao abrir novas abas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Caminho</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Caminho para o arquivo executável para a formatação Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Opções de estilo para formatação Clang, normalmente salvas em arquivo de configuração .clang-format.
 Poderá conhecer mais em &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>Modelo a ser usado ao criar um novo arquivo C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -1689,52 +2014,71 @@ Ao abrir um modelo, a posição do cursor será aquela da regex com um deslocame
 O cursor estará no final do modelo se não houver reconhecimento pela regex.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Se o deslocamento for relativo ao início ou ao final da regex.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>O deslocamento relativo ao reconhecimento da regex em número de caracteres, incluindo espaços em branco.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>Comando a ser usado para compilar C++. NÃO deverá incluir o caminho para o arquivo fonte ou &quot;-o &lt;arquivo de saída&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Argumentos para execução do programa C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>Modelo a ser usado ao criar um novo arquivo Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>Comando para usar ao compilar Java.
 NÃO deverá incluir o caminho do arquivo fonte ou o arquivo compilado da classe.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Argumentos para execução do programa Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>Comando para iniciar o programa Java. NÃO deverá incluir &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>Comando para executar %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>Nome da classe %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>Caminho da classe %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -1747,68 +2091,84 @@ Poderá usar &quot;${filename}&quot; para o nome completo do arquivo,
 &quot;${tmpdir}&quot; ou &quot;${tempdir}&quot; para o caminho absoluto do diretório temporário.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>Modelo a ser usado ao criar um novo arquivo Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Argumentos para execução do programa Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>Comandos para iniciar programa em Python. NÃO deverá incluir o caminho para o arquivo fonte.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Tema do editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>Tema para o destaque de sintaxe do editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Completar automaticamente parênteses</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Remover automaticamente parênteses</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Indentar automaticamente</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Acrescentar indentação ao inserir uma nova linha após &quot;{&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Habilitar salvamento automático</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Quebra de texto</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Quebra de linha em várias se não couber na tela.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Usar versão beta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Verificar atualizações marcadas como pré-lançamentos, consideradas não muito estáveis embora recursos adicionais.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Pares de expressões regulares a serem usados ao se adicionarem casos de testes de arquivos.
 Cada par de expressões regulares representa um caso de teste.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -1816,34 +2176,76 @@ This can be overridden for each parenthesis in each language.</source>
 e deslocar-se ao digitar o elemento mais à direita.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>Caminho para o modelo %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>Regex para a posição do cursor do modelo %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>Tipo de deslocamento de posição do cursor do modelo %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>Caracteres para o deslocamento de posição do cursor de modelo %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>Comando do compilador %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>Caminho do arquivo executável%1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -1858,14 +2260,19 @@ Poderá usar &quot;${filename}&quot; para completar o nome do arquivo,
 &quot;${tmpdir}&quot; ou &quot;${tempdir}&quot; para o caminho absoluto do diretório temporário.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>Argumentos para execução %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>Nome da classe principal para a solução.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -1874,10 +2281,12 @@ o elemento mais à esquerda se os dois forem adjacentes.
 Isso poderá ser substituído pelo símbolo correspondente em cada linguagem.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Sair de um parênteses ao pressionar Tab</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -1886,242 +2295,325 @@ os parênteses ao sair.
 Isso poderá ser substituído pelo símbolo correspondente em cada linguagem.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Enable Ctrl+Scroll to change font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Usar espaços em lugar do caractere de tabulação.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Substituir tabulações por espaços</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Salvar casos de testes também ao gravar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Salvar os casos de testes em disco ao gravar arquivo, e recuperar esses casos de testes ao ler o arquivo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Verificar atualizações ao iniciar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Verificar se há uma nova versão do CP Editor ao iniciar.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Opacidade</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>Opacidade da janela principal</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Habilitar Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Receber dados enviados pelo Competitive Companion e carregar os casos de testes.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Porta para a conexão</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>Porta a ser usada para receber dados do Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Abrir novas abas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Abrir uma nova aba para cada problema tratado pelo Competitive Companion.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Códigos para a formatação</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Abortar todos os processos</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Compilar e executar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Executar apenas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Compilar apenas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Alterar o modo de visualização</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Usar snippets</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>Caminho para o arquivo executável da CF Tool</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Mostrar compilar e executar apenas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Ocultar os botões para apenas compilar e apenas executar embaixo do editor de códigos na janela principal.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Mostrar EOLN no diff</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Usar &quot;¶&quot; para representar um caractere de mudança de linha na visualização do diff.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Salbar arquivos mais rápido</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Usar sempre o QFile em lugar de QSaveFile ao salvar arquivos.
 Isso será mais rápido embora com um pouco mais de riscos em perder o arquivo (com possibilidade diminuta).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Limite de tamanho da saída</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>Número máximo de caracteres na saída do programa.
 O programa irá abortar se stdout ou stderr forem muito extensos.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Limite de tamanho da mensagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>Número máximo de caracteres em cada mensagem no canto superior direito da janela principal.
 A mensagem será truncada se for muito extensa.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>Limite de tamanho da visualização do diff</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>Número máximo de caracteres na visualização do diff.
 A visualização se reduzirá a texto puro se a saída prevista ou a obtida for muito extensa.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Limite de tamanho do arquivo a ser aberto</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>Número máximo de caracteres no arquivo fonte a ser aberto.
 O arquivo fonte não será aberto se for muito extenso.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Caminho para o LSP executável</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>Caminho para o executável do servidor de linguagem C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Caminho para o executável do servidor de linguagem Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Caminho para o executável do servidor de linguagem Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Usar &quot;linting&quot; com o servidor de linguagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Exibir erros, avisos, informações e dicas no editor de código para linguagem C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Exibir erros, avisos, informações e dicas no editor de código para linguagem Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Exibir erros, avisos, informações e dicas no editor de código para linguagem Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Usar o completar automaticamente no servidor de linguagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Usar o completar automaticamente os resultados do servidor de linguagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Atraso no &quot;linting&quot; (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Atraso no &quot;linting&quot; (ms) após a última modificação de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Argumentos para o servidor de linguagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Argumentos a serem passados ao executável do servidor de linguagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Regras para verificar os casos de testes</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Regex da entrada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>Expressão regurar a ser verificada no nome de todo arquivo de entrada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Substituir resposta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Expressão para substituir o nome do arquivo de resposta.
 Poderá usar &quot;\1&quot; para o primeiro grupo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Caminho para salvar o arquivo de entrada</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2136,10 +2628,12 @@ Poderá usar &quot;${filename}&quot; para o nome completo do arquivo,
 &quot;${1-index}&quot; para o índice do caso de teste começando em 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Caminho para salvar o arquivo de resposta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2154,84 +2648,104 @@ Poderá usar &quot;${filename}&quot; para o nome completo do arquivo,
 &quot;${1-index}&quot; para o índice do caso de teste começando em 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Caminhos padrões para as URLs dos problemas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>Caminho padrão a ser usado ao salvar arquivo novo enquanto a URL do problema for definida</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL do problema</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>Expressão regular para verificar parte da URL do problema</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Caminho do arquivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Expressão para substituir o caminho do arquivo, sem a extensão.
 Poderá usar &quot;\1&quot; para o primeiro grupo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Fonte dos casos de testes</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>Fonte dos casos de testes</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Adicionar margem extra embaixo do editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Acrescentar uma margem extra com a altura de uma página embaixo do editor de código
 Por razões técnicas, ao alterar a altura da margem afeta-se o desfazer do histórico.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Fonte para o registro de mensagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>Fonte para o registro de mensagem</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Salvar arquivo ao compilar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Salvar arquivo ao compilar. Não será salvo se a aba não tiver título.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Salvar arquivo ao executar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Salvar arquivo ao executar. Não será salvo se a aba não tiver título.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Restaurar a URL do problema ao abrir arquivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Se a URL do problema estiver definida para usar arquivo,
 quando esse for aberto novamente, a URL do problema será restaurada.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Se a URL do problema estiver definida para usar arquivo,
@@ -2239,54 +2753,67 @@ quando houver verificação desse programa a partir do Competitive Companion,
 o arquivo antigo será aberto.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Abrir o arquivo antigo ao verificar a URL do problema também antiga</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>Linguagem da UI</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>Linguagem a ser usada na UI.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>Estilo da UI</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>Estilo de toda a aplicação.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Executar os códigos sobre casos de testes vazios</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Executar o código em todos os casos de testes em evidência mesmo se a entrada for vazia.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Verificar a resposta nos casos de testes com saída vazia</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Verificar a resposta mesmo se a saída normal ou a prevista estiver vazia.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Intervalo para o salvamento automático (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>Intervalo de tempo entre uma alteração e o salvamento automático, ou entre dois salvamentos automáticos..</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Tipo de intervalo para o salvamento automático</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2294,20 +2821,24 @@ Without modification: auto-save happens with a constant interval no matter there
 Sem alteração: o salvamento automático ocorrerá em intervalo constante mesmo sem alteração durante período.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Restaurar a última sessão ao iniciar</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Restaurar a última sessão quando a aplicação iniciar.
 Quando habilitado, não irá perguntar se é para salvar arquivos ao sair.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Salvamento automático da sessão atual periodicamente</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2316,90 +2847,114 @@ Isso será útil caso o computador congelar e tiver que ser desligado ou
 ter a aplicação abortada usando SIGKILL não tratado por ela.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Intervalo da sessão para salvamento automático</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>Intervalo de tempo entre dois salvamentos da sessão atual.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Altura máxima do caso de teste</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>Altura máxima em pixels de caso de teste sem barra de rolagem.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Identificador do proxy, ex. 127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Porta do proxy, ex. 1080</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Usuário do servidor proxy. Pode ser vazio se o servidor proxy não exigir autenticação.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Senha do servidor proxy. Pode ser vazia se o servidor proxy não exigir autenticação.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Nome</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Usuário</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Senha</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Tipo do proxy. &quot;System&quot; se usar o do sistema.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Usar fonte personalizada da aplicação</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Usar fonte personalizada para toda a aplicação ao invés da fonte padrão do sistema.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Fonte personalizada da aplicação</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>Fonte personalizada para toda a aplicação</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>Codec de saída do compilador %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Codec do texto de saída do compilador (erros, avisos etc.)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Caminhos e nomes de caminhos padrões</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2408,98 +2963,185 @@ Poderão ser usados em ações correspondendo aos padrões com o uso de ${&lt;de
 Poderão ser definidos manualmente ou alterados automaticamente após escolher o caminho para uma ação.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>Nome do caminho padrão</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>Caminho padrão</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>Caminho padrão a ser usado quando escolher o caminho para %1.
 Poderá usar ${&lt;default path name&gt;} como marcação.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Caminhos padrões mudarão após escolher o caminho para %1.
 Lista de nomes para &lt;default path name&gt;, separados por vírgulas, podendo ser vazia.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Salvar arquivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Abrir competição</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Carregar caso de teste unitário</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Acrescentar pares de casos de testes</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Verificador personalizado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Exportar e importar escolhas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Exportar e carregar sessão</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Extrair e carregar snippets</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Caminho padrão a ser usado para %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Caminhos padrões alterados por %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Pode ser substituído por %1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Formatar código ao salvar manualmente</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Formatar código em salvamento automático</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Carregar automaticamente alterações de arquivo externo se ainda houver modificações não salvas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Carregar automaticamente alterações de arquivo que não foram feitas no CP Editor se ainda houver modificações não salvas nesse.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Perguntar se é para carregar alterações de arquivo externo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -2510,32 +3152,39 @@ Se for desabilitado, as alterações de arquivo externo serão ignoradas a não 
 &quot;%1&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Limite de tamanho da saída</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>Número máximo de caracteres a serem exibidos como saída do programa.
 Se a saída for muito extensa, será truncada.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Exibir mensagens sobre as avaliações das submissões</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Exibir mensagem quando a avaliação da submissão for conhecida. Essa mensagem poderá ser vista fora do CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Argumentos do terminal</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Programa do terminal</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -2544,6 +3193,7 @@ Geralmente é o nome ou o caminho do emulador de terminal.
 Alguns dos valores possíveis são konsle, gnome-terminal, xfce-terminal, xterm ou qualquer outro.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -2552,10 +3202,15 @@ Geralmente &quot;-e&quot; para a maioria dos emuladores, incluindo konsole, xter
 Consultar o seu emulador de terminal para os argumentos adequados.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Salvar caso de teste em arquivo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2566,10 +3221,12 @@ ${time}: o tempo para tratar o problema
 ${json.X.Y}: atributo de dados fornecido pelo Competitive Companion, conforme https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Formato do tempo para os comentários de cabeçalho</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2580,283 +3237,370 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Acrescentar &quot;Powered By CP Editor&quot; nos comentários de cabeçalho</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Acrescentar linha com &quot;Powered By CP Editor&quot; nos comentários de cabeçalho.
 Não lhe custará nada, mas ajudará mais pessoas a conhecerem o CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Limite de tempo padrão (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>Limite de tempo padrão ao executar o programa.
 O programa irá abortar se não terminar dentro do limite de tempo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Usar o limite de tempo fornecido pelo Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Usar o limite de tempo fornecido pelo Competitive Companion ao verificar a aba correspondente ao limite de tempo.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Exibir fonte somente com espaçamento fixo</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Alterar definição regional (locale)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Necessário reiniciar a aplicação para efetivar completamente as alterações regionais.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Exibir somente fontes com espaçamento fixo ao escolher fonte</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Exibir limite de tamanho para o caso de teste</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Número máximo de caracteres a serem exibidos em caso de teste.
 O caso de teste será truncado e apenas de leitura se for muito extenso.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Programa para formatação Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Argumentos para formatação Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Argumentos a serem passados ao clang-format.  NÃO deverá conter &quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Estido para a formatação Clang</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Programa YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>Programa YAPF. Poderá ser &quot;yapf&quot; (se não necessitar argumentos) ou &quot;python&quot; (que necessitará como argumento &quot;-m yapf&quot;).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Argumentos YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Argumentos a serem passados ao programa. NÃO deverá conter &quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Estilo YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Opções de estilo do YAPF, geralmente salvas em .style.yapf ou setup.conf.
 Poderá aprender mais sobre isso ao executar &quot;yapf --style-help&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Formatar código ao salvar manualmente.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Formatar código ao salvar automaticamente.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Conteúdo dos comentários de cabeçalho</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de tipo correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de local correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de porta correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de usuário correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação de senha correspondente na página com a documentação de preferências do editor</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>Desmarcar automaticamente casos de testes aceitos</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>Desmarcar automaticamente casos de testes ao serem aceitos.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>Caminho para o arquivo executável do WakaTime</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Chave da API</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>Habilitar WakaTime</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>Habilitar proxy para conectar ao Github enquanto verificar se há atualizações</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>Poderá ser encontrado em https://wakatime.com/settings/account.
 Poderá ser vazio se tiver o arquivo de configuração global ~/.wakatime.cfg.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>Usar proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>Use Advanced-&gt;Network Proxy para enviar dados para WakaTime.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>Habilitar proxy para verificar atualizações</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>Indicação para habilitar proxy para verificar atualizações na página correspondente em https://cpeditor.org/docs/preferences</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation>Exibir cronômetro</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation>Iniciar/Parar cronômetro ao trocar abas</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation>Ao passar para outra aba, iniciar automaticamente o cronômetro 
 na aba atual e pará-lo na aba anterior.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation>Exibir o resultado do cronômetro apenas quando o botão for pressionado</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation>Ocultar o tempo do cronômetro e apenas exibir o tempo quando o botão para mostrar for pressionado.
 Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Habilitar emulação do Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Habilitar a emulação do Vim no editor de código</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Configuração do Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Conteúdo do Vim RC. É carregado toda vez que a emulação do Vim é iniciada.
@@ -2866,6 +3610,7 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>ShortcutItem</name>
     <message>
+        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Limpar atalho</translation>
     </message>
@@ -2873,42 +3618,52 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>StringListsItem</name>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Acrescentar</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Acrescentar linha (Ctrl+N)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Apagar a linha atual (Ctrl+W)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Remover item</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>Quer mesmo apagar a linha atual?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Mover para cima</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Mover a linha atual para cima (Ctrl+Shift+Up)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Mover para baixo</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Mover a linha atual para baixo (Ctrl+Shift+Down)</translation>
     </message>
@@ -2916,6 +3671,7 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>SupportEntry</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Doação</translation>
     </message>
@@ -2923,34 +3679,42 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>SupportUsDialog</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>Agrada-lhe o CP Editor?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>Obrigado pr usar o CP Editor!</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Para nos apoiar, poderá:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Conceder-nos uma estrela no GitHub</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Compartilhar o CP Editor com seus colegas</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Fornecer apoio financeiro</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Enviar sugestões para fazermos ainda melhor</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>Uso o @cpeditor_, uma IDE especialmente projetada para programadores competitivos, que é extraordinário!</translation>
     </message>
@@ -2958,14 +3722,17 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>Nenhum lançamento encontrado.</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>Nenhuma URL encontrada para download a versão [%1].</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Esse erro provavelmente foi causado por falta da biblioteca OpenSSL. Poderá visitar &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; para encontrar o instalador, ou proceder a instalação por meio de seu gerenciador de pacotes favorito. Terá que instalar a versão compatível com essa: [%1]</translation>
     </message>
@@ -2973,50 +3740,64 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Util::FileUtil</name>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="87"/>
+        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Falha ao abrir [%1]. Tem permissão para gravar?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="97"/>
+        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Falha ao salvar [%1]. Tem permissão para gravar?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>Arquivo [%1] não existe</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Falha ao abrir [%1]. Tem permissão para ler?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Apresentar %1 no Finder</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Apresentar %1 no Navegador</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Abrir pasta que contém %1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Apresentar %1 no Gerenciador de Arquivos</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3024,50 +3805,62 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Criar uma nova competição</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Diretório principal</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Subdiretório</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Número de problemas</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>Diretório principal não existe</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>Diretório principal [%1] não existe. Quer criar e prosseguir?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Falha ao criar o diretório</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Falha ao criar o diretório [%1].</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Detalhes da competição</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Salvar caminho</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Linguagem</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Escolher diretório principal</translation>
     </message>
@@ -3075,14 +3868,17 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>diff</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Saída</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Expectativa</translation>
     </message>
@@ -3090,26 +3886,33 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation>Cronômetro</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation>Pausa</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation>Continuar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation>Cronômetro</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
@@ -3117,162 +3920,222 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::StressTesting</name>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished">Cronômetro</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">Falha ao criar diretório temporário</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Ler testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Salvar testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Compilador</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">Limite de tempo excedido (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3280,58 +4143,72 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::TestCase</name>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Saída</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Expectativa</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Executar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Apagar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Testar em um caso de teste</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Abrir diff</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Saída #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Expectativa #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Apagar teste de caso</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>Quer mesmo apagar o cado de teste #%1?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>diff [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>A saída/esperada contéma mais do que %1 caracteres, ο diff está desabilitado. Poderá alterar o limite de tamanho em %2.</translation>
     </message>
@@ -3339,42 +4216,54 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Carregar do arquivo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Editar em tela inteira</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Editar teste de caso</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Saída</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Expectativa</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Salvar em arquivo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Salvar teste de caso em arquivo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Apenas os %1 primeiros caracteres serão mostrados. O caso de teste agora é para apenas leitura. Poderá alterar o limite de tamanho em %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar a saída para aquela esperada</translation>
     </message>
@@ -3382,173 +4271,223 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::TestCases</name>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Casos de testes</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Verificador:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Adicionar teste</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Acrescentar verificador</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Acrescentar verificador personalizado de testlib</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Acrescentar pares de casos de testes de arquivos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Escolher arquivos com casos de testes</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Carregar casos de testes</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Par de casos de testes [%1] e [%2] carregados</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Entrada [%1] carregada</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Os seguintes arquivos não foram carregados porque não coincidem:%1. Poderá definir as regras para verificação em %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>Quer mesmo apagar todos os casos de testes?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Inverter</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Ignorar espaços em branco excedentes</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Estritamente o mesmo</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Comparar int64s</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Comparar doubles, erro máximo 1e-4</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Comparar doubles, erro máximo 1e-6</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Comparar doubles, erro máximo 1e-9</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Comparar tokens</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Comparar SIM/NÃO, sem maiúscula e minúsculas</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Acrescentar teste de caso</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Há %1 casos de testes, não é possível ter mais.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Entrada #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Expectativa #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Salvar entrada #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Salvar expectativa #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Carregar %1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Casos de testes</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>Rejeitado / Aceito / Total</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Verificar todos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Desmarcar todos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Desmarcar aceitos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Apagar todos</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Apagar vazio</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Apagar marcado</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>Quer mesmo apagar todos os casos de testes marcados?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Copiar casos de testes</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Colar casos de testes</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Copiar saída para expectativa</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Quer mesmo copiar todas as saídas marcadas por suas expectativas correspondentes?</translation>
@@ -3557,26 +4496,32 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Baixar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Nova atualização disponível</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>Nova atualização %1 disponível em &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt;. Ver abaixo as alterações.&lt;br /&gt; Recomendamos manter o editor atualizado a fim de aproveitar os novos recursos.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>Beta</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>Estável</translation>
     </message>
@@ -3584,30 +4529,37 @@ Nem todos os comandos do Vim são suportados, consulte https://github.com/cpedit
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Fechar esse diálogo e abortar a verificação de atualizações</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Atualizar verificador</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Buscar a lista de lançamentos...</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Erro: %1&lt;br /&gt;&lt;br /&gt; Falha em verificar se há atualizações. Favor verificar manualmente se há atualizações em &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/ru/download&quot;&gt;https://cpeditor.org/ru/download&lt;/a&gt; ή &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translatorcomment>The most suitable translation</translatorcomment>
         <translation>Pronto! A última versão do CP Editor está à disposição para uso.</translation>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -4,410 +4,465 @@
 <context>
     <name>AppWindow</name>
     <message>
+        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Принудительный выход</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>Предыдущая сессия CP Editor была завершена некорректно. Вы хотите восстановить предыдущую сессию?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Показать Главное окно</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Открытие файлов</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>О CP Editor %1</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; - редактор кода, созданный на Qt. Дизайн CP Editor специально рассчитан на спортивное программирование, в отличии от других редакторов/IDE, который больше подходят разработчикам. Наш редакатор кода помогает сфокусироваться на построении алгоритма, автодополняя, запуская и тестируя его. Он также может использовать тест-кейсы разных платформ и отправлять решения на Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Это свободно распространяемое программное обеспечение. Условия копирования приведены в исходных текстах. Без гарантии каких-либо качеств, включая коммерческую ценность и применимость для каких-либо целей. Исходный код CP Editor доступен на &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Открыть файлы</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Сбросить настройки</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>Вы действительно хотите сбросить настройки?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1316"/>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>Сниппеты</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>Отсутсвуют сниппеты для %1. Пожалуйста, добавьте соответствущий сниппет в настройках.</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Использовать сниппет</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Выбарть сниппет:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>Отсутствуют сниппеты под названием %1 для %2</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Закрыть другие</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Закрыть все левые</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Закрыть все правые</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Копировать путь файла</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Копировать URL задачи</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Установить Codeforces URL</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Установить CF URL</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Ввести ID соревнования:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Ввести код задачи (A-Z):</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1602"/>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Задать URL задачи</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Задать URL для новой задачи:</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Логгер cобытий</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Все логи, кроме логов текущей сессии, были удалены</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: редактор, созданный для спортивного программирования</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Сохранить как...</translation>
+        <translation type="vanished">Сохранить как...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation>Сохранить как новый файл</translation>
+        <translation type="vanished">Сохранить как новый файл</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Сохранить все</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation>Сохранить все открытые файлы</translation>
+        <translation type="vanished">Сохранить все открытые файлы</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation>Закрыть текущий</translation>
+        <translation type="vanished">Закрыть текущий</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation>Закрыть текущую вкладку</translation>
+        <translation type="vanished">Закрыть текущую вкладку</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Закрыть сохраненные</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation>Закрыть сохраненные вкладки</translation>
+        <translation type="vanished">Закрыть сохраненные вкладки</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Закрыть все</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation>Закрыть все вкладки</translation>
+        <translation type="vanished">Закрыть все вкладки</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Выйти</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation>Выйти из программы</translation>
+        <translation type="vanished">Выйти из программы</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation>Открыть файл....</translation>
+        <translation type="vanished">Открыть файл....</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation>Открыть файлы</translation>
+        <translation type="vanished">Открыть файлы</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation>Открыть соревнование...</translation>
+        <translation type="vanished">Открыть соревнование...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation>Открыть соревнование</translation>
+        <translation type="vanished">Открыть соревнование</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation>Отступ</translation>
+        <translation type="vanished">Отступ</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation>Убрать отступ</translation>
+        <translation type="vanished">Убрать отступ</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation>Поднять строку</translation>
+        <translation type="vanished">Поднять строку</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation>Опустить строку</translation>
+        <translation type="vanished">Опустить строку</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation>Дублировать строку</translation>
+        <translation type="vanished">Дублировать строку</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation>Удалить линию</translation>
+        <translation type="vanished">Удалить линию</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation>Закомментировать строку</translation>
+        <translation type="vanished">Закомментировать строку</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation>Выбрать блок</translation>
+        <translation type="vanished">Выбрать блок</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Скомпилировать</translation>
+        <translation type="vanished">Скомпилировать</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Скомпилировать и запустить</translation>
+        <translation type="vanished">Скомпилировать и запустить</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Запустить</translation>
+        <translation type="vanished">Запустить</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation>Форматировать код</translation>
+        <translation type="vanished">Форматировать код</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation>Запустить отдельно</translation>
+        <translation type="vanished">Запустить отдельно</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation>Убить процесс</translation>
+        <translation type="vanished">Убить процесс</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation>Найти и заменить</translation>
+        <translation type="vanished">Найти и заменить</translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation>Параметры</translation>
+        <translation type="vanished">Параметры</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation>О Qt</translation>
+        <translation type="vanished">О Qt</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Информация о сборке</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation>Проверить обновления</translation>
+        <translation type="vanished">Проверить обновления</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation>Новый файл</translation>
+        <translation type="vanished">Новый файл</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation>Открыть в новой вкладке редактора</translation>
+        <translation type="vanished">Открыть в новой вкладке редактора</translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation>Сохранить файл локально</translation>
+        <translation type="vanished">Сохранить файл локально</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation>Использовать сниппет...</translation>
+        <translation type="vanished">Использовать сниппет...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation>Экспорт настроек...</translation>
+        <translation type="vanished">Экспорт настроек...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation>Импорт настроек...</translation>
+        <translation type="vanished">Импорт настроек...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation>Сбросить настройки</translation>
+        <translation type="vanished">Сбросить настройки</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation>Инструкции</translation>
+        <translation type="vanished">Инструкции</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation>Режим настройщика</translation>
+        <translation type="vanished">Режим настройщика</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation>Режим ввода/вывода</translation>
+        <translation type="vanished">Режим ввода/вывода</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation>Режим Split</translation>
+        <translation type="vanished">Режим Split</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation>Вывести файлы логов</translation>
+        <translation type="vanished">Вывести файлы логов</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation>Удалить файлы логов</translation>
+        <translation type="vanished">Удалить файлы логов</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Файл</translation>
+        <translation type="vanished">&amp;Файл</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Изменить</translation>
+        <translation type="vanished">&amp;Изменить</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation>&amp;Действия</translation>
+        <translation type="vanished">&amp;Действия</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation>&amp;Вид</translation>
+        <translation type="vanished">&amp;Вид</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation>&amp;Опции</translation>
+        <translation type="vanished">&amp;Опции</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Помощь</translation>
+        <translation type="vanished">&amp;Помощь</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Экспорт настроек в файл</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Импорт настроек из файла</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Экспортировать текущую сессию в файл</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Эскпортировать сессию</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Не удалось экспортировать текущую сессию как [%1]</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Загрузка сессии</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Загрузка сессии из файла закроет все открытые вкладки в текущей сессии без сохранения файлов. Вы действительно хотите продолжить?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Загрузка сессии из файла</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation>Экспорт сессии...</translation>
+        <translation type="vanished">Экспорт сессии...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation>Загрузка сессии...</translation>
+        <translation type="vanished">Загрузка сессии...</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="779"/>
+        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Файл настройки CP Editor</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="807"/>
+        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Файл сессии CP Editor</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation>Отчет об ошибках</translation>
+        <translation type="vanished">Отчет об ошибках</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Импорт настроек</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Все текущие настройки будут потеряны после импорта файла настройки. Вы хотите продолжить?</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Дублировать вкладку</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -420,197 +475,206 @@ Git commit hash: %3
 ОС: %5</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Portable-версия</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Версия для установки</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Открыть последние файлы</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>Нет последних файлов</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Очистить последние файлы</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Файл исходного кода</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Исполняемый файл</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Открыть задачу в браузере</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Установить команду компиляции</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Установить лими времени</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation>Полный экран</translation>
+        <translation type="vanished">Полный экран</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation>Поддержи нас</translation>
+        <translation type="vanished">Поддержи нас</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Stress Testing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with generator template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New File From Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C++</source>
-        <translation type="unfinished">C++</translation>
-    </message>
-    <message>
-        <source>Open a new tab with C++ template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="unfinished">Java</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Java template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="unfinished">Python</translation>
-    </message>
-    <message>
-        <source>Open a new tab with Python template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Search...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Удалить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Переименовать сниппет</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Загрузить сниппет из файлов</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Извлечь сниппет в файлы</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Еще</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Сниппет не выбран</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Несохраненные сниппеты</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>Сниппет [%1] был изменен. Вы хотите сохранить изменения или отменить их?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Удалить сниппет</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>Вы действительно хотите удалить сниппет [%1]?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Загрузить сниппет</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Не удалось открыть [%1]. Предоставлен ли доступ к чтению файла?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Дополнительные сниппеты</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Дополнительные сниппеты: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Не удалось записать изменения в файл [%1]. Предоставлен ли доступ к изменению фалйла?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>Название сниппета не может пустым.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Конфликт названий сниппетов</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>Название &quot;%1&quot; уже используется. Вы хотите перезаписать сниппет с таким именем? (Старый сниппет будет удален.)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>Название &quot;%1&quot; уже используется.
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Добавить сниппет</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Новое имя сниппета:</translation>
     </message>
@@ -618,68 +682,93 @@ Git commit hash: %3
 <context>
     <name>Core::Checker</name>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Чиать чекер</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
+        <location filename="../src/Core/Checker.cpp" line="99"/>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
+        <location filename="../src/Core/Checker.cpp" line="301"/>
+        <location filename="../src/Core/Checker.cpp" line="302"/>
+        <location filename="../src/Core/Checker.cpp" line="303"/>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Чекер</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Ошибка при создании временной директории</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Чтение testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Сохранить testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Произошла ошибка во время компиляции чекера:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Чекер[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>Чекер завершил работу с кодом %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>Чекер завершил работу с неизвестым кодом %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Превышено ограничение по времени (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>%1 из процессов при работе на тесткейсе #%2 содержит более чем %3 символов и превосходит лимит. Процесс убит. Вы можете изменить этот лимит в %4.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>Чекер убит</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Начата компиляция чекера</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>Чекер скомпилирован</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Ошибка компиляции символа: %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -687,18 +776,22 @@ Git commit hash: %3
 <context>
     <name>Core::Compiler</name>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>Файл [%1] не существует</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Неподдерживаемый язык программирования &quot;%1&quot;</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>Ошибка при старте компилятора. Пожалуйста, проверьте %1 или добавьте путь компилятора в переменную среды окружения PATH.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 пуст</translation>
     </message>
@@ -706,32 +799,39 @@ Git commit hash: %3
 <context>
     <name>Core::Runner</name>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>Исходный код %1 не существует.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Ошибка во время запуска команды. Возможно это баг.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Ошибка при запуске. Пожалуйста, сперва запустите компиляцию.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>Программа завершилась с кодом %1
 Нажмите на любую клавишу для выхода</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Не удалось запустить отдельно. Пожалуйста, проверьте настройки вашего эмулятора терминала в %1.</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>Отдельный запуск не поддерживается на вашей системе</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -739,10 +839,12 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Восстановление предыдущей сессии</translation>
     </message>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Восстановление: [%1]</translation>
     </message>
@@ -750,42 +852,52 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` не принимает аргументов или принимает один из &apos;cpp&apos;, &apos;java&apos; и &apos;python&apos;, получено [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] не является исходным файлом C++, Python или Java</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] не существует. Чтобы открыть вкладку с несуществующим файлом, используйте `open!`</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] не является числом</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 вне диапазона [1, %2]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">Н/Д</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] не является допустимым режимом просмотра. Допустимые значения: &apos;split&apos; и &apos;edit&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 не является допустимым названием языка. Допустимые значения: &apos;cpp&apos;, &apos;java&apos; и &apos;python&apos;</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">Нет активной вкладки для очистки сообщений</translation>
     </message>
@@ -793,42 +905,63 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>Процесс CF Tool был убит</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>Код задачи - 0, поэтому используется код A автоматически. Если код задачи не А, пожалуйста, установите код вручную в подменю (правая кнопка мыши) текущей вкладки.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Ошибки при получении версии CF Tool. Установлен корректный путь к CF Tool в параметрах?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool запущен</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Ошибки при получении версии CF Tool в течении 2-х секунд. Установлен корректный путь к CF Tool в параметрах?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Ошибка в получении URL [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>Произошла ошибка в CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool заверешил работу с кодом %1 отличным от нуля</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Соревнование %1 Задача %2</translation>
     </message>
@@ -836,34 +969,50 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Форматирование</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Ошибка при создании временной директории</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Форматирование завершено</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Форматирование[stdout]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Форматирование[stderr]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>Команда форматирования [%1 %2] завершилась с кодом %3.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>Процесс форматирования не завершился в течении 2 секунд. Возможно, что программа %1 не найдена CP Editor-ом. Вы можете установить путь программы в %2.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>Выходные данные процесса форматирования пусты. Пожалуйста, убедитесь, что в аргументах форматирования отсутсвует опция самозамены на месте.</translation>
     </message>
@@ -871,32 +1020,39 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>Сервер не доступен</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>Порт установолен на %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Ошибка в прослушивании порта %1. Возможно другой процесс уже работает с этим портом?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Остановка Сервера</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>JSON parser выдает ошибки:
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>Принятый запрос не является JSON&apos;ом</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>Запрос %1 был получен и проигнорирован</translation>
     </message>
@@ -904,30 +1060,42 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Language Server [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Language server выдает ошибку. Пожалуйста, проверьте логи.</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Ошибка при старте Процесса LSP. Вы установили путь к программе Language Server в %1?</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Истекло время исполнения Процесса LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Ошибка чтения Процесса LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Ошибка записи Процесса LSP</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Произошла неизвестная ошибка в Процессе LSP</translation>
     </message>
@@ -936,50 +1104,50 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation>Найти/Заменить</translation>
+        <translation type="vanished">Найти/Заменить</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation>Вид</translation>
+        <translation type="vanished">Вид</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation>Найти:</translation>
+        <translation type="vanished">Найти:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation>Заменить на:</translation>
+        <translation type="vanished">Заменить на:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation>errorLabel</translation>
+        <translation type="vanished">errorLabel</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation>Направление</translation>
+        <translation type="vanished">Направление</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation>Вверх</translation>
+        <translation type="vanished">Вверх</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation>Вниз</translation>
+        <translation type="vanished">Вниз</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Опции</translation>
+        <translation type="vanished">Опции</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation>Учитывать регистр</translation>
+        <translation type="vanished">Учитывать регистр</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation>Только слова целиком</translation>
+        <translation type="vanished">Только слова целиком</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -990,7 +1158,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1001,52 +1169,74 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation>Регулярное выражение</translation>
+        <translation type="vanished">Регулярное выражение</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation>Найти</translation>
+        <translation type="vanished">Найти</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation>Заменить</translation>
+        <translation type="vanished">Заменить</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation>Заменить все</translation>
+        <translation type="vanished">Заменить все</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../src/mainwindow.cpp" line="185"/>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Компилятор</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Пожалуйста установите язык</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="218"/>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="242"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1492"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Runner</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Язык выбран неверно. Пожалуйста, установите другой язык</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Входные данные пусты, нечего запускать</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Отправить</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Подтверждение отправки</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1057,78 +1247,101 @@ p, li { white-space: pre-wrap; }
  ЯП: %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="328"/>
+        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Ошибка в сохранении временного файла. Решение не было отправлено.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Неизвестный-%1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Открыть %1 шаблон</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1017"/>
+        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>Файл [%1] содержит более чем %2 символов и он не был открыт. Вы можете установить лимит количества символов в файле в %3.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
+        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Временный файл</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Ошибка при создании временной директории</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Чтение шаблона %1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Сохранить настройки</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>Сохранить как [%1] перед закрытием?</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Новый файл</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Установить язык вкладки</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Установить язык для использования в этой вкладке</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Перезагрузить</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1139,150 +1352,180 @@ Do you want to reload it?</source>
 Вы хотите его перезагрузить?</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Строка %1, символ %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>Выбрано %1 линей, %2 символов</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>Выбрано %1 символов</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>Начался процесс компиляции</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>Компиляция завершена</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Предупреждения компилятора</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Произошла ошибка во время компиляции</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1517"/>
+        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Ошибки компиляции</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>Компиляция остановлена</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>Подробный запуск</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Runner[%1]</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>Начался запуск программы</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>Запуск программы для тесткейса #%1 завершился за время %2мс</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>Запуск программы для тесткейса #%1 завершился с ненулевым кодом выхода %2 за время %3мс</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Превышен лимит времени выполнения программы (TLE)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>Процесс %1 на тесткейсе #%2 содержит более %3 символов, что превосходит лимит длины. Процесс будет убит. Вы можете изменить лимит длины выходного файла в %4.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 был остановлен</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>Подробный запуск</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Запуск для тесткейса #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation>CP Editor</translation>
+        <translation type="vanished">CP Editor</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation>информация с курсора</translation>
+        <translation type="vanished">информация с курсора</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>Скомпилировать</translation>
+        <translation type="vanished">Скомпилировать</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>Запустить</translation>
+        <translation type="vanished">Запустить</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>Скомпилировать и запустить</translation>
+        <translation type="vanished">Скомпилировать и запустить</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation>Сообщения</translation>
+        <translation type="vanished">Сообщения</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Очистить</translation>
+        <translation type="vanished">Очистить</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation>C++</translation>
+        <translation type="vanished">C++</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Автосохранение</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>Вы установили подходящее имя для главного класса в решении? Если нет, Вы можете установить имя в at %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Неизвестный атрибут: [%1]. Пожалуйста, проверьте настройку комментариев шапки в %2.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Установить команду компиляции</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Нестандартная команда компиляции для этой вкладки:</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Установить лимит времени</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Нестандартный лимит времени для этой вкладки: (в мс)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Вам необходимо устанвоить CF Tool для отправки Вашего кода на Codeforces. Если он уже установлен, вы можете добавить его в переменную среды PATH или проверить Ваши настройки в %1.</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Ошибка старта компиляции: %1</translation>
     </message>
@@ -1290,6 +1533,7 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
+        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1299,34 +1543,42 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>Скобки %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Удалить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Нет выбранных скобок</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Новые скобки</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Введите скобки (например, {}):</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Удалить скобки</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>Вы действительно хотите удалить скобки %1?</translation>
     </message>
@@ -1334,24 +1586,29 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Скобки: %1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Активировано %1 для %2 в %3.
 Выбрано частично, будут использованы глобальные настройки в Code Edit.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Автозавершение</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Автоудаление</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Tab Jump Out</translation>
     </message>
@@ -1359,18 +1616,25 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="41"/>
+        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Выберите файл</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Исполняемый файл</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="84"/>
+        <location filename="../src/Settings/PathItem.cpp" line="86"/>
+        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Выберите %1 как файл исходного кода</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Выберите исполняемый файл</translation>
     </message>
@@ -1378,34 +1642,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>Добро пожаловать в CP Editor! Давайте начнём.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Настройки редактора кода</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Команды компиляции и запуска на С++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Команды компиляции и запуска на Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Команды запуска на Python</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>Вы можете почитать &lt;a href=&quot;%1&quot;&gt;документация&lt;/a&gt; или просмотреть настройки для более подробной информации.</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Настройки внешнего вида</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Настройки шрифтов</translation>
     </message>
@@ -1413,34 +1685,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Восстановить настройки по умолчанию на текущей странице. (Ctrl+D)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Сбросить все изменения на текущей странице. (Ctrl+R)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Сохранить изменения на текущей странице. (Ctrl+S)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Несохраненные настройки</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>Настройки изменены. Вы хотите сохранить настройки или отказаться от них?</translation>
     </message>
@@ -1448,239 +1728,272 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
+        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Параметры</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Поиск...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Домой</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Назад на основную страницу</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation>Редактирование кода</translation>
+        <translation type="vanished">Редактирование кода</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation>Язык</translation>
+        <translation type="vanished">Язык</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Основное</translation>
+        <translation type="vanished">Основное</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation>Внешний вид</translation>
+        <translation type="vanished">Внешний вид</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation>Действия</translation>
+        <translation type="vanished">Действия</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Сохранить</translation>
+        <translation type="vanished">Сохранить</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation>Привязать файл и задачу</translation>
+        <translation type="vanished">Привязать файл и задачу</translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation>Расширения</translation>
+        <translation type="vanished">Расширения</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation>Clang Format</translation>
+        <translation type="vanished">Clang Format</translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation>Language Server</translation>
+        <translation type="vanished">Language Server</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 Команды</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 Шаблоны</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 Сниппеты</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 Скобки</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>%1 Сервер</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation>Competitive Companion</translation>
+        <translation type="vanished">Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation>CF Tool</translation>
+        <translation type="vanished">CF Tool</translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation>Путь файлов</translation>
+        <translation type="vanished">Путь файлов</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation>Тесткейсы</translation>
+        <translation type="vanished">Тесткейсы</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation>URL задачи</translation>
+        <translation type="vanished">URL задачи</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation>Горячие клавиши</translation>
+        <translation type="vanished">Горячие клавиши</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation>Дополнительно</translation>
+        <translation type="vanished">Дополнительно</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation>Обновить</translation>
+        <translation type="vanished">Обновить</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation>Лимиты</translation>
+        <translation type="vanished">Лимиты</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation>Автосохранение</translation>
+        <translation type="vanished">Автосохранение</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation>Сохранении сессиии</translation>
+        <translation type="vanished">Сохранении сессиии</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation>Прокси сети</translation>
+        <translation type="vanished">Прокси сети</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation>Пути по умолчанию</translation>
+        <translation type="vanished">Пути по умолчанию</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation>Загрузка внешних файловый изменений</translation>
+        <translation type="vanished">Загрузка внешних файловый изменений</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation>Отдельный запуск</translation>
+        <translation type="vanished">Отдельный запуск</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation>Шрифт</translation>
-    </message>
-    <message>
-        <source>YAPF</source>
-        <translation></translation>
+        <translation type="vanished">Шрифт</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation>Форматирование кода</translation>
+        <translation type="vanished">Форматирование кода</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation type="unfinished">Тесткейсы</translation>
-    </message>
-    <message>
-        <source>WakaTime</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Stopwatch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Stress Testing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator Template</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Тесткейсы</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Ширина вкладки</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>Ширина символов вкладки или количество пробелов на конце</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Шрифт редактора</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>Шрифт редактора кода</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Язык по умолчанию</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>Язык по умолчанию во время создания новой вкладки</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Путь</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Путь до исполняемых файлов Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Опции Clang Format style, который обычно сохраняются в файле .clang-format.
 Больше информации на &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>Шаблон, используемый для создании нового C++ файла</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -1689,52 +2002,71 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 Курсор будет в конце шаблона, если нет совпадений с регулярным выражением.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Относительное смещение относительно начала регулярного выражения или конца регулярного выражения.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>Смещение относительно совпадения регулярного выражения по количеству символов, включая пробелы.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>Команда, используемая для компиляции C ++. Она НЕ должен включать путь к исходному файлу или &quot;-o &lt;output file&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Аргументы при выполнении программы на C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>Шаблон, используемый при создании нового файла Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>Команда, используемая для компиляции Java.
 Она НЕ должна включать путь к исходному файлу или путь к скомпилированному файлу класса.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Аргументы при выполнении программы на Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>Команда для запуска программы на Java. НЕ должна включать &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 Run Command</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 Имя класса</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 Путь класса</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -1747,68 +2079,84 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; или &quot;${tempdir}&quot; для абсолютного пути к временному каталогу.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>Шаблон, используемый при создании нового файла Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Аргументы, используемые при запуске программы на Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>Команда для запуска программы на Python. Она НЕ должна включать путь к исходному файлу.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Тема редактора</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>Синтаксическая подсветка темы редактора кода</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Автоподстановка скобок</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Автоудаление скобок</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Авто отступ</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Добавьте отступ при вводе новой строки после &quot;{&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Включить автосохранение</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Свернуть текст</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Свернуть строку в несколько строк, если она не помещается на экране.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Использовать бета-версию</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Проверьте наличие обновлений, помеченных как предрелизы, которые считаются не очень стабильными, но имеют больше возможностей.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Пары регулярных выражений, используемые при добавлении пар тесткейсов из файлов.
 Каждая пара регулярных выражений представляет собой тесткейс.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -1817,34 +2165,76 @@ This can be overridden for each parenthesis in each language.</source>
 Это может быть переопределено для каждой скобки на каждом языке.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 Путь шаблона</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>%1 Шаблон-регулярное выражение положения курсора</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>%1 Шаблон типа отступа позиции курсора</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>%1 Шаблон символа отступа позиции курсора</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 Команда компиляции</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 Путь к исполняемому файлу</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -1859,14 +2249,19 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; или &quot;${tempdir}&quot; для абсолютного пути к временной директории.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 Run Arguments</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>Название основного класса вашего решения.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -1875,10 +2270,12 @@ This can be overridden for each parenthesis in each language.</source>
 Это может быть переопределено для каждой круглой скобки на каждом языке.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Переключаться по скобкам при помощи Tab</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -1887,242 +2284,325 @@ This can be overridden for each parenthesis in each language.</source>
 Это может быть переопределено для каждой круглой скобки на каждом языке.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Enable Ctrl+Scroll to change font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Использовать пробелы вместо символа табуляции.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Заменять табуляции на пробелы</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Сохранять тесткейса при нажатии на &quot;Сохранить&quot;</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Сохраните тесткейсы на диске при сохранении файла и загрузите сохраненные тескейсы при открытии файла.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Проверять обновления при запуске программы</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Проверьте, есть ли новая версия редактора CP при запуске CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Прозрачность</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>Прозрачность главного окна</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Включить Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Получать данные с Competitive Companion и загружать примеры тесткейсов.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Подключить порт</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>Порт используется для отправки данных из Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Открыть новые вкладки</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Открывать новые вкладки для каждой задачи переданной Competitive Companion.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Форматировать код</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Убить все процессы</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Скомпилировать и запустить</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Только запустить</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Только скомпилировать</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Изменить вид обзора</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Использовать сниппеты</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>Путь к исполняемому файлу CF Tool</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Показывать только &quot;компиляцию и запуск&quot;</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Скрыть кнопку &quot;Только компиляция&quot; и кнопку &quot;Только запуск&quot; под редактором кода в главном окне.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Показывать EOLN в Diff</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Использовать &quot;¶&quot; как показатель новой строки в HTML Diff Viewer.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Сохранять файлы быстрее</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Всегда используйте QFile вместо QSaveFile для сохранения файлов.
 Это будет быстрее, но с немного большим риском потери файла (с очень малой вероятностью).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Лимит длины выходных данных</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>Максимальное количество символов в выходных данных программы.
 Программа будет убита, если ее стандартный вывод или стандартный вывод слишком длинные.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Лимит длины сообщений</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>Максимальное количество символов в каждом сообщении в правом верхнем углу главного окна.
 Сообщение будет удалено, если оно слишком длинное.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>Лимит длины HTML Diff Viewer</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>Максимальное количество символов в HTML Diff Viewer.
 Средство просмотра различий вернется к простому тексту, если либо вывод, либо ответ слишком длинный.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Лимит длины открываемого файла</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>Максимальное количество символов в исходном файле для открытия.
 Исходный файл не будет открыт, если он слишком длинный.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Путь до исполняемого файла LSP</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>Путь до исполняемого файла C++ Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Путь до исполняемого файла Java Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Путь до исполняемого файла Python Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Использовать функцию Linting с Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Показывать ошибки, предупреждения, информацию и подсказки в редакторе кода для языка C++</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Показывать ошибки, предупреждения, информацию и подсказки в редакторе кода для языка Java</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Показывать ошибки, предупреждения, информацию и подсказки в редакторе кода для языка Python</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Используйте автозавершение с языковым сервером</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Используйте результаты автозаполнения с языкового сервера</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Задержка операции Linting в мс</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Задержка в операции Linting (мс) после модификации кода</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Аргументы для Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Аргументы для доступа к Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Правило определения тесткейсов</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Ввести регулярное выражение</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>Регулярное выражение, которое соответствует полному имени входного файла</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Замена ответа</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Выражение замены для имени файла ответов.
 Вы можете использовать &quot;\1&quot; для первой захваченной группы.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Сохранить путь входного файла</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2137,10 +2617,12 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${0-index}&quot; для индекса тесткейса, начинающегося с 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Сохранить путь файла ответа</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2155,138 +2637,171 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${1-index}&quot; для индекса тесткейса, начинающегося с 1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Пути к файлам по умолчанию для URL задач</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>Путь к файлу по умолчанию, используемый при сохранении нового файла, по URL задачи</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL задачи</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>Регулярное выражение, которое соответствует URL задачи</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Путь файла</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Выражение замены для пути к файлу без суффикса имени файла.
 Вы можете использовать &quot;\1&quot; для первой захваченной группы.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Шрифт тесткейсов</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>Шрифт тесткейсов</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Добавить дополнительное поле в нижней части редактора кода</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Добавьте дополнительное поле с высотой страницы в нижней части редактора кода.
 По техническим причинам изменение высоты поля влияет на историю отмены.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Шрифт лога</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>Шрифт лога</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Сохранить файл во время компиляции</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Сохранить файл во время компиляции. Файл не будет сохраняться, если вкладка не имеет названия.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Сохранить файл при запуске</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Сохранить файл во время запуска. Файл не будет сохраняться, если вкладка не имеет названия.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Восстановить URL-адрес проблемы при открытии файла</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Если для файла был задан проблемный URL-адрес, 
 то при повторном открытии этого файла проблемный URL-адрес будет восстановлен.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Если для файла был задан URL-адрес проблемы, то
 при повторном анализе этой проблемы из Competitive Companion будет открыт старый файл.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Открыть старый файл при разборе старого проблемного URL-адреса</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>Язык UI</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>Язык, отображённый на UI.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>Стиль UI</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>Стиль всего приложения.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Запустить свой код на пустых тесткейсах</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Запустить свой код на всех не скрытых тестовых случаях, даже если входные данные пусты.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Проверить свой ответ на тестовых примерах с пустым выводом</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Проверить свой ответ, даже если ваш вывод или ответ пуст.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Интервал автосохранения (мс)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>Интервал времени между модификацией и автосохранением или между двумя автосохранениями.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Вид интервала автосохранения</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2295,20 +2810,24 @@ Without modification: auto-save happens with a constant interval no matter there
 Без модификации: автоматическое сохранение происходит с постоянным интервалом независимо от того, есть модификации или нет.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Восстановить последний сеанс при запуске приложения</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Восстановить последний сеанс при запуске приложения.
 Когда это включено, вас не спросят, нужно ли сохранять несохраненные файлы при выходе.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Периодическое автосохранение текущего сеанса</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2317,90 +2836,114 @@ kill the application with SIGKILL which could not be handled by the application.
 остановите приложение с помощью SIGKILL, которое не может быть обработано приложением.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Интервал процесса автосохранения</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>Интервал времени между двумя автосохранениями текущего сеанса.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Максимальная высота панели тесткейсов</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>Максимальная высота тестового набора без полосы прокрутки в пикселях.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Название хоста прокси, например 127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Порт прокси, например 1080</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Пользователь прокси-сервера. Он может быть пустым, если прокси-сервер не требует аутентификации.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Пароль прокси-сервера. Он может быть пустым, если прокси-сервер не требует аутентификации.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Имя хоста</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Пользователь</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Тип прокси.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Использовать свой шрифт для приложения</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Используйте свой шрифт для всего приложения вместо системного шрифта.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Кастомный шрифт для программы</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>Кастомный шрифт для всего приложения</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 Кодек выхода компилятора</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Текстовый кодек выхода компилятора (ошибки, предупреждения и т.д.)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Сделать названия путей по умолчанию</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2409,98 +2952,185 @@ They can be either manually set or automatically changed after choosing a path f
 Они могут быть установлены вручную или автоматически изменены после выбора пути для действия.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>Название стандартного пути</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>Стандартный путь</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>Путь по умолчанию, используемый при выборе пути для %1.
 Вы можете использовать ${&lt;default path name&gt;} в качестве заполнителя.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Стандратные пути изменятся после выбора пути для %1.
 Это список &lt;default path name&gt;s, разделенный запятыми, который не может быть пустым.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Открыть соревнование</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Добавить один тесткейс</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Добавить пары тесткейсов</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Кастомный чекер</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Экспорт и импорт настроек</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Экспорт и загрузка сессии</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Экспорт и загрузка сниппетов</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Стандартный путь для %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Стандартные пути могут быть изменены %1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Может быть перезаписан %1.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Форматировать код при ручном сохранении</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Форматировать код при автосохранении</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Автоматическая загрузка внешних изменений файлов, если нет несохраненных изменений</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Автоматически загружайте изменения в файлы, которые не были сделаны в CP Editor, если в CP Editor нет несохраненных изменений.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Разрешить загружать внешние изменения в файлы</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -2511,32 +3141,39 @@ If this is disabled, external file changes will be ignored unless they are loade
 &quot;%1&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Показывать оповещения о вердиктах решения</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>Максимальное число символов, которые будут отображены в выводе программы.
 Если вывод очень большой, то он будет опущен.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Показывать всплывающие уведомления для вердиктов отправок</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Показывать всплывающие уведомления, когда известен вердикт отправки. Вы сможете видеть сообщения за пределами CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Аргументы терминала</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Программа терминала</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -2545,6 +3182,7 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 Некоторые возможные значения: konsole, gnome-terminal, xfce-terminal, xterm или некоторые другие эмуляторы терминала.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -2553,10 +3191,15 @@ Consult your terminal emulator for the suitable arguments.</source>
 Уточните аргументы, доступные для вашего эмулятора терминала.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Сохранить тесткейс в файл</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2567,10 +3210,12 @@ ${time}: время парсинга задачи
 ${json.X.Y}: атрибут данных, предоставляемых Competitive Companion&apos;ом. Вы можете узанть большее на https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Формат времени для комментариев в шарке</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2581,280 +3226,367 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Добавить &quot;Powered By CP Editor&quot; в комментарии шапки</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Добавить строку &quot;Powered By CP Editor&quot; в комментарии шапки
 Это ничего Вам не стоит, но помогает многим людям узнавать о CP Editor.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Стандартный лимит времни (в мс)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>Стандартный лимит времени выполнения при запуске программы.
 Программа будет убита, если будет превышен лимит выполнения.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Исопльзовать лимит времени из Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Использовать лимит времени взятым Competitive Companion-ом как лимит времени соответствующей вкладки.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Показывать только моноширинный шрифт</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Изменить язык</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Вам необходимо перезагрузить программу для полноценного применения нового языка.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Показывать только моноширинные шрифты при выборе</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Показывать лимит длины тесткейса</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Максимальное отображаемое число символов в тесткейсе.
 Если тесткейс будет слишком большой, он будет пропущен и доступен только для чтения.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Программа Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Аргументы Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Аргументы, применяемы для Clang Format. Они НЕ должны содержать &quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Стиль Clang Format</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Программа YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>Программа для YAPF. Это может быть &quot;yapf&quot; (который не требует аргументы) или &quot;python&quot; (который требует аргумент &quot;-m yapf&quot;).</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Аргументы YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Аргументы, применяемы для программы YAPF. Они не должны содержать &quot;-i&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Стиль YAPF</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Параметры стиля YAPF, которые обычно сохраняются в конфигурационный файл .style.yapf or setup.conf.
 Вы можете узнать больше об этом запустив &quot;yapf --style-help&quot;.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Форматировать код, когда он сохраняется вручную.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Форматировать код, когда он автоматически сохраняется.</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Содержание заголовков комменатриев</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation type="unfinished">прокси сети</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Включить эмуляцию Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Включить эмуляцию Vim в редакторе кода</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Конфигурация Vim</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Содержимое Vim RC. Загружается при каждом запуске эмуляции Vim.
@@ -2864,6 +3596,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
+        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Очистить горячую клавишу</translation>
     </message>
@@ -2871,42 +3604,52 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Вставить ряд (Ctrl+N)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Удалить данный ряд (Ctrl+W)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Удалить элементы</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>Вы действительно хотите удалить данный ряд?</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Переместить вверх</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Переместите текущий ряд вверх (Ctrl+Shift+Up)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Переместить вниз</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Переместите текущий ряд вниз (Ctrl+Shift+Down)</translation>
     </message>
@@ -2914,6 +3657,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Пожертвовать</translation>
     </message>
@@ -2921,34 +3665,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>Нравится CP Editor?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>Спасибо Вам за использование CP Editor!</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Для того чтобы поддержать нас, Вы можете:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Дать нам звезду на GitHub</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Поделиться информацией о CP Editor cо своими друзьями</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Поддержать нас финансово</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Дать немного советов чтобы помочь нам быть лучше</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>Я использую @cpeditor_ — специальная IDE для спортивного программирования и она отлична!</translation>
     </message>
@@ -2956,14 +3708,17 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>Не найдено релизов.</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>Не найдено URL для загрузки версии [%1].</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Эта ошибка, вероятно, вызвана отсутствием библиотеки OpenSSL. Вы можете посетить &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; для установки бинарного файла, или установите его через Ваш пакетный менеджер. Рекомендуется установить версию, совместимую с этой версией: [%1]</translation>
     </message>
@@ -2971,50 +3726,64 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="87"/>
+        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Не удалось открыть файл [%1]. Предоставлен ли доступ к записи в фалйл?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="97"/>
+        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Не удалось сохранить [%1]. Предоставлен ли доступ  к записи в фалйл?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>Файла [%1] не существует</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Не удалось открыть файл [%1]. Предоставлен ли доступ к чтению фалйла?</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Показать %1 в Finder</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Показать %1 в Проводнике</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Открыть папку содержащую %1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Показать %1 в Файловом менеджере</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3022,50 +3791,62 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Создать новое соревнование</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Главная директория</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Поддиректория</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Число задач</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>Главная директория не существует</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>Главная директория [%1] не существует. Вы хотите создать ее и продолжить?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Ошибка при создании директории</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Ошибка при создании директории [%1].</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Детали соревнования</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Сохранить путь</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Выбрать главную директорию</translation>
     </message>
@@ -3073,14 +3854,17 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Отображение различий</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Ожидаемо</translation>
     </message>
@@ -3088,26 +3872,33 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation type="unfinished">Сбросить</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3115,162 +3906,222 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">Ошибка при создании временной директории</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Чтение testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Сохранить testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Компилятор</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3278,58 +4129,72 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Ввод</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Ожидаемо</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Запуск</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Удалить</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Проверить на одном тесткейсе</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Открыть отображение различий</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Ввод #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Вывод #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Ожидаемо #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Удалить тесткейс</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>Вы уверены, что хотите удалить тесткейс #%1?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Отображение различий[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>Вывод/ответ содержит более %1 знаков, HTML diff viewer отключён. Вы можете изменить лимит длины в %2.</translation>
     </message>
@@ -3337,42 +4202,54 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Загрузить из файла</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Отредактировать в большем окне</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Изменить тесткейс</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Ввод</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Ожидаемо</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Сохранить в файл</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Сохранить тесткейс в файл</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Отображены только первые %1 символов. Сейчас тесткейсы доступны только для чтения. Вы можете установить лимит длины в %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Копировать вывод в ожидаемый</translation>
     </message>
@@ -3380,173 +4257,223 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Тесткейсы</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Чекер:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Добавить тест</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Ещё</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Добавить чекер</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Добавить кастомный чекер</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Добавить пары тесткейсов из файла</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Закрыть файлы тесткейсов</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Загрузить тесткейсы</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Пара тесткейсов [%1] и [%2] загружены</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Вводные данные [%1] загружены</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Следующие файлы не загружаются, потому что они не совпадают:%1. Можно установить правила соответствия в %2.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>Вы уверены удалить все тесткейсы?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Инвертировать</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Игнорировать конечные пробелы</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Строго также</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Сравнение int64s</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Сравнение doubles, максимальная погрешность 1e-4</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Сравнение doubles, максимальная погрешность 1e-6</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Сравнение doubles, максимальная погрешность 1e-9</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Сравнение токенов</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Сравнение YES/NO без учёта регистра</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Добавить тесткейс</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Здесь уже %1 тестов, Вы не можете добавить больше.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Вводные данные #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Ожидаемо #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Сохранить ввод #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Сохранить ответ #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Загрузка %1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Тесткейсы</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>Не принято / Принято / Всего</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Отметить все</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Снять все отметки</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Снять отметки с принятых</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Удалить все</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Удалить пустые</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Удалить отмеченные</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>Вы действительно хотите удалить все отмеченные тест-кейсы?</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Копировать тест-кейсы</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Вставить тест-кейсы</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Копировать вывод в ожидаемый</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Вы действительно хотите скопировать все отмеченные тест-кейсы в соответсвующие им ожидаемые?</translation>
@@ -3555,26 +4482,32 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Скачать</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Доступно новое обновление</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>Новое %1 обновление &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; доступно. Смотрите ниже список изменений.&lt;br /&gt;Мы настоятельно рекомендуем вам обновлять редактор, чтобы вы не пропустили потрясающие новые функции и исправления ошибок.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>бета</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>стабильная версия</translation>
     </message>
@@ -3582,30 +4515,37 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Закройте это окно и отмените проверку обновления</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Проверка обновлений</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Загружается список релизов...</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Ошибка: %1&lt;br /&gt;&lt;br /&gt;Произошла ошибка при проверке обновления. Пожалуйста, проверьте обновление вручную на &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/ru/download&quot;&gt;https://cpeditor.org/ru/download&lt;/a&gt; или &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translatorcomment>The most suitable translation</translatorcomment>
         <translation>Вы уже используете последнюю версию CP Editor. Ура-а-а-а!</translation>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -4,465 +4,438 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>Принудительный выход</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>Предыдущая сессия CP Editor была завершена некорректно. Вы хотите восстановить предыдущую сессию?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>Показать Главное окно</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>Открытие файлов</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>О CP Editor %1</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; - редактор кода, созданный на Qt. Дизайн CP Editor специально рассчитан на спортивное программирование, в отличии от других редакторов/IDE, который больше подходят разработчикам. Наш редакатор кода помогает сфокусироваться на построении алгоритма, автодополняя, запуская и тестируя его. Он также может использовать тест-кейсы разных платформ и отправлять решения на Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;Это свободно распространяемое программное обеспечение. Условия копирования приведены в исходных текстах. Без гарантии каких-либо качеств, включая коммерческую ценность и применимость для каких-либо целей. Исходный код CP Editor доступен на &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>Открыть файлы</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>Сбросить настройки</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>Вы действительно хотите сбросить настройки?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1316"/>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>Сниппеты</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>Отсутсвуют сниппеты для %1. Пожалуйста, добавьте соответствущий сниппет в настройках.</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>Использовать сниппет</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>Выбарть сниппет:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>Отсутствуют сниппеты под названием %1 для %2</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>Закрыть другие</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>Закрыть все левые</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>Закрыть все правые</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>Копировать путь файла</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>Копировать URL задачи</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>Установить Codeforces URL</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>Установить CF URL</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>Ввести ID соревнования:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>Ввести код задачи (A-Z):</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1602"/>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>Задать URL задачи</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>Задать URL для новой задачи:</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>Логгер cобытий</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>Все логи, кроме логов текущей сессии, были удалены</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: редактор, созданный для спортивного программирования</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation type="vanished">Сохранить как...</translation>
+        <translation>Сохранить как...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation type="vanished">Сохранить как новый файл</translation>
+        <translation>Сохранить как новый файл</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>Сохранить все</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation type="vanished">Сохранить все открытые файлы</translation>
+        <translation>Сохранить все открытые файлы</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation type="vanished">Закрыть текущий</translation>
+        <translation>Закрыть текущий</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation type="vanished">Закрыть текущую вкладку</translation>
+        <translation>Закрыть текущую вкладку</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>Закрыть сохраненные</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation type="vanished">Закрыть сохраненные вкладки</translation>
+        <translation>Закрыть сохраненные вкладки</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>Закрыть все</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation type="vanished">Закрыть все вкладки</translation>
+        <translation>Закрыть все вкладки</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>Выйти</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation type="vanished">Выйти из программы</translation>
+        <translation>Выйти из программы</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation type="vanished">Открыть файл....</translation>
+        <translation>Открыть файл....</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation type="vanished">Открыть файлы</translation>
+        <translation>Открыть файлы</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation type="vanished">Открыть соревнование...</translation>
+        <translation>Открыть соревнование...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation type="vanished">Открыть соревнование</translation>
+        <translation>Открыть соревнование</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation type="vanished">Отступ</translation>
+        <translation>Отступ</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation type="vanished">Убрать отступ</translation>
+        <translation>Убрать отступ</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation type="vanished">Поднять строку</translation>
+        <translation>Поднять строку</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation type="vanished">Опустить строку</translation>
+        <translation>Опустить строку</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation type="vanished">Дублировать строку</translation>
+        <translation>Дублировать строку</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation type="vanished">Удалить линию</translation>
+        <translation>Удалить линию</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation type="vanished">Закомментировать строку</translation>
+        <translation>Закомментировать строку</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation type="vanished">Выбрать блок</translation>
+        <translation>Выбрать блок</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Скомпилировать</translation>
+        <translation>Скомпилировать</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Скомпилировать и запустить</translation>
+        <translation>Скомпилировать и запустить</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Запустить</translation>
+        <translation>Запустить</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation type="vanished">Форматировать код</translation>
+        <translation>Форматировать код</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation type="vanished">Запустить отдельно</translation>
+        <translation>Запустить отдельно</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation type="vanished">Убить процесс</translation>
+        <translation>Убить процесс</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation type="vanished">Найти и заменить</translation>
+        <translation>Найти и заменить</translation>
+    </message>
+    <message>
+        <source>Stress Testing...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation type="vanished">Параметры</translation>
+        <translation>Параметры</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation type="vanished">О Qt</translation>
+        <translation>О Qt</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>Информация о сборке</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation type="vanished">Проверить обновления</translation>
+        <translation>Проверить обновления</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation type="vanished">Новый файл</translation>
+        <translation>Новый файл</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation type="vanished">Открыть в новой вкладке редактора</translation>
+        <translation>Открыть в новой вкладке редактора</translation>
+    </message>
+    <message>
+        <source>Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with generator template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with C++ template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Java template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Python template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation type="vanished">Сохранить файл локально</translation>
+        <translation>Сохранить файл локально</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation type="vanished">Использовать сниппет...</translation>
+        <translation>Использовать сниппет...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation type="vanished">Экспорт настроек...</translation>
+        <translation>Экспорт настроек...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation type="vanished">Импорт настроек...</translation>
+        <translation>Импорт настроек...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation type="vanished">Сбросить настройки</translation>
+        <translation>Сбросить настройки</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation type="vanished">Инструкции</translation>
+        <translation>Инструкции</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation type="vanished">Режим настройщика</translation>
+        <translation>Режим настройщика</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation type="vanished">Режим ввода/вывода</translation>
+        <translation>Режим ввода/вывода</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation type="vanished">Режим Split</translation>
+        <translation>Режим Split</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation type="vanished">Вывести файлы логов</translation>
+        <translation>Вывести файлы логов</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation type="vanished">Удалить файлы логов</translation>
+        <translation>Удалить файлы логов</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">&amp;Файл</translation>
+        <translation>&amp;Файл</translation>
+    </message>
+    <message>
+        <source>New File From Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="vanished">&amp;Изменить</translation>
+        <translation>&amp;Изменить</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation type="vanished">&amp;Действия</translation>
+        <translation>&amp;Действия</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">&amp;Вид</translation>
+        <translation>&amp;Вид</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation type="vanished">&amp;Опции</translation>
+        <translation>&amp;Опции</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="vanished">&amp;Помощь</translation>
+        <translation>&amp;Помощь</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>Экспорт настроек в файл</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>Импорт настроек из файла</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>Экспортировать текущую сессию в файл</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>Эскпортировать сессию</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>Не удалось экспортировать текущую сессию как [%1]</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>Загрузка сессии</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>Загрузка сессии из файла закроет все открытые вкладки в текущей сессии без сохранения файлов. Вы действительно хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>Загрузка сессии из файла</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation type="vanished">Экспорт сессии...</translation>
+        <translation>Экспорт сессии...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation type="vanished">Загрузка сессии...</translation>
+        <translation>Загрузка сессии...</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="779"/>
-        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>Файл настройки CP Editor</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="807"/>
-        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>Файл сессии CP Editor</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation type="vanished">Отчет об ошибках</translation>
+        <translation>Отчет об ошибках</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>Импорт настроек</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>Все текущие настройки будут потеряны после импорта файла настройки. Вы хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>Дублировать вкладку</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -475,206 +448,169 @@ Git commit hash: %3
 ОС: %5</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>Portable-версия</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>Версия для установки</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>Открыть последние файлы</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>Нет последних файлов</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>Очистить последние файлы</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>Файл исходного кода</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>Исполняемый файл</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>Открыть задачу в браузере</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>Установить команду компиляции</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>Установить лими времени</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation type="vanished">Полный экран</translation>
+        <translation>Полный экран</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation type="vanished">Поддержи нас</translation>
+        <translation>Поддержи нас</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="obsolete">C++</translation>
+        <translation type="unfinished">C++</translation>
     </message>
     <message>
         <source>Java</source>
-        <translation type="obsolete">Java</translation>
+        <translation type="unfinished">Java</translation>
     </message>
     <message>
         <source>Python</source>
-        <translation type="obsolete">Python</translation>
+        <translation type="unfinished">Python</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>Search...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>Переименовать сниппет</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>Загрузить сниппет из файлов</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>Извлечь сниппет в файлы</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>Еще</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>Сниппет не выбран</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>Несохраненные сниппеты</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>Сниппет [%1] был изменен. Вы хотите сохранить изменения или отменить их?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>Удалить сниппет</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>Вы действительно хотите удалить сниппет [%1]?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>Загрузить сниппет</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Не удалось открыть [%1]. Предоставлен ли доступ к чтению файла?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>Дополнительные сниппеты</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>Дополнительные сниппеты: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>Не удалось записать изменения в файл [%1]. Предоставлен ли доступ к изменению фалйла?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>Название сниппета не может пустым.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>Конфликт названий сниппетов</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>Название &quot;%1&quot; уже используется. Вы хотите перезаписать сниппет с таким именем? (Старый сниппет будет удален.)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>Название &quot;%1&quot; уже используется.
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>Добавить сниппет</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>Новое имя сниппета:</translation>
     </message>
@@ -682,93 +618,68 @@ Git commit hash: %3
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>Чиать чекер</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
-        <location filename="../src/Core/Checker.cpp" line="99"/>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
-        <location filename="../src/Core/Checker.cpp" line="301"/>
-        <location filename="../src/Core/Checker.cpp" line="302"/>
-        <location filename="../src/Core/Checker.cpp" line="303"/>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>Чекер</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>Ошибка при создании временной директории</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>Чтение testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>Сохранить testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>Произошла ошибка во время компиляции чекера:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>Чекер[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>Чекер завершил работу с кодом %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>Чекер завершил работу с неизвестым кодом %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>Превышено ограничение по времени (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>%1 из процессов при работе на тесткейсе #%2 содержит более чем %3 символов и превосходит лимит. Процесс убит. Вы можете изменить этот лимит в %4.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>Чекер убит</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>Начата компиляция чекера</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>Чекер скомпилирован</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>Ошибка компиляции символа: %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -776,22 +687,18 @@ Git commit hash: %3
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>Файл [%1] не существует</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>Неподдерживаемый язык программирования &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>Ошибка при старте компилятора. Пожалуйста, проверьте %1 или добавьте путь компилятора в переменную среды окружения PATH.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 пуст</translation>
     </message>
@@ -799,39 +706,32 @@ Git commit hash: %3
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>Исходный код %1 не существует.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>Ошибка во время запуска команды. Возможно это баг.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>Ошибка при запуске. Пожалуйста, сперва запустите компиляцию.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>Программа завершилась с кодом %1
 Нажмите на любую клавишу для выхода</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>Не удалось запустить отдельно. Пожалуйста, проверьте настройки вашего эмулятора терминала в %1.</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>Отдельный запуск не поддерживается на вашей системе</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -839,12 +739,10 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>Восстановление предыдущей сессии</translation>
     </message>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>Восстановление: [%1]</translation>
     </message>
@@ -852,52 +750,42 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` не принимает аргументов или принимает один из &apos;cpp&apos;, &apos;java&apos; и &apos;python&apos;, получено [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] не является исходным файлом C++, Python или Java</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] не существует. Чтобы открыть вкладку с несуществующим файлом, используйте `open!`</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] не является числом</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 вне диапазона [1, %2]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">Н/Д</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] не является допустимым режимом просмотра. Допустимые значения: &apos;split&apos; и &apos;edit&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 не является допустимым названием языка. Допустимые значения: &apos;cpp&apos;, &apos;java&apos; и &apos;python&apos;</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">Нет активной вкладки для очистки сообщений</translation>
     </message>
@@ -905,63 +793,42 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>Процесс CF Tool был убит</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>Код задачи - 0, поэтому используется код A автоматически. Если код задачи не А, пожалуйста, установите код вручную в подменю (правая кнопка мыши) текущей вкладки.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Ошибки при получении версии CF Tool. Установлен корректный путь к CF Tool в параметрах?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool запущен</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>Ошибки при получении версии CF Tool в течении 2-х секунд. Установлен корректный путь к CF Tool в параметрах?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>Ошибка в получении URL [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>Произошла ошибка в CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool заверешил работу с кодом %1 отличным от нуля</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>Соревнование %1 Задача %2</translation>
     </message>
@@ -969,50 +836,34 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>Форматирование</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>Ошибка при создании временной директории</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>Форматирование завершено</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>Форматирование[stdout]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>Форматирование[stderr]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>Команда форматирования [%1 %2] завершилась с кодом %3.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>Процесс форматирования не завершился в течении 2 секунд. Возможно, что программа %1 не найдена CP Editor-ом. Вы можете установить путь программы в %2.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>Выходные данные процесса форматирования пусты. Пожалуйста, убедитесь, что в аргументах форматирования отсутсвует опция самозамены на месте.</translation>
     </message>
@@ -1020,39 +871,32 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>Сервер не доступен</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>Порт установолен на %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>Ошибка в прослушивании порта %1. Возможно другой процесс уже работает с этим портом?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>Остановка Сервера</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>JSON parser выдает ошибки:
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>Принятый запрос не является JSON&apos;ом</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>Запрос %1 был получен и проигнорирован</translation>
     </message>
@@ -1060,42 +904,30 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Language Server [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Language server выдает ошибку. Пожалуйста, проверьте логи.</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>Ошибка при старте Процесса LSP. Вы установили путь к программе Language Server в %1?</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Истекло время исполнения Процесса LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Ошибка чтения Процесса LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Ошибка записи Процесса LSP</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Произошла неизвестная ошибка в Процессе LSP</translation>
     </message>
@@ -1104,50 +936,50 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation type="vanished">Найти/Заменить</translation>
+        <translation>Найти/Заменить</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">Вид</translation>
+        <translation>Вид</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation type="vanished">Найти:</translation>
+        <translation>Найти:</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation type="vanished">Заменить на:</translation>
+        <translation>Заменить на:</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation type="vanished">errorLabel</translation>
+        <translation>errorLabel</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="vanished">Направление</translation>
+        <translation>Направление</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="vanished">Вверх</translation>
+        <translation>Вверх</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="vanished">Вниз</translation>
+        <translation>Вниз</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">Опции</translation>
+        <translation>Опции</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation type="vanished">Учитывать регистр</translation>
+        <translation>Учитывать регистр</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation type="vanished">Только слова целиком</translation>
+        <translation>Только слова целиком</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1158,7 +990,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1169,74 +1001,52 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation type="vanished">Регулярное выражение</translation>
+        <translation>Регулярное выражение</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation type="vanished">Найти</translation>
+        <translation>Найти</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="vanished">Заменить</translation>
+        <translation>Заменить</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation type="vanished">Заменить все</translation>
+        <translation>Заменить все</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="185"/>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>Компилятор</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>Пожалуйста установите язык</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="218"/>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="242"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1492"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>Runner</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>Язык выбран неверно. Пожалуйста, установите другой язык</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>Входные данные пусты, нечего запускать</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>Отправить</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>Подтверждение отправки</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1247,101 +1057,78 @@ p, li { white-space: pre-wrap; }
  ЯП: %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="328"/>
-        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation>CF Tool</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>Ошибка в сохранении временного файла. Решение не было отправлено.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>Неизвестный-%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>Открыть %1 шаблон</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1017"/>
-        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>Файл [%1] содержит более чем %2 символов и он не был открыт. Вы можете установить лимит количества символов в файле в %3.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
-        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>Временный файл</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>Ошибка при создании временной директории</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>Чтение шаблона %1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>Сохранить настройки</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>Сохранить как [%1] перед закрытием?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>Новый файл</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>Установить язык вкладки</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>Установить язык для использования в этой вкладке</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>Перезагрузить</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1352,180 +1139,150 @@ Do you want to reload it?</source>
 Вы хотите его перезагрузить?</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>Строка %1, символ %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>Выбрано %1 линей, %2 символов</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>Выбрано %1 символов</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>Начался процесс компиляции</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>Компиляция завершена</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>Предупреждения компилятора</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>Произошла ошибка во время компиляции</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1517"/>
-        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>Ошибки компиляции</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>Компиляция остановлена</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>Подробный запуск</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>Runner[%1]</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>Начался запуск программы</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>Запуск программы для тесткейса #%1 завершился за время %2мс</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>Запуск программы для тесткейса #%1 завершился с ненулевым кодом выхода %2 за время %3мс</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation>/stderr</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>Превышен лимит времени выполнения программы (TLE)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>Процесс %1 на тесткейсе #%2 содержит более %3 символов, что превосходит лимит длины. Процесс будет убит. Вы можете изменить лимит длины выходного файла в %4.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 был остановлен</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>Подробный запуск</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>Запуск для тесткейса #%1</translation>
     </message>
     <message>
         <source>CP Editor</source>
-        <translation type="vanished">CP Editor</translation>
+        <translation>CP Editor</translation>
     </message>
     <message>
         <source>cursor info</source>
-        <translation type="vanished">информация с курсора</translation>
+        <translation>информация с курсора</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">Скомпилировать</translation>
+        <translation>Скомпилировать</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">Запустить</translation>
+        <translation>Запустить</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">Скомпилировать и запустить</translation>
+        <translation>Скомпилировать и запустить</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation type="vanished">Сообщения</translation>
+        <translation>Сообщения</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="vanished">Очистить</translation>
+        <translation>Очистить</translation>
     </message>
     <message>
         <source>C++</source>
-        <translation type="vanished">C++</translation>
+        <translation>C++</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>Автосохранение</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>Вы установили подходящее имя для главного класса в решении? Если нет, Вы можете установить имя в at %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>Неизвестный атрибут: [%1]. Пожалуйста, проверьте настройку комментариев шапки в %2.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>Установить команду компиляции</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>Нестандартная команда компиляции для этой вкладки:</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>Установить лимит времени</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>Нестандартный лимит времени для этой вкладки: (в мс)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>Вам необходимо устанвоить CF Tool для отправки Вашего кода на Codeforces. Если он уже установлен, вы можете добавить его в переменную среды PATH или проверить Ваши настройки в %1.</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>Ошибка старта компиляции: %1</translation>
     </message>
@@ -1533,7 +1290,6 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1543,42 +1299,34 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>Скобки %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>Нет выбранных скобок</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>Новые скобки</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>Введите скобки (например, {}):</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>Удалить скобки</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>Вы действительно хотите удалить скобки %1?</translation>
     </message>
@@ -1586,29 +1334,24 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>Скобки: %1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>Активировано %1 для %2 в %3.
 Выбрано частично, будут использованы глобальные настройки в Code Edit.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>Автозавершение</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>Автоудаление</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>Tab Jump Out</translation>
     </message>
@@ -1616,25 +1359,18 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="41"/>
-        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>Выберите файл</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>Исполняемый файл</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="84"/>
-        <location filename="../src/Settings/PathItem.cpp" line="86"/>
-        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>Выберите %1 как файл исходного кода</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>Выберите исполняемый файл</translation>
     </message>
@@ -1642,42 +1378,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>Добро пожаловать в CP Editor! Давайте начнём.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>Настройки редактора кода</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>Команды компиляции и запуска на С++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Команды компиляции и запуска на Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Команды запуска на Python</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>Вы можете почитать &lt;a href=&quot;%1&quot;&gt;документация&lt;/a&gt; или просмотреть настройки для более подробной информации.</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>Настройки внешнего вида</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>Настройки шрифтов</translation>
     </message>
@@ -1685,42 +1413,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>Сбросить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>Восстановить настройки по умолчанию на текущей странице. (Ctrl+D)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>Сбросить все изменения на текущей странице. (Ctrl+R)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>Сохранить изменения на текущей странице. (Ctrl+S)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>Несохраненные настройки</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>Настройки изменены. Вы хотите сохранить настройки или отказаться от них?</translation>
     </message>
@@ -1728,272 +1448,239 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
-        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>Поиск...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>Домой</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>Назад на основную страницу</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation type="vanished">Редактирование кода</translation>
+        <translation>Редактирование кода</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">Язык</translation>
+        <translation>Язык</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="vanished">Основное</translation>
+        <translation>Основное</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation>C++</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation>Java</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation>Python</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="vanished">Внешний вид</translation>
+        <translation>Внешний вид</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation type="vanished">Действия</translation>
+        <translation>Действия</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">Сохранить</translation>
+        <translation>Сохранить</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation type="vanished">Привязать файл и задачу</translation>
+        <translation>Привязать файл и задачу</translation>
+    </message>
+    <message>
+        <source>Stopwatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stress Testing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generator Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation type="vanished">Расширения</translation>
+        <translation>Расширения</translation>
     </message>
     <message>
         <source>Clang Format</source>
-        <translation type="vanished">Clang Format</translation>
+        <translation>Clang Format</translation>
+    </message>
+    <message>
+        <source>YAPF</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language Server</source>
-        <translation type="vanished">Language Server</translation>
+        <translation>Language Server</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 Команды</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 Шаблоны</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 Сниппеты</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 Скобки</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation>%1 Сервер</translation>
     </message>
     <message>
         <source>Competitive Companion</source>
-        <translation type="vanished">Competitive Companion</translation>
+        <translation>Competitive Companion</translation>
     </message>
     <message>
         <source>CF Tool</source>
-        <translation type="vanished">CF Tool</translation>
+        <translation>CF Tool</translation>
+    </message>
+    <message>
+        <source>WakaTime</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>File Path</source>
-        <translation type="vanished">Путь файлов</translation>
+        <translation>Путь файлов</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation type="vanished">Тесткейсы</translation>
+        <translation>Тесткейсы</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation type="vanished">URL задачи</translation>
+        <translation>URL задачи</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation type="vanished">Горячие клавиши</translation>
+        <translation>Горячие клавиши</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="vanished">Дополнительно</translation>
+        <translation>Дополнительно</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="vanished">Обновить</translation>
+        <translation>Обновить</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation type="vanished">Лимиты</translation>
+        <translation>Лимиты</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation type="vanished">Автосохранение</translation>
+        <translation>Автосохранение</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation type="vanished">Сохранении сессиии</translation>
+        <translation>Сохранении сессиии</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation type="vanished">Прокси сети</translation>
+        <translation>Прокси сети</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation type="vanished">Пути по умолчанию</translation>
+        <translation>Пути по умолчанию</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation type="vanished">Загрузка внешних файловый изменений</translation>
+        <translation>Загрузка внешних файловый изменений</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation type="vanished">Отдельный запуск</translation>
+        <translation>Отдельный запуск</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="vanished">Шрифт</translation>
+        <translation>Шрифт</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation type="vanished">Форматирование кода</translation>
+        <translation>Форматирование кода</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation type="obsolete">Тесткейсы</translation>
+        <translation type="unfinished">Тесткейсы</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Ширина вкладки</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>Ширина символов вкладки или количество пробелов на конце</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>Шрифт редактора</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>Шрифт редактора кода</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>Язык по умолчанию</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>Язык по умолчанию во время создания новой вкладки</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>Путь</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Путь до исполняемых файлов Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Опции Clang Format style, который обычно сохраняются в файле .clang-format.
 Больше информации на &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>Шаблон, используемый для создании нового C++ файла</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -2002,71 +1689,52 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 Курсор будет в конце шаблона, если нет совпадений с регулярным выражением.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>Относительное смещение относительно начала регулярного выражения или конца регулярного выражения.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>Смещение относительно совпадения регулярного выражения по количеству символов, включая пробелы.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>Команда, используемая для компиляции C ++. Она НЕ должен включать путь к исходному файлу или &quot;-o &lt;output file&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>Аргументы при выполнении программы на C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>Шаблон, используемый при создании нового файла Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>Команда, используемая для компиляции Java.
 Она НЕ должна включать путь к исходному файлу или путь к скомпилированному файлу класса.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>Аргументы при выполнении программы на Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>Команда для запуска программы на Java. НЕ должна включать &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 Run Command</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 Имя класса</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 Путь класса</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2079,84 +1747,68 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; или &quot;${tempdir}&quot; для абсолютного пути к временному каталогу.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>Шаблон, используемый при создании нового файла Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>Аргументы, используемые при запуске программы на Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>Команда для запуска программы на Python. Она НЕ должна включать путь к исходному файлу.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>Тема редактора</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>Синтаксическая подсветка темы редактора кода</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>Автоподстановка скобок</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>Автоудаление скобок</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>Авто отступ</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>Добавьте отступ при вводе новой строки после &quot;{&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>Включить автосохранение</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>Свернуть текст</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>Свернуть строку в несколько строк, если она не помещается на экране.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>Использовать бета-версию</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>Проверьте наличие обновлений, помеченных как предрелизы, которые считаются не очень стабильными, но имеют больше возможностей.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>Пары регулярных выражений, используемые при добавлении пар тесткейсов из файлов.
 Каждая пара регулярных выражений представляет собой тесткейс.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -2165,76 +1817,34 @@ This can be overridden for each parenthesis in each language.</source>
 Это может быть переопределено для каждой скобки на каждом языке.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 Путь шаблона</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>%1 Шаблон-регулярное выражение положения курсора</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>%1 Шаблон типа отступа позиции курсора</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>%1 Шаблон символа отступа позиции курсора</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 Команда компиляции</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 Путь к исполняемому файлу</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2249,19 +1859,14 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${tmpdir}&quot; или &quot;${tempdir}&quot; для абсолютного пути к временной директории.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 Run Arguments</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>Название основного класса вашего решения.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -2270,12 +1875,10 @@ This can be overridden for each parenthesis in each language.</source>
 Это может быть переопределено для каждой круглой скобки на каждом языке.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>Переключаться по скобкам при помощи Tab</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -2284,325 +1887,250 @@ This can be overridden for each parenthesis in each language.</source>
 Это может быть переопределено для каждой круглой скобки на каждом языке.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Enable Ctrl+Scroll to change font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>Использовать пробелы вместо символа табуляции.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>Заменять табуляции на пробелы</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>Сохранять тесткейса при нажатии на &quot;Сохранить&quot;</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>Сохраните тесткейсы на диске при сохранении файла и загрузите сохраненные тескейсы при открытии файла.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>Проверять обновления при запуске программы</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>Проверьте, есть ли новая версия редактора CP при запуске CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>Прозрачность</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>Прозрачность главного окна</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>Включить Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>Получать данные с Competitive Companion и загружать примеры тесткейсов.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>Подключить порт</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>Порт используется для отправки данных из Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>Открыть новые вкладки</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>Открывать новые вкладки для каждой задачи переданной Competitive Companion.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>Форматировать код</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>Убить все процессы</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>Скомпилировать и запустить</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>Только запустить</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>Только скомпилировать</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>Изменить вид обзора</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>Использовать сниппеты</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>Путь к исполняемому файлу CF Tool</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>Показывать только &quot;компиляцию и запуск&quot;</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>Скрыть кнопку &quot;Только компиляция&quot; и кнопку &quot;Только запуск&quot; под редактором кода в главном окне.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>Показывать EOLN в Diff</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>Использовать &quot;¶&quot; как показатель новой строки в HTML Diff Viewer.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>Сохранять файлы быстрее</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>Всегда используйте QFile вместо QSaveFile для сохранения файлов.
 Это будет быстрее, но с немного большим риском потери файла (с очень малой вероятностью).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>Лимит длины выходных данных</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>Максимальное количество символов в выходных данных программы.
 Программа будет убита, если ее стандартный вывод или стандартный вывод слишком длинные.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>Лимит длины сообщений</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>Максимальное количество символов в каждом сообщении в правом верхнем углу главного окна.
 Сообщение будет удалено, если оно слишком длинное.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>Лимит длины HTML Diff Viewer</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>Максимальное количество символов в HTML Diff Viewer.
 Средство просмотра различий вернется к простому тексту, если либо вывод, либо ответ слишком длинный.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>Лимит длины открываемого файла</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>Максимальное количество символов в исходном файле для открытия.
 Исходный файл не будет открыт, если он слишком длинный.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>Путь до исполняемого файла LSP</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>Путь до исполняемого файла C++ Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Путь до исполняемого файла Java Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Путь до исполняемого файла Python Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>Использовать функцию Linting с Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>Показывать ошибки, предупреждения, информацию и подсказки в редакторе кода для языка C++</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>Показывать ошибки, предупреждения, информацию и подсказки в редакторе кода для языка Java</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>Показывать ошибки, предупреждения, информацию и подсказки в редакторе кода для языка Python</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>Используйте автозавершение с языковым сервером</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>Используйте результаты автозаполнения с языкового сервера</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Задержка операции Linting в мс</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>Задержка в операции Linting (мс) после модификации кода</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Аргументы для Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>Аргументы для доступа к Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>Правило определения тесткейсов</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>Ввести регулярное выражение</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>Регулярное выражение, которое соответствует полному имени входного файла</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>Замена ответа</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Выражение замены для имени файла ответов.
 Вы можете использовать &quot;\1&quot; для первой захваченной группы.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>Сохранить путь входного файла</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2617,12 +2145,10 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${0-index}&quot; для индекса тесткейса, начинающегося с 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>Сохранить путь файла ответа</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2637,171 +2163,138 @@ You can use &quot;${filename}&quot; for the complete file name,
 &quot;${1-index}&quot; для индекса тесткейса, начинающегося с 1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>Пути к файлам по умолчанию для URL задач</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>Путь к файлу по умолчанию, используемый при сохранении нового файла, по URL задачи</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>URL задачи</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>Регулярное выражение, которое соответствует URL задачи</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>Путь файла</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>Выражение замены для пути к файлу без суффикса имени файла.
 Вы можете использовать &quot;\1&quot; для первой захваченной группы.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>Шрифт тесткейсов</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>Шрифт тесткейсов</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>Добавить дополнительное поле в нижней части редактора кода</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>Добавьте дополнительное поле с высотой страницы в нижней части редактора кода.
 По техническим причинам изменение высоты поля влияет на историю отмены.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>Шрифт лога</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>Шрифт лога</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>Сохранить файл во время компиляции</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Сохранить файл во время компиляции. Файл не будет сохраняться, если вкладка не имеет названия.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>Сохранить файл при запуске</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>Сохранить файл во время запуска. Файл не будет сохраняться, если вкладка не имеет названия.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>Восстановить URL-адрес проблемы при открытии файла</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>Если для файла был задан проблемный URL-адрес, 
 то при повторном открытии этого файла проблемный URL-адрес будет восстановлен.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>Если для файла был задан URL-адрес проблемы, то
 при повторном анализе этой проблемы из Competitive Companion будет открыт старый файл.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>Открыть старый файл при разборе старого проблемного URL-адреса</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>Язык UI</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>Язык, отображённый на UI.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>Стиль UI</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>Стиль всего приложения.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>Запустить свой код на пустых тесткейсах</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>Запустить свой код на всех не скрытых тестовых случаях, даже если входные данные пусты.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>Проверить свой ответ на тестовых примерах с пустым выводом</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>Проверить свой ответ, даже если ваш вывод или ответ пуст.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>Интервал автосохранения (мс)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>Интервал времени между модификацией и автосохранением или между двумя автосохранениями.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>Вид интервала автосохранения</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2810,24 +2303,20 @@ Without modification: auto-save happens with a constant interval no matter there
 Без модификации: автоматическое сохранение происходит с постоянным интервалом независимо от того, есть модификации или нет.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>Восстановить последний сеанс при запуске приложения</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>Восстановить последний сеанс при запуске приложения.
 Когда это включено, вас не спросят, нужно ли сохранять несохраненные файлы при выходе.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>Периодическое автосохранение текущего сеанса</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2836,114 +2325,90 @@ kill the application with SIGKILL which could not be handled by the application.
 остановите приложение с помощью SIGKILL, которое не может быть обработано приложением.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>Интервал процесса автосохранения</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>Интервал времени между двумя автосохранениями текущего сеанса.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>Максимальная высота панели тесткейсов</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>Максимальная высота тестового набора без полосы прокрутки в пикселях.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Название хоста прокси, например 127.0.0.1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Порт прокси, например 1080</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Пользователь прокси-сервера. Он может быть пустым, если прокси-сервер не требует аутентификации.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Пароль прокси-сервера. Он может быть пустым, если прокси-сервер не требует аутентификации.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>Имя хоста</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>Пользователь</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>Пароль</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Тип прокси.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>Использовать свой шрифт для приложения</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>Используйте свой шрифт для всего приложения вместо системного шрифта.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>Кастомный шрифт для программы</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>Кастомный шрифт для всего приложения</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 Кодек выхода компилятора</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>Текстовый кодек выхода компилятора (ошибки, предупреждения и т.д.)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>Сделать названия путей по умолчанию</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2952,185 +2417,98 @@ They can be either manually set or automatically changed after choosing a path f
 Они могут быть установлены вручную или автоматически изменены после выбора пути для действия.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>Название стандартного пути</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>Стандартный путь</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>Путь по умолчанию, используемый при выборе пути для %1.
 Вы можете использовать ${&lt;default path name&gt;} в качестве заполнителя.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>Стандратные пути изменятся после выбора пути для %1.
 Это список &lt;default path name&gt;s, разделенный запятыми, который не может быть пустым.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>Открыть соревнование</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>Добавить один тесткейс</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>Добавить пары тесткейсов</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>Кастомный чекер</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>Экспорт и импорт настроек</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>Экспорт и загрузка сессии</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>Экспорт и загрузка сниппетов</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>Стандартный путь для %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>Стандартные пути могут быть изменены %1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>Может быть перезаписан %1.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>Форматировать код при ручном сохранении</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>Форматировать код при автосохранении</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>Автоматическая загрузка внешних изменений файлов, если нет несохраненных изменений</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>Автоматически загружайте изменения в файлы, которые не были сделаны в CP Editor, если в CP Editor нет несохраненных изменений.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>Разрешить загружать внешние изменения в файлы</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -3141,39 +2519,32 @@ If this is disabled, external file changes will be ignored unless they are loade
 &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>Показывать оповещения о вердиктах решения</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>Максимальное число символов, которые будут отображены в выводе программы.
 Если вывод очень большой, то он будет опущен.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>Показывать всплывающие уведомления для вердиктов отправок</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>Показывать всплывающие уведомления, когда известен вердикт отправки. Вы сможете видеть сообщения за пределами CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>Аргументы терминала</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>Программа терминала</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -3182,7 +2553,6 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 Некоторые возможные значения: konsole, gnome-terminal, xfce-terminal, xterm или некоторые другие эмуляторы терминала.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -3191,15 +2561,10 @@ Consult your terminal emulator for the suitable arguments.</source>
 Уточните аргументы, доступные для вашего эмулятора терминала.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>Сохранить тесткейс в файл</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -3210,12 +2575,10 @@ ${time}: время парсинга задачи
 ${json.X.Y}: атрибут данных, предоставляемых Competitive Companion&apos;ом. Вы можете узанть большее на https://github.com/jmerle/competitive-companion#explanation</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>Формат времени для комментариев в шарке</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -3226,367 +2589,280 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>Добавить &quot;Powered By CP Editor&quot; в комментарии шапки</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>Добавить строку &quot;Powered By CP Editor&quot; в комментарии шапки
 Это ничего Вам не стоит, но помогает многим людям узнавать о CP Editor.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>Стандартный лимит времни (в мс)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>Стандартный лимит времени выполнения при запуске программы.
 Программа будет убита, если будет превышен лимит выполнения.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>Исопльзовать лимит времени из Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>Использовать лимит времени взятым Competitive Companion-ом как лимит времени соответствующей вкладки.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>Показывать только моноширинный шрифт</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>Изменить язык</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>Вам необходимо перезагрузить программу для полноценного применения нового языка.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>Показывать только моноширинные шрифты при выборе</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>Показывать лимит длины тесткейса</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>Максимальное отображаемое число символов в тесткейсе.
 Если тесткейс будет слишком большой, он будет пропущен и доступен только для чтения.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Программа Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Аргументы Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>Аргументы, применяемы для Clang Format. Они НЕ должны содержать &quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Стиль Clang Format</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>Программа YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>Программа для YAPF. Это может быть &quot;yapf&quot; (который не требует аргументы) или &quot;python&quot; (который требует аргумент &quot;-m yapf&quot;).</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>Аргументы YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>Аргументы, применяемы для программы YAPF. Они не должны содержать &quot;-i&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>Стиль YAPF</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>Параметры стиля YAPF, которые обычно сохраняются в конфигурационный файл .style.yapf or setup.conf.
 Вы можете узнать больше об этом запустив &quot;yapf --style-help&quot;.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>Форматировать код, когда он сохраняется вручную.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>Форматировать код, когда он автоматически сохраняется.</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>Содержание заголовков комменатриев</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>прокси сети</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation type="unfinished">прокси сети</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>Включить эмуляцию Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>Включить эмуляцию Vim в редакторе кода</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Конфигурация Vim</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Содержимое Vim RC. Загружается при каждом запуске эмуляции Vim.
@@ -3596,7 +2872,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>Очистить горячую клавишу</translation>
     </message>
@@ -3604,52 +2879,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>Вставить ряд (Ctrl+N)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>Удалить данный ряд (Ctrl+W)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>Удалить элементы</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>Вы действительно хотите удалить данный ряд?</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>Переместить вверх</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>Переместите текущий ряд вверх (Ctrl+Shift+Up)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>Переместить вниз</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>Переместите текущий ряд вниз (Ctrl+Shift+Down)</translation>
     </message>
@@ -3657,7 +2922,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>Пожертвовать</translation>
     </message>
@@ -3665,42 +2929,34 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>Нравится CP Editor?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>Спасибо Вам за использование CP Editor!</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>Для того чтобы поддержать нас, Вы можете:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>Дать нам звезду на GitHub</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>Поделиться информацией о CP Editor cо своими друзьями</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>Поддержать нас финансово</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>Дать немного советов чтобы помочь нам быть лучше</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>Я использую @cpeditor_ — специальная IDE для спортивного программирования и она отлична!</translation>
     </message>
@@ -3708,17 +2964,14 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>Не найдено релизов.</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>Не найдено URL для загрузки версии [%1].</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>Эта ошибка, вероятно, вызвана отсутствием библиотеки OpenSSL. Вы можете посетить &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; для установки бинарного файла, или установите его через Ваш пакетный менеджер. Рекомендуется установить версию, совместимую с этой версией: [%1]</translation>
     </message>
@@ -3726,64 +2979,50 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="87"/>
-        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>Не удалось открыть файл [%1]. Предоставлен ли доступ к записи в фалйл?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="97"/>
-        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>Не удалось сохранить [%1]. Предоставлен ли доступ  к записи в фалйл?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>Файла [%1] не существует</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>Не удалось открыть файл [%1]. Предоставлен ли доступ к чтению фалйла?</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>Показать %1 в Finder</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>Показать %1 в Проводнике</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>Открыть папку содержащую %1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>Показать %1 в Файловом менеджере</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3791,62 +3030,50 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>Создать новое соревнование</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>Главная директория</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>Поддиректория</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>Число задач</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>Главная директория не существует</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>Главная директория [%1] не существует. Вы хотите создать ее и продолжить?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>Ошибка при создании директории</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>Ошибка при создании директории [%1].</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>Детали соревнования</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>Сохранить путь</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>Выбрать главную директорию</translation>
     </message>
@@ -3854,17 +3081,14 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Отображение различий</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>Ожидаемо</translation>
     </message>
@@ -3872,33 +3096,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation type="unfinished">Сбросить</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3906,222 +3123,162 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">Ошибка при создании временной директории</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">Чтение testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">Сохранить testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">Компилятор</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4129,72 +3286,58 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>Ввод</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>Ожидаемо</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>Запуск</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>Проверить на одном тесткейсе</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>Открыть отображение различий</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>Ввод #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>Вывод #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>Ожидаемо #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>Удалить тесткейс</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>Вы уверены, что хотите удалить тесткейс #%1?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Отображение различий[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>Вывод/ответ содержит более %1 знаков, HTML diff viewer отключён. Вы можете изменить лимит длины в %2.</translation>
     </message>
@@ -4202,54 +3345,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>Загрузить из файла</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>Отредактировать в большем окне</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>Изменить тесткейс</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>Ввод</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>Вывод</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>Ожидаемо</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>Сохранить в файл</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>Сохранить тесткейс в файл</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>Отображены только первые %1 символов. Сейчас тесткейсы доступны только для чтения. Вы можете установить лимит длины в %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>Копировать вывод в ожидаемый</translation>
     </message>
@@ -4257,223 +3388,173 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>Тесткейсы</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>Чекер:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>Добавить тест</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>Ещё</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>Добавить чекер</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>Добавить кастомный чекер</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>Добавить пары тесткейсов из файла</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>Закрыть файлы тесткейсов</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>Загрузить тесткейсы</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>Пара тесткейсов [%1] и [%2] загружены</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>Вводные данные [%1] загружены</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>Следующие файлы не загружаются, потому что они не совпадают:%1. Можно установить правила соответствия в %2.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>Вы уверены удалить все тесткейсы?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>Инвертировать</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>Игнорировать конечные пробелы</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>Строго также</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - Сравнение int64s</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - Сравнение doubles, максимальная погрешность 1e-4</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - Сравнение doubles, максимальная погрешность 1e-6</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - Сравнение doubles, максимальная погрешность 1e-9</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - Сравнение токенов</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - Сравнение YES/NO без учёта регистра</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>Добавить тесткейс</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>Здесь уже %1 тестов, Вы не можете добавить больше.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>Вводные данные #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>Ожидаемо #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>Сохранить ввод #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>Сохранить ответ #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>Загрузка %1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>Тесткейсы</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>Не принято / Принято / Всего</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>Отметить все</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>Снять все отметки</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>Снять отметки с принятых</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>Удалить все</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>Удалить пустые</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Удалить отмеченные</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>Вы действительно хотите удалить все отмеченные тест-кейсы?</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>Копировать тест-кейсы</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>Вставить тест-кейсы</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>Копировать вывод в ожидаемый</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>Вы действительно хотите скопировать все отмеченные тест-кейсы в соответсвующие им ожидаемые?</translation>
@@ -4482,32 +3563,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>Скачать</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>Доступно новое обновление</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>Новое %1 обновление &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; доступно. Смотрите ниже список изменений.&lt;br /&gt;Мы настоятельно рекомендуем вам обновлять редактор, чтобы вы не пропустили потрясающие новые функции и исправления ошибок.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>бета</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>стабильная версия</translation>
     </message>
@@ -4515,37 +3590,30 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>Закройте это окно и отмените проверку обновления</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>Проверка обновлений</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>Загружается список релизов...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>Ошибка: %1&lt;br /&gt;&lt;br /&gt;Произошла ошибка при проверке обновления. Пожалуйста, проверьте обновление вручную на &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/ru/download&quot;&gt;https://cpeditor.org/ru/download&lt;/a&gt; или &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translatorcomment>The most suitable translation</translatorcomment>
         <translation>Вы уже используете последнюю версию CP Editor. Ура-а-а-а!</translation>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -4,450 +4,410 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>热退出</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>在上一次会话中，CP Editor 被意外关闭，你希望恢复上一次会话吗？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>显示主窗口</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>打开文件中</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>关于 CP Editor %1</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; 是一个基于 Qt 的原生态 IDE。它专为算法竞赛设计，不像其它 IDE 主要是为了开发设计。它可以帮助你自动化编译、运行、测试，从而让你专注于算法设计。它甚至可以从各种算法竞赛网站上获取样例，将代码提交到 Codeforces 上！&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;本程序是自由软件；请参看源代码的版权声明。本软件没有任何担保；包括没有适销性和某一专用目的下的适用性担保。CP Editor 的代码可以在 &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt; 获取。&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>重置设置</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>你确定要重置所有设置吗？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1316"/>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>代码片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>语言 %1 没有任何代码片段。请在设置窗口中添加。</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>使用代码片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>选择一个代码片段：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>语言 %2 没有叫做 %1 的代码片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>关闭其它标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>关闭左侧标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>关闭右侧标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>复制文件路径</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>复制题目链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>设置 Codeforces 链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>设置 CF 链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>输入比赛 ID：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>输入题目编号（A-Z）：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1602"/>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>设置题目链接</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>输入新的题目链接：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>事件日志器</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>除当前会话外所有日志已被删除</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: 一款为算法竞赛量身定制的编辑器</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation type="vanished">另存为...</translation>
+        <translation>另存为...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation type="vanished">保存到一个新文件</translation>
+        <translation>保存到一个新文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>保存所有</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation type="vanished">保存所有打开的文件</translation>
+        <translation>保存所有打开的文件</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation type="vanished">关闭当前</translation>
+        <translation>关闭当前</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation type="vanished">关闭当前标签页</translation>
+        <translation>关闭当前标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>关闭已保存</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation type="vanished">关闭已保存的标签页</translation>
+        <translation>关闭已保存的标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>关闭所有</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation type="vanished">关闭所有标签页</translation>
+        <translation>关闭所有标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation type="vanished">退出程序</translation>
+        <translation>退出程序</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation type="vanished">打开文件...</translation>
+        <translation>打开文件...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation type="vanished">打开文件</translation>
+        <translation>打开文件</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation type="vanished">打开比赛...</translation>
+        <translation>打开比赛...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation type="vanished">打开一个比赛</translation>
+        <translation>打开一个比赛</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation type="vanished">增加缩进</translation>
+        <translation>增加缩进</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation type="vanished">减少缩进</translation>
+        <translation>减少缩进</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation type="vanished">向上交换当前行</translation>
+        <translation>向上交换当前行</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation type="vanished">向下交换当前行</translation>
+        <translation>向下交换当前行</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation type="vanished">复制当前行</translation>
+        <translation>复制当前行</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation type="vanished">删除当前行</translation>
+        <translation>删除当前行</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation type="vanished">开启/关闭单行注释</translation>
+        <translation>开启/关闭单行注释</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation type="vanished">开启/关闭多行注释</translation>
+        <translation>开启/关闭多行注释</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">编译</translation>
+        <translation>编译</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">编译并运行</translation>
+        <translation>编译并运行</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">运行</translation>
+        <translation>运行</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation type="vanished">格式化代码</translation>
+        <translation>格式化代码</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation type="vanished">在终端中运行</translation>
+        <translation>在终端中运行</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation type="vanished">终止所有进程</translation>
+        <translation>终止所有进程</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation type="vanished">查找和替换</translation>
+        <translation>查找和替换</translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation type="vanished">设置</translation>
+        <translation>设置</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation type="vanished">关于 Qt</translation>
+        <translation>关于 Qt</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>构建信息</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation type="vanished">检查更新</translation>
+        <translation>检查更新</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation type="vanished">新建文件</translation>
+        <translation>新建文件</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation type="vanished">在编辑器中打开一个新标签页</translation>
+        <translation>在编辑器中打开一个新标签页</translation>
+    </message>
+    <message>
+        <source>C++</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Java</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Python</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation type="vanished">在磁盘上保存文件</translation>
+        <translation>在磁盘上保存文件</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation type="vanished">使用代码片段...</translation>
+        <translation>使用代码片段...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation type="vanished">导出设置...</translation>
+        <translation>导出设置...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation type="vanished">导入设置...</translation>
+        <translation>导入设置...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation type="vanished">重置设置</translation>
+        <translation>重置设置</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation type="vanished">帮助手册</translation>
+        <translation>帮助手册</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation type="vanished">编辑器模式</translation>
+        <translation>编辑器模式</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation type="vanished">IO 模式</translation>
+        <translation>IO 模式</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation type="vanished">分屏模式</translation>
+        <translation>分屏模式</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation type="vanished">显示日志文件</translation>
+        <translation>显示日志文件</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation type="vanished">删除日志文件</translation>
+        <translation>删除日志文件</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">文件(&amp;F)</translation>
+        <translation>文件(&amp;F)</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="vanished">编辑(&amp;E)</translation>
+        <translation>编辑(&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation type="vanished">动作(&amp;A)</translation>
+        <translation>动作(&amp;A)</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">视图(&amp;V)</translation>
+        <translation>视图(&amp;V)</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation type="vanished">选项(&amp;O)</translation>
+        <translation>选项(&amp;O)</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="vanished">帮助(&amp;H)</translation>
+        <translation>帮助(&amp;H)</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>将设置导出至文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>从文件中导入设置</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>将当前会话导出至文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>导出会话</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>未能成功将当前会话导出至 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>加载会话</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>从文件中加载会话会关闭当前的所有标签页并且不会保存文件。你确定要继续吗？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>从文件中加载会话</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation type="vanished">导出会话...</translation>
+        <translation>导出会话...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation type="vanished">加载会话...</translation>
+        <translation>加载会话...</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="779"/>
-        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>CP Editor 配置文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="807"/>
-        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>CP Editor 会话文件</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation type="vanished">报告问题</translation>
+        <translation>报告问题</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -460,237 +420,197 @@ git 提交编号: %3
 操作系统: %5</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>导入设置</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>当前所有设置都会在从文件中导入设置后丢失。你确定要继续吗？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>复制标签页</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>绿色版</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>安装版</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>打开最近的文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>最近没有打开过任何文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>清空最近打开的文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>源代码</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>可执行文件</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>在浏览器中打开题目</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>设置编译命令</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>设置时间限制</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation type="vanished">全屏</translation>
+        <translation>全屏</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation type="vanished">支持我们</translation>
+        <translation>支持我们</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>如何退出全屏模式</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>按下 F11 以退出全屏模式。</translation>
     </message>
     <message>
         <source>Stress Testing...</source>
-        <translation type="vanished">对拍...</translation>
+        <translation>对拍...</translation>
     </message>
     <message>
         <source>Generator</source>
-        <translation type="vanished">数据生成器</translation>
+        <translation>数据生成器</translation>
     </message>
     <message>
         <source>Open a new tab with generator template</source>
-        <translation type="vanished">基于数据生成器模版打开新标签页</translation>
+        <translation>基于数据生成器模版打开新标签页</translation>
     </message>
     <message>
         <source>New File From Template</source>
-        <translation type="vanished">从模板新建文件</translation>
+        <translation>从模板新建文件</translation>
     </message>
     <message>
         <source>Open a new tab with C++ template</source>
-        <translation type="vanished">基于C++模版打开新标签页</translation>
+        <translation>基于C++模版打开新标签页</translation>
     </message>
     <message>
         <source>Open a new tab with Java template</source>
-        <translation type="vanished">基于Java模版打开新标签页</translation>
+        <translation>基于Java模版打开新标签页</translation>
     </message>
     <message>
         <source>Open a new tab with Python template</source>
-        <translation type="vanished">基于Python模版打开新标签页</translation>
+        <translation>基于Python模版打开新标签页</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>搜索...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>从文件中加载代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>导出代码片段到文件</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>无代码片段被选择</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>未保存的代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>代码片段 [%1] 已被更改。你希望保存更改还是丢弃更改？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>删除代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>你真的要删除代码片段 [%1] 吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>加载代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>打开 [%1] 失败。你拥有读取权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>导出代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>导出代码片段：%1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>写入 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>代码片段的名称不能为空白。
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>代码片段名称冲突</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>名称 &quot;%1&quot; 已经被使用了。你希望覆盖吗？（对应旧片段将会被删除。）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>名称 &quot;%1&quot; 已经被使用了。
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>添加代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>新代码片段的名称：</translation>
     </message>
@@ -698,93 +618,68 @@ git 提交编号: %3
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>读取评测器代码</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
-        <location filename="../src/Core/Checker.cpp" line="99"/>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
-        <location filename="../src/Core/Checker.cpp" line="301"/>
-        <location filename="../src/Core/Checker.cpp" line="302"/>
-        <location filename="../src/Core/Checker.cpp" line="303"/>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>评测器</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>读取 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>保存 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>编译评测器时发生错误：
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>评测器[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>评测器以返回值 %1 退出</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>评测器以未知返回值 %1 退出</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>测试点 #%2 的 %1 超过 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在 %4 更改限制大小。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>评测器已被终止运行</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>开始编译评测器</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>评测器编译完成</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>未能成功编译评测器：%1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>评测器的源代码发生改变，正在重新编译...</translation>
     </message>
@@ -792,22 +687,18 @@ git 提交编号: %3
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>源文件 [%1] 不存在</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>编程语言“%1”不受支持</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>未能启动编译器。请检查 %1 或将编译器添加到 PATH 环境变量中。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 为空</translation>
     </message>
@@ -815,39 +706,32 @@ git 提交编号: %3
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>源文件 [%1] 不存在。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>未能成功获取运行指令。这可能是一个 bug。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>未能成功运行。请先编译。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>程序以返回值 %1 结束了
 按任意键退出</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>未能成功在终端中运行。请在 %1 中检查终端模拟器的设置。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>你的平台上不支持在终端中运行</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>未能成功创建临时文件。</translation>
     </message>
@@ -855,12 +739,10 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>正在恢复上一次会话</translation>
     </message>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>正在恢复：[%1]</translation>
     </message>
@@ -868,52 +750,42 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` 不需要参数，或参数应为 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一，但收到了 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] 不是 C++、Python 或 Java 源文件</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] 不存在。要打开一个不存在的文件的标签页，请使用 `open!`</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] 不是一个数字</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 超出范围 [1, %2]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">不适用</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] 不是有效的视图模式。应为 &apos;split&apos; 或 &apos;edit&apos; 之一</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 不是有效的语言名称。应为 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">没有活动的标签页可用于清除消息</translation>
     </message>
@@ -921,63 +793,42 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>CF Tool 已被终止</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>题目编号为 0，将自动使用 A 作为题目编号。如果题目的实际编号不是 A，请在当前标签页的右键菜单中手动设置。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>未能成功获取 CF Tool 版本。你在设置中填写的 CF Tool 路径是否正确？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool 已启动</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>未能成功在两秒内启动 CF Tool。你在设置中填写的 CF Tool 路径是否正确？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>未能成功解析链接 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>CF Tool 运行出错</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool 以非零返回值 %1 结束</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>比赛 %1 题目 %2</translation>
     </message>
@@ -985,50 +836,34 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>格式化工具</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>格式化完毕</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>格式化工具[stdout]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>格式化工具[stderr]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>格式化命令 [%1 %2] 以返回值 %3 结束了。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>格式化进程未能在 2 秒内结束。这很可能是因为 CP Editor 没有找到 %1 程序。你可以在 %2 设置程序的路径。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>格式化进程的输出为空。请确保格式化命令中没有就地修改选项。</translation>
     </message>
@@ -1036,39 +871,32 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>服务器已关闭</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>端口已被设置为 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>监听端口 %1 失败。是否有其它进程正在占用？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>服务器已停止</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>JSON 解析器报告了错误：
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>收到的请求不是 JSON</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>收到并忽略了一个 %1 请求</translation>
     </message>
@@ -1076,42 +904,30 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Language server 出现错误。请检查日志文件以获取详细信息。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>启动 Language server 进程失败。你是否已在 %1 设置语言服务器的路径？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Language server 超时</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Language server 读取错误</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Language server 写入错误</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Language server 发生未知错误</translation>
     </message>
@@ -1120,46 +936,50 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation type="vanished">查找/替换</translation>
+        <translation>查找/替换</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Find:</source>
-        <translation type="vanished">查找：</translation>
+        <translation>查找：</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation type="vanished">替换为：</translation>
+        <translation>替换为：</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation type="vanished">错误信息</translation>
+        <translation>错误信息</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="vanished">方向</translation>
+        <translation>方向</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="vanished">上</translation>
+        <translation>上</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="vanished">下</translation>
+        <translation>下</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">选项</translation>
+        <translation>选项</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation type="vanished">区分大小写</translation>
+        <translation>区分大小写</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation type="vanished">全字匹配</translation>
+        <translation>全字匹配</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1170,7 +990,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1181,74 +1001,52 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation type="vanished">正则表达式</translation>
+        <translation>正则表达式</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation type="vanished">查找</translation>
+        <translation>查找</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="vanished">替换</translation>
+        <translation>替换</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation type="vanished">替换全部</translation>
+        <translation>替换全部</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="185"/>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>编译器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>请设置语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="218"/>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="242"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1492"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>语言错误，请设置语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>所有输入均为空，没有需要运行的</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>提交</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>确认提交</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1259,101 +1057,78 @@ p, li { white-space: pre-wrap; }
 语言：%2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="328"/>
-        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>保存临时文件失败，代码未提交。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>未命名-%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>打开 %1 的模板</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1017"/>
-        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>文件 [%1] 包含超过 %2 个字符，因此没有被打开。你可以在 %3 更改长度限制。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
-        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>临时文件</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>未能成功创建临时文件夹</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>读取 %1 的模板</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>保存更改</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>关闭前将更改保存至 [%1]？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>新文件</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>设置标签页语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>设置该标签页所使用的语言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>重载</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1364,172 +1139,150 @@ Do you want to reload it?</source>
 你希望重新加载它吗？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>行 %1，列 %2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>共有 %1 行，%2 个字符被选择</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>共有 %1 个字符被选择</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>编译已开始</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>编译已结束</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>编译警告</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>编译时发生错误</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1517"/>
-        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>编译错误</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>编译已终止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>运行器[%1]</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>程序已开始运行</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>程序在测试点 #%1 上运行了 %2ms 后终止了</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>程序在测试点 #%1 上运行了 %3ms 后以非零返回值 %2 终止了</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>在测试点 #%2 上运行的程序的 %1 包含多于 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在 %4 更改长度限制。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 已被终止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>在测试点 #%1 上运行的程序</translation>
     </message>
     <message>
+        <source>CP Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>cursor info</source>
-        <translation type="vanished">光标信息</translation>
+        <translation>光标信息</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">编译</translation>
+        <translation>编译</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">运行</translation>
+        <translation>运行</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">编译并运行</translation>
+        <translation>编译并运行</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation type="vanished">消息</translation>
+        <translation>消息</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="vanished">清除</translation>
+        <translation>清除</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="82"/>
+        <source>C++</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Auto Save</source>
         <translation>自动保存</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>你设置了你代码中主类的名字吗？如果没有，你可以在 %1 进行设置。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>未知的属性: [%1]。请在 %2 检查头部注释的设置。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>设置编译命令</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>这个标签页的自定义编译命令：</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>设置时间限制</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>这个标签页的自定义时间限制：(毫秒)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>你需要安装 CF Tool 以将代码提交到 Codeforces。如果你已经安装了，你可以将它添加到 PATH 环境变量中，或者检查 %1 处的设置。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>未能开始编译：%1</translation>
     </message>
@@ -1537,7 +1290,6 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1547,42 +1299,34 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 括号</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>没有括号对被选择</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>新的括号对</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>输入一对括号（例如: {}）：</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>删除括号对</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>你真的要删除括号对 %1 吗？</translation>
     </message>
@@ -1590,29 +1334,24 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>括号对：%1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>在 %3 中为括号对 %2 启用 %1。
 如果复选框被部分选择，则会使用全局设置。</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>自动补全</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>自动删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>按 Tab 键跳出</translation>
     </message>
@@ -1620,25 +1359,18 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="41"/>
-        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>选择一个文件</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>可执行文件</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="84"/>
-        <location filename="../src/Settings/PathItem.cpp" line="86"/>
-        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>选择一个 %1 源文件</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>选择一个可执行文件</translation>
     </message>
@@ -1646,42 +1378,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>欢迎使用 CP Editor！让我们开始吧。</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>代码编辑器设置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>C++ 编译运行命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Java 编译运行命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Python 运行命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>你可以阅读 &lt;a href=&quot;%1&quot;&gt;文档&lt;/a&gt; 或在设置中浏览以获取更多信息。</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>外观设置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>字体设置</translation>
     </message>
@@ -1689,42 +1413,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>将当前页设置重置为默认（Ctrl+D）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>丢弃当前页的更改（Ctrl+R）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>保存当前页设置（Ctrl+S）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>未保存的设置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>设置已变更。你希望保存设置还是丢弃更改？</translation>
     </message>
@@ -1732,268 +1448,239 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
-        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>搜索...</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>主页</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>回到主页</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation type="vanished">代码编辑</translation>
+        <translation>代码编辑</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">语言</translation>
+        <translation>语言</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="vanished">通用</translation>
+        <translation>通用</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation></translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="vanished">外观</translation>
+        <translation>外观</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation type="vanished">动作</translation>
+        <translation>动作</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">保存</translation>
+        <translation>保存</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation type="vanished">关联文件和题目</translation>
+        <translation>关联文件和题目</translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation type="vanished">扩展</translation>
+        <translation>扩展</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 命令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 模板</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 代码片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 括号</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
+        <source>Clang Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>YAPF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>%1 Server</source>
         <translation></translation>
     </message>
     <message>
+        <source>Competitive Companion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CF Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WakaTime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>File Path</source>
-        <translation type="vanished">文件路径</translation>
+        <translation>文件路径</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation type="vanished">测试点</translation>
+        <translation>测试点</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation type="vanished">题目链接</translation>
+        <translation>题目链接</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation type="vanished">热键</translation>
+        <translation>热键</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="vanished">高级</translation>
+        <translation>高级</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="vanished">更新</translation>
+        <translation>更新</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation type="vanished">限制</translation>
+        <translation>限制</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation type="vanished">自动保存</translation>
+        <translation>自动保存</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation type="vanished">保存会话</translation>
+        <translation>保存会话</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation type="vanished">网络代理</translation>
+        <translation>网络代理</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation type="vanished">默认路径</translation>
+        <translation>默认路径</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation type="vanished">加载外部文件修改</translation>
+        <translation>加载外部文件修改</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation type="vanished">终端中运行</translation>
+        <translation>终端中运行</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="vanished">字体</translation>
+        <translation>字体</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation type="vanished">代码格式化</translation>
+        <translation>代码格式化</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation type="vanished">测试用例</translation>
+        <translation>测试用例</translation>
     </message>
     <message>
         <source>Stopwatch</source>
-        <translation type="vanished">计时器</translation>
+        <translation>计时器</translation>
     </message>
     <message>
         <source>Stress Testing</source>
-        <translation type="vanished">对拍</translation>
+        <translation>对拍</translation>
     </message>
     <message>
         <source>Generator Template</source>
-        <translation type="vanished">数据生成器模版</translation>
+        <translation>数据生成器模版</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>缩进宽度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>制表符的宽度或缩进的空格个数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>光标宽度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>光标的像素宽度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>编辑器字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>代码编辑器的字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>默认编程语言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>打开新标签页时默认的编程语言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Clang Format 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Clang Format 格式化所用风格，通常存储为 .clang-format。
 你可以在 &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt; 上了解更多。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>新建 C++ 代码时所用模板的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -2002,70 +1689,51 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 如果没有匹配，光标将会在模板结尾。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>偏移是基于正则表达式匹配的开头还是结尾。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>包含空白字符的偏移字符数，相对于正则表达式的匹配位置。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>编译 C++ 代码所用命令。这里不应该包含源代码路径或是&quot;-o &lt;output file&gt;&quot;。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>执行 C++ 程序时提供的命令行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>新建 Java 代码时所用模板的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>编译 Java 代码所用命令。这里不应该包含源代码路径或是输出的 class 文件路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>执行 Java 程序时提供的命令行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>执行 Java 程序时的命令。这里不应该包含&quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 运行命令</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 类名称</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 类路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2078,84 +1746,68 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用 &quot;${tmpdir}&quot; 或 &quot;${tempdir}&quot; 来代指临时目录的绝对路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>新建 Python 代码时所用模板的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>执行 Python 程序时提供的命令行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>执行 Python 程序时的命令。这里不应该包含源代码路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>编辑器主题</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>代码编辑器高亮所用的主题</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>自动补全括号</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>自动删除括号</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>自动缩进</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>在&quot;{&quot;后换行时插入一个缩进。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>自动保存</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>文本自动换行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>当单行超出屏幕时折成多行。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>使用测试版本</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>检查更新时包含测试版本。测试版将会包含更多功能，但可能不太稳定。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>从文件添加成对测试用例时使用的成对的正则表达式。
 每对正则表达式代表一个测试点。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -2163,76 +1815,34 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 模板路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>使用 %1 模板时光标初始位置定位使用的正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>使用 %1 模板时光标初始位置的偏移类型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>使用 %1 模板时光标初始位置的偏移字符量</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 编译命令</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 可执行文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2247,19 +1857,14 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用 &quot;${tmpdir}&quot; 或 &quot;${tempdir}&quot; 来代指临时目录的绝对路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 运行参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>你的代码中主类的名称。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -2267,12 +1872,10 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>在按下 Tab 键时跳出括号</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -2280,325 +1883,250 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Enable Ctrl+Scroll to change font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>输入制表符时插入空格代替。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>将制表符替换为空格</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>保存文件时保存测试用例</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>在保存文件时一并保存测试用例，在加载时一并加载。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>启动时检查更新</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>在启动程序时检查有无新版本。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>主窗口的不透明度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>启用 Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>接受 Competitive Companion 发送的数据并加载测试数据。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>连接端口</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>从 Competitive Companion 接受数据使用的端口</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>打开新标签页</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>为 Competitive Companion 解析的每一个题目打开一个新标签页。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>格式化代码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>结束所有进程</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>编译并运行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>仅运行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>仅编译</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>切换视图模式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>使用代码片段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>CF Tool 可执行文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>只显示编译并运行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>在主窗口隐藏编译，运行两个按钮。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>在差异查看器中显示行尾字符</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>在 HTML 差异查看器中使用 &quot;¶&quot; 表示换行符。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>更快地保存文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>总是使用 QFile 而不是 QSaveFile 来保存。
 这会更快速，但更可能丢失文件（概率极小）。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>输出长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>程序的最大输出字符数。
 stdout 或 stderr 过长的程序将会被终止。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>消息长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>主窗口右上角内每条信息的最大长度。
 超长部分将会被省略。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>HTML 差异查看器长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>HTML 差异查看器中显示的最大长度。
 如果超长，将会使用纯文本进行显示。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>打开文件长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>允许打开的文件的最大字符数。
 如果超长，将不会打开。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>C++ Language Server 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Java Language Server 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Python Language Server 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>启用 Language Server</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>在编辑器中为 C++ 显示错误、警告、信息和提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>在编辑器中为 Java 显示错误、警告、信息和提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>在编辑器中为 Python 显示错误、警告、信息和提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>使用 Language Server 的自动补全</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>使用由 Language Server 提供的自动补全</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>提示延迟（毫秒）</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>最后一次修改后，延迟进行提示的时间间隔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>传给 Language Server 程序的参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>测试数据匹配规则</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>输入正则</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>匹配整个输入文件名的正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>答案替换</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>答案文件名的替换表达式。
 你可以使用 &quot;\1&quot; 来代指匹配中的第一个捕获组。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>输入文件保存路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2613,12 +2141,10 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用&quot;${1-index}&quot;来代指以 1 起始的编号。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>答案文件保存路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2633,104 +2159,84 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用&quot;${1-index}&quot;来代指以 1 起始的编号。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>针对题目链接的默认保存路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>在设置了题目链接时，保存新文件使用的默认文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>题目链接</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>能够匹配题目链接的一部分的正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>文件路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>默认保存路径的替换表达式，不含文件后缀名。
 你可以使用 &quot;\1&quot; 来代指匹配中的第一个捕获组。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>测试用例字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>显示测试用例所用字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>在代码编辑器底部添加额外的边距</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>在代码编辑器底部添加额外的边距。
 由于技术原因，改变边距会影响撤销/重做历史。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>消息字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>显示消息所用字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>编译时保存文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>在编译前保存代码。如果是未命名标签页，则不会保存。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>执行时保存文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>在运行前保存代码。如果是未命名标签页，则不会保存。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>打开文件时加载对应题目</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>如果一个文件曾经被设置过题目链接，当你再次
 打开这个文件时，会继续使用原来那个题目链接。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>如果一个文件曾经被设置过题目链接，
@@ -2738,67 +2244,54 @@ from Competitive Companion again, the old file will be opened.</source>
 解析这道题目时，以前的那个文件会被打开。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>加载以前的题目时打开以前的文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>界面语言 (UI Language)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>在用户界面中显示的语言。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>界面风格</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>整个应用程序的风格。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>在空的测试点上运行你的代码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>在所有未隐藏的测试点运行你的代码，即使输入为空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>在输出为空的测试点上检查输出的正确性</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>即使你的输出或答案的输出为空，依然检查输出的正确性。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>自动保存间隔 (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>修改代码到自动保存之间或两次自动保存之间的时间间隔。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>自动保存间隔类型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2807,24 +2300,20 @@ After the first modification: 在修改代码时，若计时器未在运行，�
 Without modification: 以恒定的时间间隔自动保存，无论是否进行了修改。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>在启动时恢复上一次会话</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>在程序启动时恢复上一次会话。
 当这个选项启用时，你不会在退出时被询问是否保存已修改的文件。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>定期自动保存当前会话</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2832,114 +2321,90 @@ kill the application with SIGKILL which could not be handled by the application.
 这在你的电脑卡死而需要强制断开电源或使用 SIGKILL 来强制结束程序时有用。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>自动保存会话的间隔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>两次自动保存会话之间的时间间隔。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>测试用例最大高度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>无需滚动条时一个测试用例的最大高度，以像素为单位。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>代理的主机名，例如：127.0.0.1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>代理的端口，例如：1080</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>代理的用户名。若代理服务器不需要认证则可以留空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>代理的密码。若代理服务器不需要认证则可以留空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>主机名</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>端口</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>用户名</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>密码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>代理的类型。类型 &quot;System&quot; 会使用系统代理设置。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>使用自定义的全局字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>使用一个自定义的字体作为整个 CP Editor 的字体，而非使用默认的系统字体。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>自定义全局字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>整个 CP Editor 使用的自定义字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 编译器输出编码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>编译器输出（错误，警告等）的文字编码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>默认路径的名称和路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2948,185 +2413,98 @@ They can be either manually set or automatically changed after choosing a path f
 它们可以被手动设置，也可以在为一个动作选择路径后被自动设置。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>一个默认路径的名称</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>一个默认路径的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>用于 %1 的默认路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>选择 %1 的路径时使用的默认路径。
 你可以使用 ${&lt;默认路径名称&gt;} 来作为占位符。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>被 %1 改变的默认路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>为 %1 选择一个路径后被改变的默认路径。
 它是一个 &lt;默认路径名称&gt; 的列表，相邻两项之间用半角逗号隔开，可以为空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>保存文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>打开比赛</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>加载单个测试用例</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>添加多对测试用例</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>自定义评测器</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>导出和导入设置</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>导出和加载会话</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>导出和加载代码片段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>它可以被 %1 覆盖。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>手动保存时格式化代码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>自动保存时格式化代码</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>若没有未保存的修改，自动加载外部文件修改</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>如果 CP Editor 内部没有未保存的修改，自动加载不是在 CP Editor 内进行的文件修改。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>询问是否加载外部文件修改</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -3135,38 +2513,31 @@ If this is disabled, external file changes will be ignored unless they are loade
 如果这个选项被禁用，那么除非被“%1”自动加载，外部文件修改会被忽略。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>输出显示长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>会显示出来的程序输出的最大字符数。如果输出过长，超长部分会被省略。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>为评测结果显示气泡消息</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>当获知了一个提交的评测结果时，显示一条气泡消息。你可以在 CP Editor 外看到这条消息。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>终端参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>终端程序</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -3174,7 +2545,6 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 一些可能的值：konsole, gnome-terminal, xfce-terminal, xterm 或任何其它终端模拟器。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -3184,15 +2554,10 @@ Consult your terminal emulator for the suitable arguments.</source>
 请自行查阅适用于你所使用的终端模拟器的参数。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>将测试用例保存到文件</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -3203,12 +2568,10 @@ ${time}: 获取题目时的时间
 ${json.X.Y}: 由 Competitive Companion 提供的数据的一个属性，你可以在 https://github.com/jmerle/competitive-companion#explanation 获取更多信息</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>头部注释的时间格式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -3219,367 +2582,280 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>在头部注释中添加 &quot;Powered By CP Editor&quot;</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>在头部注释中添加一行 &quot;Powered By CP Editor&quot;。
 这可以在不花费任何代价的情况下让更多的人知道 CP Editor。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>默认时间限制（毫秒）</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>执行程序的默认时间限制。
 超时的程序会被终止。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>使用从 Competitive Companion 获取的时间限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>为对应的标签页使用由 Competitive Companion 解析得到的时间限制。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>仅显示等宽字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>改变语言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>你需要重启程序以彻底地改变语言。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>在选择字体时只显示等宽字体</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>显示测试用例长度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>会显示出来的测试用例的最大字符数。如果测试用例过长，超长部分会被省略，且测试用例会变得只读。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Clang Format 程序</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Clang Format 参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>传递给 clang-format 的参数。它不应包含 &quot;-i&quot;。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Clang Format 风格</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>YAPF 程序</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>YAPF 的程序。它可以是 `yapf`（无需额外设置参数）或 `python`（需要 `-m yapf` 作为参数）。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>YAPF 参数</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>传递给 YAPF 程序的参数。它不应包含 &quot;-i&quot;。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>YAPF 风格</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>YAPF 格式化所用风格，通常存储为 .style.yapf 或 setup.conf。
 你可以运行 `yapf --style-help` 以了解更多。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>手动保存时格式化代码。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>自动保存时格式化代码。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>头部注释的内容</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>自动取消选中已通过的测试点</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>在测试点通过测试时自动取消选中。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>WakaTime 可执行文件的路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Api 密钥</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>启用 WakaTime</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>在检查更新时使用代理连接到 GitHub</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>可以在 https://wakatime.com/settings/account 查看。
 如果有 WakaTime 的全局配置文件 ~/.wakatime.cfg 则可以留空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>使用代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>使用 高级-&gt;网络代理 将数据发送给 WakaTime。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>为检查更新启用代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation>显示计时器</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation>切换标签页时启动/暂停计时器</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation>切换标签页后，暂停原来那个标签页的计时器并启动当前标签页的计时器。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation>只在按钮按下时显示计时结果</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation>隐藏计时结果，只在“显示”按钮按下时显示。这或许可以避免计时结果更新使人分心。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation>高亮包含代码诊断信息的行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation>错误信息的颜色</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation>警告信息的颜色</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation>使用 WakaTime 来记录你的时间使用情况。需要安装 WakaTime CLI。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation>在 UI 中显示计时器。你可以用它来记录做题用时。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation>默认路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation>启用 CF Tool</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation>启用或禁用 CF Tool。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation>数据生成器模版使用的编程语言。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation>数据生成器模版的路径。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation>使用模板时光标初始位置定位使用的正则表达式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation>使用模板时光标初始位置的偏移类型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation>使用模板时光标初始位置的偏移字符量</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation>模版使用的编程语言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation>模板路径</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>启用 Vim 模拟</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>在代码编辑器中启用 Vim 模拟</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Vim 配置</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Vim RC 的内容。每次启动 Vim 模拟时都会加载。
@@ -3589,7 +2865,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>清除快捷键</translation>
     </message>
@@ -3597,52 +2872,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>插入一行（Ctrl+N）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>删除当前行（Ctrl+W）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>删除项目</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>你真的要删除当前行吗？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>上移</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>将当前行上移一行（Ctrl+Shift+↑）</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>下移</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>将当前行下移一行（Ctrl+Shift+↓）</translation>
     </message>
@@ -3650,7 +2915,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>捐赠</translation>
     </message>
@@ -3658,42 +2922,34 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>喜欢 CP Editor 吗？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>感谢您使用 CP Editor！</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>你可以用下列方式支持我们：</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>在 GitHub 上给我们一个 star</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>向你的朋友们分享 CP Editor</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>在经济上支持我们</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>提供一些建议以使我们做得更好</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>我正在使用 @cpeditor_，一款为算法竞赛量身定制的 IDE，它非常好用！</translation>
     </message>
@@ -3701,17 +2957,14 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>未发现更新。</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>没有发现版本 [%1] 可用的下载链接。</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>这个错误很可能是缺失 OpenSSL 库导致的。你可以访问 &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; 来获取 OpenSSL 的下载地址，或使用你喜欢的包管理器来安装。你需要安装一个和此版本兼容的版本：[%1]</translation>
     </message>
@@ -3719,64 +2972,50 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="87"/>
-        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>打开 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="97"/>
-        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>保存 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>文件 [%1] 不存在</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>打开 [%1] 失败。你拥有读取权限吗？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>在访达中查看%1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>在资源管理器中查看%1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>打开包含%1的文件夹</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>在文件管理器中查看%1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation>C++ 源代码</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation>Java 源代码</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation>Python 源代码</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation>源代码</translation>
     </message>
@@ -3784,62 +3023,50 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>创建一个新比赛</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>主目录</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>子目录</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>题目数量</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>主目录不存在</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>主目录 [%1] 不存在。你想要创建目录并继续吗？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>创建目录失败</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>未能成功创建目录 [%1]。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>比赛细节</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>保存路径</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>选择主目录</translation>
     </message>
@@ -3847,17 +3074,14 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>差异查看器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
@@ -3865,33 +3089,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation>启动</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation>暂停</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation>继续</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation>计时器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation>显示</translation>
     </message>
@@ -3899,222 +3116,162 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation>对拍</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation>数据生成器路径:</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation>例如:&quot;10 [5..100] abacaba&quot;</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation>标准程序路径：</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation>参数模式不合法</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation>读取数据生成器代码</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation>读取标准程序代码</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation>打开数据生成器失败</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation>打开标准程序失败</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation>读取 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation>保存 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation>编译器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation>使用运行参数 &quot;%1&quot; 测试</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation>数据生成器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation>用户程序</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation>标准程序</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation>程序在运行 %1ms 后以非零返回值 %2 终止了</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation>程序已被终止运行</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation>超出输出长度限制</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation>所有测试结束</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation>%1 编译已开始</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation>%1 编译已结束</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation>%1 编译错误：%2</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation>%1 编译失败：%2</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation>%1 编译已终止</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation>发现反例</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation>用户程序：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation>添加到测试用例</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation>停止对拍</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation>已将反例添加至测试用例</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation>用时：%1:%2  |  已完成：%3</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation>从打开的文件中选择数据生成器...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation>从打开的文件中选择标准程序...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation>使用数据生成器参数：</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation>请选择数据生成器和标准程序</translation>
     </message>
@@ -4122,72 +3279,58 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>输入</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>在单个测试点上进行测试</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>打开差异查看器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>输入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>输出 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>删除测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>你确定要删除测试点 #%1 吗？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>差异查看器[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>输出或答案超过了 %1 个字符，因此 HTML 差异查看器已被禁用。你可以在 %2 更改限制大小。</translation>
     </message>
@@ -4195,54 +3338,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>从文件中加载</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>在更大的窗口中编辑</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>编辑测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>输入</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>保存到文件</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>将测试用例保存到文件</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>只显示了前 %1 个字符。现在测试用例编辑器是只读的。你可以在 %2 中设置长度限制。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>将输出复制到答案</translation>
     </message>
@@ -4250,223 +3381,173 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>测试用例</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>评测器：</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>添加测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>添加评测器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>添加基于 testlib 的自定义评测器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>从文件添加成对的测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>选择测试点文件</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>加载测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>已加载一对测试点 [%1] 和 [%2]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>已加载输入 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>下列文件由于没有匹配而未加载：%1。你可以在 %2 设置匹配规则。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>你确定要删除所有测试点吗？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>反选</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>忽略行末空格和文末换行</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>严格一致</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - 匹配 64 位整数</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - 匹配浮点数，最大允许误差 1e-4</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - 匹配浮点数，最大允许误差 1e-6</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - 匹配浮点数，最大允许误差 1e-9</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - 匹配字符串</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - 匹配 YES 和 NO，大小写不敏感</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>添加测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>已经有 %1 个测试点了，你不能继续添加更多了。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>输入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>保存输入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>保存答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>加载 %1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>未通过 / 通过 / 总计</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>取消全选</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>取消选择已通过的</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>全部删除</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>删除空测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>删除选中的测试点</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>你确定要删除所有选中的测试点吗？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>复制测试用例</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>粘贴测试用例</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>将输出复制到答案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>你确定要将所有选中的输出复制到与之对应的答案吗？</translation>
@@ -4475,32 +3556,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>新更新可用</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>一个新的 %1 更新 &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; 可用。更新日志在下方。&lt;br /&gt;我们强烈建议您更新至最新版本，这样你才不会错过新的特性和 bug 修复。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>测试</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>稳定</translation>
     </message>
@@ -4508,37 +3583,30 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>关闭对话框并终止检查更新</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>更新检查器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>获取更新列表中...</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>错误：%1&lt;br /&gt;&lt;br /&gt;检查更新失败。请前往 &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/zh/download&quot;&gt;https://cpeditor.org/zh/download&lt;/a&gt; 或 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt; 手动检查更新。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation>恭喜！！你已经在使用最新版本的 CP Editor 了。</translation>
     </message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -4,398 +4,450 @@
 <context>
     <name>AppWindow</name>
     <message>
+        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translation>热退出</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>在上一次会话中，CP Editor 被意外关闭，你希望恢复上一次会话吗？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>显示主窗口</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>打开文件中</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>关于 CP Editor %1</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; 是一个基于 Qt 的原生态 IDE。它专为算法竞赛设计，不像其它 IDE 主要是为了开发设计。它可以帮助你自动化编译、运行、测试，从而让你专注于算法设计。它甚至可以从各种算法竞赛网站上获取样例，将代码提交到 Codeforces 上！&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;本程序是自由软件；请参看源代码的版权声明。本软件没有任何担保；包括没有适销性和某一专用目的下的适用性担保。CP Editor 的代码可以在 &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt; 获取。&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>打开文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>重置设置</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>你确定要重置所有设置吗？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1316"/>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>代码片段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>语言 %1 没有任何代码片段。请在设置窗口中添加。</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>使用代码片段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>选择一个代码片段：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>语言 %2 没有叫做 %1 的代码片段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>关闭其它标签页</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translation>关闭左侧标签页</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>关闭右侧标签页</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>复制文件路径</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>复制题目链接</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>设置 Codeforces 链接</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>设置 CF 链接</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>输入比赛 ID：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>输入题目编号（A-Z）：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1602"/>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>设置题目链接</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>输入新的题目链接：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>事件日志器</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>除当前会话外所有日志已被删除</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor: 一款为算法竞赛量身定制的编辑器</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>另存为...</translation>
+        <translation type="vanished">另存为...</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation>保存到一个新文件</translation>
+        <translation type="vanished">保存到一个新文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>保存所有</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation>保存所有打开的文件</translation>
+        <translation type="vanished">保存所有打开的文件</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation>关闭当前</translation>
+        <translation type="vanished">关闭当前</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation>关闭当前标签页</translation>
+        <translation type="vanished">关闭当前标签页</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>关闭已保存</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation>关闭已保存的标签页</translation>
+        <translation type="vanished">关闭已保存的标签页</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>关闭所有</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation>关闭所有标签页</translation>
+        <translation type="vanished">关闭所有标签页</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation>退出程序</translation>
+        <translation type="vanished">退出程序</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation>打开文件...</translation>
+        <translation type="vanished">打开文件...</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation>打开文件</translation>
+        <translation type="vanished">打开文件</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation>打开比赛...</translation>
+        <translation type="vanished">打开比赛...</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation>打开一个比赛</translation>
+        <translation type="vanished">打开一个比赛</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation>增加缩进</translation>
+        <translation type="vanished">增加缩进</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation>减少缩进</translation>
+        <translation type="vanished">减少缩进</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation>向上交换当前行</translation>
+        <translation type="vanished">向上交换当前行</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation>向下交换当前行</translation>
+        <translation type="vanished">向下交换当前行</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation>复制当前行</translation>
+        <translation type="vanished">复制当前行</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation>删除当前行</translation>
+        <translation type="vanished">删除当前行</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation>开启/关闭单行注释</translation>
+        <translation type="vanished">开启/关闭单行注释</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation>开启/关闭多行注释</translation>
+        <translation type="vanished">开启/关闭多行注释</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>编译</translation>
+        <translation type="vanished">编译</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>编译并运行</translation>
+        <translation type="vanished">编译并运行</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>运行</translation>
+        <translation type="vanished">运行</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation>格式化代码</translation>
+        <translation type="vanished">格式化代码</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation>在终端中运行</translation>
+        <translation type="vanished">在终端中运行</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation>终止所有进程</translation>
+        <translation type="vanished">终止所有进程</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation>查找和替换</translation>
+        <translation type="vanished">查找和替换</translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation>设置</translation>
+        <translation type="vanished">设置</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation>关于 Qt</translation>
+        <translation type="vanished">关于 Qt</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>构建信息</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation>检查更新</translation>
+        <translation type="vanished">检查更新</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation>新建文件</translation>
+        <translation type="vanished">新建文件</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation>在编辑器中打开一个新标签页</translation>
+        <translation type="vanished">在编辑器中打开一个新标签页</translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation>在磁盘上保存文件</translation>
+        <translation type="vanished">在磁盘上保存文件</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation>使用代码片段...</translation>
+        <translation type="vanished">使用代码片段...</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation>导出设置...</translation>
+        <translation type="vanished">导出设置...</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation>导入设置...</translation>
+        <translation type="vanished">导入设置...</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation>重置设置</translation>
+        <translation type="vanished">重置设置</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation>帮助手册</translation>
+        <translation type="vanished">帮助手册</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation>编辑器模式</translation>
+        <translation type="vanished">编辑器模式</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation>IO 模式</translation>
+        <translation type="vanished">IO 模式</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation>分屏模式</translation>
+        <translation type="vanished">分屏模式</translation>
     </message>
     <message>
         <source>Show Log Files</source>
-        <translation>显示日志文件</translation>
+        <translation type="vanished">显示日志文件</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation>删除日志文件</translation>
+        <translation type="vanished">删除日志文件</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>文件(&amp;F)</translation>
+        <translation type="vanished">文件(&amp;F)</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>编辑(&amp;E)</translation>
+        <translation type="vanished">编辑(&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation>动作(&amp;A)</translation>
+        <translation type="vanished">动作(&amp;A)</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation>视图(&amp;V)</translation>
+        <translation type="vanished">视图(&amp;V)</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation>选项(&amp;O)</translation>
+        <translation type="vanished">选项(&amp;O)</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>帮助(&amp;H)</translation>
+        <translation type="vanished">帮助(&amp;H)</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>将设置导出至文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>从文件中导入设置</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>将当前会话导出至文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>导出会话</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>未能成功将当前会话导出至 [%1]</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>加载会话</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>从文件中加载会话会关闭当前的所有标签页并且不会保存文件。你确定要继续吗？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>从文件中加载会话</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation>导出会话...</translation>
+        <translation type="vanished">导出会话...</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation>加载会话...</translation>
+        <translation type="vanished">加载会话...</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="779"/>
+        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>CP Editor 配置文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="807"/>
+        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>CP Editor 会话文件</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation>报告问题</translation>
+        <translation type="vanished">报告问题</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -408,209 +460,237 @@ git 提交编号: %3
 操作系统: %5</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>导入设置</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>当前所有设置都会在从文件中导入设置后丢失。你确定要继续吗？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translation>复制标签页</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>绿色版</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>安装版</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>打开最近的文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>最近没有打开过任何文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>清空最近打开的文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>源代码</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>可执行文件</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>在浏览器中打开题目</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>设置编译命令</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>设置时间限制</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation>全屏</translation>
+        <translation type="vanished">全屏</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation>支持我们</translation>
+        <translation type="vanished">支持我们</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>如何退出全屏模式</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>按下 F11 以退出全屏模式。</translation>
     </message>
     <message>
         <source>Stress Testing...</source>
-        <translation>对拍...</translation>
+        <translation type="vanished">对拍...</translation>
     </message>
     <message>
         <source>Generator</source>
-        <translation>数据生成器</translation>
+        <translation type="vanished">数据生成器</translation>
     </message>
     <message>
         <source>Open a new tab with generator template</source>
-        <translation>基于数据生成器模版打开新标签页</translation>
+        <translation type="vanished">基于数据生成器模版打开新标签页</translation>
     </message>
     <message>
         <source>New File From Template</source>
-        <translation>从模板新建文件</translation>
-    </message>
-    <message>
-        <source>C++</source>
-        <translation></translation>
+        <translation type="vanished">从模板新建文件</translation>
     </message>
     <message>
         <source>Open a new tab with C++ template</source>
-        <translation>基于C++模版打开新标签页</translation>
-    </message>
-    <message>
-        <source>Java</source>
-        <translation></translation>
+        <translation type="vanished">基于C++模版打开新标签页</translation>
     </message>
     <message>
         <source>Open a new tab with Java template</source>
-        <translation>基于Java模版打开新标签页</translation>
-    </message>
-    <message>
-        <source>Python</source>
-        <translation></translation>
+        <translation type="vanished">基于Java模版打开新标签页</translation>
     </message>
     <message>
         <source>Open a new tab with Python template</source>
-        <translation>基于Python模版打开新标签页</translation>
+        <translation type="vanished">基于Python模版打开新标签页</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>搜索...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>重命名</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>从文件中加载代码片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>导出代码片段到文件</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>无代码片段被选择</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>未保存的代码片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>代码片段 [%1] 已被更改。你希望保存更改还是丢弃更改？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>删除代码片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>你真的要删除代码片段 [%1] 吗？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>加载代码片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>打开 [%1] 失败。你拥有读取权限吗？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>导出代码片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>导出代码片段：%1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>写入 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>代码片段的名称不能为空白。
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>代码片段名称冲突</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translation>名称 &quot;%1&quot; 已经被使用了。你希望覆盖吗？（对应旧片段将会被删除。）</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>名称 &quot;%1&quot; 已经被使用了。
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>添加代码片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>新代码片段的名称：</translation>
     </message>
@@ -618,68 +698,93 @@ git 提交编号: %3
 <context>
     <name>Core::Checker</name>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>读取评测器代码</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
+        <location filename="../src/Core/Checker.cpp" line="99"/>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
+        <location filename="../src/Core/Checker.cpp" line="301"/>
+        <location filename="../src/Core/Checker.cpp" line="302"/>
+        <location filename="../src/Core/Checker.cpp" line="303"/>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>评测器</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>读取 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>保存 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>编译评测器时发生错误：
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>评测器[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>评测器以返回值 %1 退出</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>评测器以未知返回值 %1 退出</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>测试点 #%2 的 %1 超过 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在 %4 更改限制大小。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>评测器已被终止运行</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>开始编译评测器</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>评测器编译完成</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>未能成功编译评测器：%1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>评测器的源代码发生改变，正在重新编译...</translation>
     </message>
@@ -687,18 +792,22 @@ git 提交编号: %3
 <context>
     <name>Core::Compiler</name>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>源文件 [%1] 不存在</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>编程语言“%1”不受支持</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>未能启动编译器。请检查 %1 或将编译器添加到 PATH 环境变量中。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 为空</translation>
     </message>
@@ -706,32 +815,39 @@ git 提交编号: %3
 <context>
     <name>Core::Runner</name>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>源文件 [%1] 不存在。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>未能成功获取运行指令。这可能是一个 bug。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>未能成功运行。请先编译。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>程序以返回值 %1 结束了
 按任意键退出</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>未能成功在终端中运行。请在 %1 中检查终端模拟器的设置。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>你的平台上不支持在终端中运行</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>未能成功创建临时文件。</translation>
     </message>
@@ -739,10 +855,12 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>正在恢复上一次会话</translation>
     </message>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>正在恢复：[%1]</translation>
     </message>
@@ -750,42 +868,52 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` 不需要参数，或参数应为 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一，但收到了 [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] 不是 C++、Python 或 Java 源文件</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] 不存在。要打开一个不存在的文件的标签页，请使用 `open!`</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] 不是一个数字</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 超出范围 [1, %2]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">不适用</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] 不是有效的视图模式。应为 &apos;split&apos; 或 &apos;edit&apos; 之一</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 不是有效的语言名称。应为 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">没有活动的标签页可用于清除消息</translation>
     </message>
@@ -793,42 +921,63 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>CF Tool 已被终止</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>题目编号为 0，将自动使用 A 作为题目编号。如果题目的实际编号不是 A，请在当前标签页的右键菜单中手动设置。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>未能成功获取 CF Tool 版本。你在设置中填写的 CF Tool 路径是否正确？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool 已启动</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>未能成功在两秒内启动 CF Tool。你在设置中填写的 CF Tool 路径是否正确？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translation>未能成功解析链接 [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>CF Tool 运行出错</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool 以非零返回值 %1 结束</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>比赛 %1 题目 %2</translation>
     </message>
@@ -836,34 +985,50 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>格式化工具</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>格式化完毕</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>格式化工具[stdout]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>格式化工具[stderr]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>格式化命令 [%1 %2] 以返回值 %3 结束了。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>格式化进程未能在 2 秒内结束。这很可能是因为 CP Editor 没有找到 %1 程序。你可以在 %2 设置程序的路径。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>格式化进程的输出为空。请确保格式化命令中没有就地修改选项。</translation>
     </message>
@@ -871,32 +1036,39 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>服务器已关闭</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>端口已被设置为 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>监听端口 %1 失败。是否有其它进程正在占用？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>服务器已停止</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>JSON 解析器报告了错误：
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>收到的请求不是 JSON</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>收到并忽略了一个 %1 请求</translation>
     </message>
@@ -904,30 +1076,42 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Language server 出现错误。请检查日志文件以获取详细信息。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>启动 Language server 进程失败。你是否已在 %1 设置语言服务器的路径？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>Language server 超时</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>Language server 读取错误</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>Language server 写入错误</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>Language server 发生未知错误</translation>
     </message>
@@ -936,50 +1120,46 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation>查找/替换</translation>
+        <translation type="vanished">查找/替换</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
-        <source>Form</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Find:</source>
-        <translation>查找：</translation>
+        <translation type="vanished">查找：</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation>替换为：</translation>
+        <translation type="vanished">替换为：</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation>错误信息</translation>
+        <translation type="vanished">错误信息</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation>方向</translation>
+        <translation type="vanished">方向</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>选项</translation>
+        <translation type="vanished">选项</translation>
     </message>
     <message>
         <source>Case sensitive</source>
-        <translation>区分大小写</translation>
+        <translation type="vanished">区分大小写</translation>
     </message>
     <message>
         <source>Whole words only</source>
-        <translation>全字匹配</translation>
+        <translation type="vanished">全字匹配</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -990,7 +1170,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1001,52 +1181,74 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation>正则表达式</translation>
+        <translation type="vanished">正则表达式</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation>查找</translation>
+        <translation type="vanished">查找</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation>替换</translation>
+        <translation type="vanished">替换</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation>替换全部</translation>
+        <translation type="vanished">替换全部</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../src/mainwindow.cpp" line="185"/>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>编译器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>请设置语言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="218"/>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="242"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1492"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translation>运行器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>语言错误，请设置语言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>所有输入均为空，没有需要运行的</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>提交</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>确认提交</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1057,78 +1259,101 @@ p, li { white-space: pre-wrap; }
 语言：%2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="328"/>
+        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>保存临时文件失败，代码未提交。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>未命名-%1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>另存为</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>打开 %1 的模板</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1017"/>
+        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>打开文件</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>文件 [%1] 包含超过 %2 个字符，因此没有被打开。你可以在 %3 更改长度限制。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>保存</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
+        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>临时文件</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>未能成功创建临时文件夹</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>读取 %1 的模板</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>保存更改</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translation>关闭前将更改保存至 [%1]？</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>新文件</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>设置标签页语言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>设置该标签页所使用的语言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>重载</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1139,150 +1364,172 @@ Do you want to reload it?</source>
 你希望重新加载它吗？</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>行 %1，列 %2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>共有 %1 行，%2 个字符被选择</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>共有 %1 个字符被选择</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>编译已开始</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>编译已结束</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>编译警告</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>编译时发生错误</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1517"/>
+        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>编译错误</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>编译已终止</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>运行器[%1]</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>程序已开始运行</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>程序在测试点 #%1 上运行了 %2ms 后终止了</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>程序在测试点 #%1 上运行了 %3ms 后以非零返回值 %2 终止了</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>在测试点 #%2 上运行的程序的 %1 包含多于 %3 个字符，超出了输出长度限制，因此进程被结束。你可以在 %4 更改长度限制。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 已被终止</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>终端运行器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translation>在测试点 #%1 上运行的程序</translation>
     </message>
     <message>
-        <source>CP Editor</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>cursor info</source>
-        <translation>光标信息</translation>
+        <translation type="vanished">光标信息</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>编译</translation>
+        <translation type="vanished">编译</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>运行</translation>
+        <translation type="vanished">运行</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>编译并运行</translation>
+        <translation type="vanished">编译并运行</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation>消息</translation>
+        <translation type="vanished">消息</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>清除</translation>
+        <translation type="vanished">清除</translation>
     </message>
     <message>
-        <source>C++</source>
-        <translation></translation>
-    </message>
-    <message>
+        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>自动保存</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>你设置了你代码中主类的名字吗？如果没有，你可以在 %1 进行设置。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>未知的属性: [%1]。请在 %2 检查头部注释的设置。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>设置编译命令</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>这个标签页的自定义编译命令：</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>设置时间限制</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>这个标签页的自定义时间限制：(毫秒)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>你需要安装 CF Tool 以将代码提交到 Codeforces。如果你已经安装了，你可以将它添加到 PATH 环境变量中，或者检查 %1 处的设置。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>未能开始编译：%1</translation>
     </message>
@@ -1290,6 +1537,7 @@ Do you want to reload it?</source>
 <context>
     <name>MessageLogger</name>
     <message>
+        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1299,34 +1547,42 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 括号</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>没有括号对被选择</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>新的括号对</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translation>输入一对括号（例如: {}）：</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>删除括号对</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>你真的要删除括号对 %1 吗？</translation>
     </message>
@@ -1334,24 +1590,29 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>括号对：%1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>在 %3 中为括号对 %2 启用 %1。
 如果复选框被部分选择，则会使用全局设置。</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>自动补全</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>自动删除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>按 Tab 键跳出</translation>
     </message>
@@ -1359,18 +1620,25 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="41"/>
+        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>选择一个文件</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>可执行文件</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="84"/>
+        <location filename="../src/Settings/PathItem.cpp" line="86"/>
+        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>选择一个 %1 源文件</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>选择一个可执行文件</translation>
     </message>
@@ -1378,34 +1646,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>欢迎使用 CP Editor！让我们开始吧。</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>代码编辑器设置</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>C++ 编译运行命令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Java 编译运行命令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Python 运行命令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>你可以阅读 &lt;a href=&quot;%1&quot;&gt;文档&lt;/a&gt; 或在设置中浏览以获取更多信息。</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>外观设置</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>字体设置</translation>
     </message>
@@ -1413,34 +1689,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>将当前页设置重置为默认（Ctrl+D）</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>丢弃当前页的更改（Ctrl+R）</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>保存当前页设置（Ctrl+S）</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>未保存的设置</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>设置已变更。你希望保存设置还是丢弃更改？</translation>
     </message>
@@ -1448,239 +1732,268 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
+        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>设置</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>搜索...</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>主页</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>回到主页</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation>代码编辑</translation>
+        <translation type="vanished">代码编辑</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation>语言</translation>
+        <translation type="vanished">语言</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>通用</translation>
+        <translation type="vanished">通用</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation></translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation>外观</translation>
+        <translation type="vanished">外观</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation>动作</translation>
+        <translation type="vanished">动作</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>保存</translation>
+        <translation type="vanished">保存</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation>关联文件和题目</translation>
+        <translation type="vanished">关联文件和题目</translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation>扩展</translation>
+        <translation type="vanished">扩展</translation>
     </message>
     <message>
-        <source>Clang Format</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Language Server</source>
-        <translation></translation>
-    </message>
-    <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 命令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 模板</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 代码片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 括号</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation></translation>
     </message>
     <message>
-        <source>Competitive Companion</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>CF Tool</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>File Path</source>
-        <translation>文件路径</translation>
+        <translation type="vanished">文件路径</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation>测试点</translation>
+        <translation type="vanished">测试点</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation>题目链接</translation>
+        <translation type="vanished">题目链接</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation>热键</translation>
+        <translation type="vanished">热键</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation>高级</translation>
+        <translation type="vanished">高级</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation>更新</translation>
+        <translation type="vanished">更新</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation>限制</translation>
+        <translation type="vanished">限制</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation>自动保存</translation>
+        <translation type="vanished">自动保存</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation>保存会话</translation>
+        <translation type="vanished">保存会话</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation>网络代理</translation>
+        <translation type="vanished">网络代理</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation>默认路径</translation>
+        <translation type="vanished">默认路径</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation>加载外部文件修改</translation>
+        <translation type="vanished">加载外部文件修改</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation>终端中运行</translation>
+        <translation type="vanished">终端中运行</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation>字体</translation>
-    </message>
-    <message>
-        <source>YAPF</source>
-        <translation></translation>
+        <translation type="vanished">字体</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation>代码格式化</translation>
+        <translation type="vanished">代码格式化</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation>测试用例</translation>
-    </message>
-    <message>
-        <source>WakaTime</source>
-        <translation></translation>
+        <translation type="vanished">测试用例</translation>
     </message>
     <message>
         <source>Stopwatch</source>
-        <translation>计时器</translation>
+        <translation type="vanished">计时器</translation>
     </message>
     <message>
         <source>Stress Testing</source>
-        <translation>对拍</translation>
+        <translation type="vanished">对拍</translation>
     </message>
     <message>
         <source>Generator Template</source>
-        <translation>数据生成器模版</translation>
+        <translation type="vanished">数据生成器模版</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>缩进宽度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>制表符的宽度或缩进的空格个数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>光标宽度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>光标的像素宽度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>编辑器字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>代码编辑器的字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>默认编程语言</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>打开新标签页时默认的编程语言</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Clang Format 可执行文件的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Clang Format 格式化所用风格，通常存储为 .clang-format。
 你可以在 &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt; 上了解更多。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>新建 C++ 代码时所用模板的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -1689,51 +2002,70 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 如果没有匹配，光标将会在模板结尾。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>偏移是基于正则表达式匹配的开头还是结尾。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>包含空白字符的偏移字符数，相对于正则表达式的匹配位置。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>编译 C++ 代码所用命令。这里不应该包含源代码路径或是&quot;-o &lt;output file&gt;&quot;。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>执行 C++ 程序时提供的命令行参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>新建 Java 代码时所用模板的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>编译 Java 代码所用命令。这里不应该包含源代码路径或是输出的 class 文件路径。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>执行 Java 程序时提供的命令行参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>执行 Java 程序时的命令。这里不应该包含&quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 运行命令</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 类名称</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 类路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -1746,68 +2078,84 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用 &quot;${tmpdir}&quot; 或 &quot;${tempdir}&quot; 来代指临时目录的绝对路径。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>新建 Python 代码时所用模板的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>执行 Python 程序时提供的命令行参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>执行 Python 程序时的命令。这里不应该包含源代码路径。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>编辑器主题</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>代码编辑器高亮所用的主题</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>自动补全括号</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>自动删除括号</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>自动缩进</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>在&quot;{&quot;后换行时插入一个缩进。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>自动保存</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translation>文本自动换行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>当单行超出屏幕时折成多行。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>使用测试版本</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>检查更新时包含测试版本。测试版将会包含更多功能，但可能不太稳定。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>从文件添加成对测试用例时使用的成对的正则表达式。
 每对正则表达式代表一个测试点。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -1815,34 +2163,76 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 模板路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>使用 %1 模板时光标初始位置定位使用的正则表达式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>使用 %1 模板时光标初始位置的偏移类型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>使用 %1 模板时光标初始位置的偏移字符量</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 编译命令</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 可执行文件路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -1857,14 +2247,19 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用 &quot;${tmpdir}&quot; 或 &quot;${tempdir}&quot; 来代指临时目录的绝对路径。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 运行参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>你的代码中主类的名称。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -1872,10 +2267,12 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>在按下 Tab 键时跳出括号</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -1883,242 +2280,325 @@ This can be overridden for each parenthesis in each language.</source>
 此设置可以被各个语言的设置所覆盖。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Enable Ctrl+Scroll to change font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>输入制表符时插入空格代替。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>将制表符替换为空格</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>保存文件时保存测试用例</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>在保存文件时一并保存测试用例，在加载时一并加载。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>启动时检查更新</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>在启动程序时检查有无新版本。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>主窗口的不透明度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>启用 Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>接受 Competitive Companion 发送的数据并加载测试数据。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>连接端口</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>从 Competitive Companion 接受数据使用的端口</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>打开新标签页</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>为 Competitive Companion 解析的每一个题目打开一个新标签页。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>格式化代码</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>结束所有进程</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>编译并运行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>仅运行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>仅编译</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>切换视图模式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>使用代码片段</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>CF Tool 可执行文件路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>只显示编译并运行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>在主窗口隐藏编译，运行两个按钮。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>在差异查看器中显示行尾字符</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>在 HTML 差异查看器中使用 &quot;¶&quot; 表示换行符。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>更快地保存文件</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>总是使用 QFile 而不是 QSaveFile 来保存。
 这会更快速，但更可能丢失文件（概率极小）。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>输出长度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>程序的最大输出字符数。
 stdout 或 stderr 过长的程序将会被终止。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>消息长度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>主窗口右上角内每条信息的最大长度。
 超长部分将会被省略。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>HTML 差异查看器长度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>HTML 差异查看器中显示的最大长度。
 如果超长，将会使用纯文本进行显示。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>打开文件长度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>允许打开的文件的最大字符数。
 如果超长，将不会打开。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>C++ Language Server 可执行文件的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Java Language Server 可执行文件的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Python Language Server 可执行文件的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>启用 Language Server</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>在编辑器中为 C++ 显示错误、警告、信息和提示</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>在编辑器中为 Java 显示错误、警告、信息和提示</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>在编辑器中为 Python 显示错误、警告、信息和提示</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>使用 Language Server 的自动补全</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>使用由 Language Server 提供的自动补全</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>提示延迟（毫秒）</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>最后一次修改后，延迟进行提示的时间间隔</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>传给 Language Server 程序的参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>测试数据匹配规则</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>输入正则</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>匹配整个输入文件名的正则表达式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>答案替换</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>答案文件名的替换表达式。
 你可以使用 &quot;\1&quot; 来代指匹配中的第一个捕获组。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>输入文件保存路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2133,10 +2613,12 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用&quot;${1-index}&quot;来代指以 1 起始的编号。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>答案文件保存路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2151,84 +2633,104 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用&quot;${1-index}&quot;来代指以 1 起始的编号。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>针对题目链接的默认保存路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>在设置了题目链接时，保存新文件使用的默认文件路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>题目链接</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>能够匹配题目链接的一部分的正则表达式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>文件路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>默认保存路径的替换表达式，不含文件后缀名。
 你可以使用 &quot;\1&quot; 来代指匹配中的第一个捕获组。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>测试用例字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>显示测试用例所用字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>在代码编辑器底部添加额外的边距</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>在代码编辑器底部添加额外的边距。
 由于技术原因，改变边距会影响撤销/重做历史。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>消息字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>显示消息所用字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>编译时保存文件</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>在编译前保存代码。如果是未命名标签页，则不会保存。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>执行时保存文件</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>在运行前保存代码。如果是未命名标签页，则不会保存。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>打开文件时加载对应题目</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>如果一个文件曾经被设置过题目链接，当你再次
 打开这个文件时，会继续使用原来那个题目链接。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>如果一个文件曾经被设置过题目链接，
@@ -2236,54 +2738,67 @@ from Competitive Companion again, the old file will be opened.</source>
 解析这道题目时，以前的那个文件会被打开。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>加载以前的题目时打开以前的文件</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>界面语言 (UI Language)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>在用户界面中显示的语言。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>界面风格</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>整个应用程序的风格。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>在空的测试点上运行你的代码</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>在所有未隐藏的测试点运行你的代码，即使输入为空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>在输出为空的测试点上检查输出的正确性</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>即使你的输出或答案的输出为空，依然检查输出的正确性。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>自动保存间隔 (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>修改代码到自动保存之间或两次自动保存之间的时间间隔。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>自动保存间隔类型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2292,20 +2807,24 @@ After the first modification: 在修改代码时，若计时器未在运行，�
 Without modification: 以恒定的时间间隔自动保存，无论是否进行了修改。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>在启动时恢复上一次会话</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>在程序启动时恢复上一次会话。
 当这个选项启用时，你不会在退出时被询问是否保存已修改的文件。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>定期自动保存当前会话</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2313,90 +2832,114 @@ kill the application with SIGKILL which could not be handled by the application.
 这在你的电脑卡死而需要强制断开电源或使用 SIGKILL 来强制结束程序时有用。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>自动保存会话的间隔</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>两次自动保存会话之间的时间间隔。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>测试用例最大高度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>无需滚动条时一个测试用例的最大高度，以像素为单位。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>代理的主机名，例如：127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>代理的端口，例如：1080</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>代理的用户名。若代理服务器不需要认证则可以留空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>代理的密码。若代理服务器不需要认证则可以留空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>主机名</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>端口</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>用户名</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>密码</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>代理的类型。类型 &quot;System&quot; 会使用系统代理设置。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translation>使用自定义的全局字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>使用一个自定义的字体作为整个 CP Editor 的字体，而非使用默认的系统字体。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>自定义全局字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>整个 CP Editor 使用的自定义字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 编译器输出编码</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>编译器输出（错误，警告等）的文字编码</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>默认路径的名称和路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2405,98 +2948,185 @@ They can be either manually set or automatically changed after choosing a path f
 它们可以被手动设置，也可以在为一个动作选择路径后被自动设置。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>一个默认路径的名称</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>一个默认路径的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>用于 %1 的默认路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>打开文件</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>选择 %1 的路径时使用的默认路径。
 你可以使用 ${&lt;默认路径名称&gt;} 来作为占位符。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>被 %1 改变的默认路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>为 %1 选择一个路径后被改变的默认路径。
 它是一个 &lt;默认路径名称&gt; 的列表，相邻两项之间用半角逗号隔开，可以为空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>保存文件</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>打开比赛</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>加载单个测试用例</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>添加多对测试用例</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>自定义评测器</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>导出和导入设置</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>导出和加载会话</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>导出和加载代码片段</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>它可以被 %1 覆盖。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>手动保存时格式化代码</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>自动保存时格式化代码</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>若没有未保存的修改，自动加载外部文件修改</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>如果 CP Editor 内部没有未保存的修改，自动加载不是在 CP Editor 内进行的文件修改。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>询问是否加载外部文件修改</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -2505,31 +3135,38 @@ If this is disabled, external file changes will be ignored unless they are loade
 如果这个选项被禁用，那么除非被“%1”自动加载，外部文件修改会被忽略。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>输出显示长度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>会显示出来的程序输出的最大字符数。如果输出过长，超长部分会被省略。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>为评测结果显示气泡消息</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>当获知了一个提交的评测结果时，显示一条气泡消息。你可以在 CP Editor 外看到这条消息。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>终端参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>终端程序</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -2537,6 +3174,7 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 一些可能的值：konsole, gnome-terminal, xfce-terminal, xterm 或任何其它终端模拟器。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -2546,10 +3184,15 @@ Consult your terminal emulator for the suitable arguments.</source>
 请自行查阅适用于你所使用的终端模拟器的参数。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>将测试用例保存到文件</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2560,10 +3203,12 @@ ${time}: 获取题目时的时间
 ${json.X.Y}: 由 Competitive Companion 提供的数据的一个属性，你可以在 https://github.com/jmerle/competitive-companion#explanation 获取更多信息</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>头部注释的时间格式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2574,280 +3219,367 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>在头部注释中添加 &quot;Powered By CP Editor&quot;</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>在头部注释中添加一行 &quot;Powered By CP Editor&quot;。
 这可以在不花费任何代价的情况下让更多的人知道 CP Editor。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>默认时间限制（毫秒）</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>执行程序的默认时间限制。
 超时的程序会被终止。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>使用从 Competitive Companion 获取的时间限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>为对应的标签页使用由 Competitive Companion 解析得到的时间限制。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>仅显示等宽字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>改变语言</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>你需要重启程序以彻底地改变语言。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>在选择字体时只显示等宽字体</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>显示测试用例长度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>会显示出来的测试用例的最大字符数。如果测试用例过长，超长部分会被省略，且测试用例会变得只读。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Clang Format 程序</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Clang Format 参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>传递给 clang-format 的参数。它不应包含 &quot;-i&quot;。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Clang Format 风格</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>YAPF 程序</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>YAPF 的程序。它可以是 `yapf`（无需额外设置参数）或 `python`（需要 `-m yapf` 作为参数）。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>YAPF 参数</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>传递给 YAPF 程序的参数。它不应包含 &quot;-i&quot;。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>YAPF 风格</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>YAPF 格式化所用风格，通常存储为 .style.yapf 或 setup.conf。
 你可以运行 `yapf --style-help` 以了解更多。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>手动保存时格式化代码。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>自动保存时格式化代码。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>头部注释的内容</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>自动取消选中已通过的测试点</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>在测试点通过测试时自动取消选中。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>WakaTime 可执行文件的路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>Api 密钥</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>启用 WakaTime</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>在检查更新时使用代理连接到 GitHub</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>可以在 https://wakatime.com/settings/account 查看。
 如果有 WakaTime 的全局配置文件 ~/.wakatime.cfg 则可以留空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>使用代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>使用 高级-&gt;网络代理 将数据发送给 WakaTime。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>为检查更新启用代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>网络代理</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation>显示计时器</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation>切换标签页时启动/暂停计时器</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation>切换标签页后，暂停原来那个标签页的计时器并启动当前标签页的计时器。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation>只在按钮按下时显示计时结果</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation>隐藏计时结果，只在“显示”按钮按下时显示。这或许可以避免计时结果更新使人分心。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation>高亮包含代码诊断信息的行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation>错误信息的颜色</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation>警告信息的颜色</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation>使用 WakaTime 来记录你的时间使用情况。需要安装 WakaTime CLI。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation>在 UI 中显示计时器。你可以用它来记录做题用时。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation>默认路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation>启用 CF Tool</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation>启用或禁用 CF Tool。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation>数据生成器模版使用的编程语言。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation>数据生成器模版的路径。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation>使用模板时光标初始位置定位使用的正则表达式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation>使用模板时光标初始位置的偏移类型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation>使用模板时光标初始位置的偏移字符量</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation>模版使用的编程语言</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation>模板路径</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>启用 Vim 模拟</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>在代码编辑器中启用 Vim 模拟</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Vim 配置</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Vim RC 的内容。每次启动 Vim 模拟时都会加载。
@@ -2857,6 +3589,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
+        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>清除快捷键</translation>
     </message>
@@ -2864,42 +3597,52 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>插入一行（Ctrl+N）</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>删除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>删除当前行（Ctrl+W）</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>删除项目</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>你真的要删除当前行吗？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>上移</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>将当前行上移一行（Ctrl+Shift+↑）</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>下移</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>将当前行下移一行（Ctrl+Shift+↓）</translation>
     </message>
@@ -2907,6 +3650,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>捐赠</translation>
     </message>
@@ -2914,34 +3658,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>喜欢 CP Editor 吗？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>感谢您使用 CP Editor！</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>你可以用下列方式支持我们：</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>在 GitHub 上给我们一个 star</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>向你的朋友们分享 CP Editor</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>在经济上支持我们</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>提供一些建议以使我们做得更好</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translation>我正在使用 @cpeditor_，一款为算法竞赛量身定制的 IDE，它非常好用！</translation>
     </message>
@@ -2949,14 +3701,17 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>未发现更新。</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>没有发现版本 [%1] 可用的下载链接。</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translation>这个错误很可能是缺失 OpenSSL 库导致的。你可以访问 &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;OpenSSLWiki&lt;/a&gt; 来获取 OpenSSL 的下载地址，或使用你喜欢的包管理器来安装。你需要安装一个和此版本兼容的版本：[%1]</translation>
     </message>
@@ -2964,50 +3719,64 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="87"/>
+        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>打开 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="97"/>
+        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>保存 [%1] 失败。你拥有写入权限吗？</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>文件 [%1] 不存在</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>打开 [%1] 失败。你拥有读取权限吗？</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translation>在访达中查看%1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translation>在资源管理器中查看%1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>打开包含%1的文件夹</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>在文件管理器中查看%1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation>C++ 源代码</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation>Java 源代码</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation>Python 源代码</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation>源代码</translation>
     </message>
@@ -3015,50 +3784,62 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>创建一个新比赛</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>主目录</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>子目录</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>题目数量</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>主目录不存在</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>主目录 [%1] 不存在。你想要创建目录并继续吗？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>创建目录失败</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>未能成功创建目录 [%1]。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>比赛细节</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>保存路径</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>选择主目录</translation>
     </message>
@@ -3066,14 +3847,17 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>差异查看器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
@@ -3081,26 +3865,33 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation>启动</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation>暂停</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation>继续</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation>计时器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation>显示</translation>
     </message>
@@ -3108,162 +3899,222 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation>对拍</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation>数据生成器路径:</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation>例如:&quot;10 [5..100] abacaba&quot;</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation>标准程序路径：</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation>停止</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation>参数模式不合法</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation>读取数据生成器代码</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation>读取标准程序代码</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation>打开数据生成器失败</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation>打开标准程序失败</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation>未能成功创建临时目录</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation>读取 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation>保存 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation>编译器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation>使用运行参数 &quot;%1&quot; 测试</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation>数据生成器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation>用户程序</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation>标准程序</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation>超出时间限制</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation>程序在运行 %1ms 后以非零返回值 %2 终止了</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation>程序已被终止运行</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation>超出输出长度限制</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation>所有测试结束</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation>%1 编译已开始</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation>%1 编译已结束</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation>%1 编译错误：%2</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation>%1 编译失败：%2</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation>%1 编译已终止</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation>发现反例</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation>用户程序：%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation>添加到测试用例</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation>忽略</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation>停止对拍</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation>已将反例添加至测试用例</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation>用时：%1:%2  |  已完成：%3</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation>从打开的文件中选择数据生成器...</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation>从打开的文件中选择标准程序...</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation>使用数据生成器参数：</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation>请选择数据生成器和标准程序</translation>
     </message>
@@ -3271,58 +4122,72 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>输入</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>删除</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>在单个测试点上进行测试</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>打开差异查看器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>输入 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>输出 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>删除测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>你确定要删除测试点 #%1 吗？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>差异查看器[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>输出或答案超过了 %1 个字符，因此 HTML 差异查看器已被禁用。你可以在 %2 更改限制大小。</translation>
     </message>
@@ -3330,42 +4195,54 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>从文件中加载</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>在更大的窗口中编辑</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>编辑测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>输入</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>输出</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>保存到文件</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>将测试用例保存到文件</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>只显示了前 %1 个字符。现在测试用例编辑器是只读的。你可以在 %2 中设置长度限制。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>将输出复制到答案</translation>
     </message>
@@ -3373,173 +4250,223 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>测试用例</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>评测器：</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>添加测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>添加评测器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>添加基于 testlib 的自定义评测器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>从文件添加成对的测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>选择测试点文件</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>加载测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>已加载一对测试点 [%1] 和 [%2]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>已加载输入 [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>下列文件由于没有匹配而未加载：%1。你可以在 %2 设置匹配规则。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>你确定要删除所有测试点吗？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>反选</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>忽略行末空格和文末换行</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>严格一致</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - 匹配 64 位整数</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - 匹配浮点数，最大允许误差 1e-4</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - 匹配浮点数，最大允许误差 1e-6</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - 匹配浮点数，最大允许误差 1e-9</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - 匹配字符串</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - 匹配 YES 和 NO，大小写不敏感</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>添加测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>已经有 %1 个测试点了，你不能继续添加更多了。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>输入 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>保存输入 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>保存答案 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>加载 %1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>未通过 / 通过 / 总计</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>全选</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>取消全选</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>取消选择已通过的</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>全部删除</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>删除空测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>删除选中的测试点</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>你确定要删除所有选中的测试点吗？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>复制测试用例</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>粘贴测试用例</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>将输出复制到答案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>你确定要将所有选中的输出复制到与之对应的答案吗？</translation>
@@ -3548,26 +4475,32 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>新更新可用</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>一个新的 %1 更新 &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; 可用。更新日志在下方。&lt;br /&gt;我们强烈建议您更新至最新版本，这样你才不会错过新的特性和 bug 修复。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>测试</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>稳定</translation>
     </message>
@@ -3575,30 +4508,37 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>关闭对话框并终止检查更新</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>更新检查器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>获取更新列表中...</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>错误：%1&lt;br /&gt;&lt;br /&gt;检查更新失败。请前往 &lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/zh/download&quot;&gt;https://cpeditor.org/zh/download&lt;/a&gt; 或 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt; 手动检查更新。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation>恭喜！！你已经在使用最新版本的 CP Editor 了。</translation>
     </message>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -4,68 +4,55 @@
 <context>
     <name>AppWindow</name>
     <message>
-        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>開啟最近使用的檔案</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>沒有最近開啟的檔案</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>清除最近使用的檔案</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translatorcomment>參照 Visual Studio</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>在上次的工作階段中 CP Editor 被異常地終止了。要還原工作階段嗎？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>顯示主視窗</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>關於本程式</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>開啟檔案中</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>關於 CP Editor %1</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; 是一款基於 Qt 技術的程式碼編輯器。針對競程用途專門設計，是讓它與其他編輯器或 IDE 如此不同的原因。CP Editor 將編譯、執行、測試的過程自動化，讓您可以專注在設計演算法。不僅如此，它甚至可以從其他平台取得測試資料，並繳交程式碼至 Codeforces。&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;本程式為自由軟體，請參見原始碼的版權聲明。本軟體不負任何擔保責任，包括對適售性或特定目的適用性所為的擔保。您可以在 &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt; 取得 CP Editor 的原始碼。&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>建置資訊</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -78,596 +65,557 @@ Git commit hash：%3
 作業系統：%5</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>免安裝版</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>安裝版</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>儲存全部</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>重置偏好設定</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>確定要將所有偏好設定重置為預設值？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>將設定值匯出為檔案</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="779"/>
-        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>CP Editor 設定檔</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>匯入設定</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>從檔案匯入的設定值將覆蓋現有的狀態。確定要繼續？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>從檔案匯入設定值</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>將目前的工作階段匯出為檔案</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="807"/>
-        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>CP Editor 工作階段檔</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>匯出工作階段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>無法將目前的工作階段匯出到「%1」</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>載入工作階段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>從檔案載入工作階段，將會關閉目前工作階段中包含未存檔的所有分頁。確定要繼續？</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>從檔案載入工作階段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor：一款專為競程設計的編輯器</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1316"/>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>沒有 %1 的程式碼片段。請在偏好設定視窗裡新增一個。</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>使用程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>選擇程式碼片段：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>%2 沒有名為「%1」的程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>如何退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>按下 F11 鍵來退出全螢幕模式。</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>關閉其他</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translatorcomment>參考 Firefox 翻譯</translatorcomment>
         <translation>關閉左方分頁</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>關閉右方分頁</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>關閉已存檔的</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>關閉全部</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translatorcomment>「複製」有疑義，應釐清與 Copy 的差異</translatorcomment>
         <translation>建立分頁副本</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>設定編譯命令</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>限制執行時間</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>原始檔</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>可執行檔</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>複製檔案路徑</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>在瀏覽器中開啟題目</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>複製題目網址</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>設定 Codeforces 網址</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>設定 CF 網址</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>輸入比賽 ID：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>輸入題目代號 (A-Z)：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1602"/>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>設定題目網址</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>輸入新題目網址：</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>事件紀錄</translation>
     </message>
     <message>
-        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>除了目前工作階段的所有記錄檔已被刪除</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation type="vanished">新檔案</translation>
+        <translation>新檔案</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation type="vanished">在編輯器中開啟新分頁</translation>
+        <translation>在編輯器中開啟新分頁</translation>
+    </message>
+    <message>
+        <source>Generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with generator template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C++</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with C++ template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Java</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Java template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Python</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open a new tab with Python template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation type="vanished">將檔案儲存到磁碟</translation>
+        <translation>將檔案儲存到磁碟</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation type="vanished">另存新檔…</translation>
+        <translation>另存新檔…</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation type="vanished">另存新檔</translation>
+        <translation>另存新檔</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation type="vanished">儲存所有開啟的檔案</translation>
+        <translation>儲存所有開啟的檔案</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation type="vanished">關閉目前分頁</translation>
+        <translation>關閉目前分頁</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation type="vanished">關閉目前分頁</translation>
+        <translation>關閉目前分頁</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation type="vanished">關閉已存檔的分頁</translation>
+        <translation>關閉已存檔的分頁</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation type="vanished">關閉所有分頁</translation>
+        <translation>關閉所有分頁</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation type="vanished">退出應用程式</translation>
+        <translation>退出應用程式</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation type="vanished">開啟檔案…</translation>
+        <translation>開啟檔案…</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation type="vanished">開啟檔案</translation>
+        <translation>開啟檔案</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation type="vanished">建立競賽…</translation>
+        <translation>建立競賽…</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation type="vanished">建立比賽</translation>
+        <translation>建立比賽</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation type="vanished">增縮排</translation>
+        <translation>增縮排</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation type="vanished">退縮排</translation>
+        <translation>退縮排</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation type="vanished">上移一列</translation>
+        <translation>上移一列</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation type="vanished">下移一列</translation>
+        <translation>下移一列</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation type="vanished">建立此列副本</translation>
+        <translation>建立此列副本</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation type="vanished">刪除整列</translation>
+        <translation>刪除整列</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation type="vanished">切換註解</translation>
+        <translation>切換註解</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation type="vanished">切換區塊註解</translation>
+        <translation>切換區塊註解</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">編譯</translation>
+        <translation>編譯</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">編譯並執行</translation>
+        <translation>編譯並執行</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">執行</translation>
+        <translation>執行</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation type="vanished">排版程式碼</translation>
+        <translation>排版程式碼</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation type="vanished">在終端機中執行</translation>
+        <translation>在終端機中執行</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation type="vanished">終止處理程序</translation>
+        <translation>終止處理程序</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation type="vanished">尋找及取代</translation>
+        <translation>尋找及取代</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation type="vanished">使用程式碼片段…</translation>
+        <translation>使用程式碼片段…</translation>
+    </message>
+    <message>
+        <source>Stress Testing...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation type="vanished">偏好設定</translation>
+        <translation>偏好設定</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation type="vanished">重置設定</translation>
+        <translation>重置設定</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation type="vanished">匯出設定…</translation>
+        <translation>匯出設定…</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation type="vanished">匯入設定…</translation>
+        <translation>匯入設定…</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation type="vanished">匯出工作階段…</translation>
+        <translation>匯出工作階段…</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation type="vanished">載入工作階段…</translation>
+        <translation>載入工作階段…</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation type="vanished">使用手冊</translation>
+        <translation>使用手冊</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation type="vanished">回報問題</translation>
+        <translation>回報問題</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation type="vanished">關於 Qt</translation>
+        <translation>關於 Qt</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation type="vanished">檢查更新</translation>
+        <translation>檢查更新</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation type="vanished">支持我們</translation>
+        <translation>支持我們</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation type="vanished">編輯器模式</translation>
+        <translation>編輯器模式</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation type="vanished">IO 模式</translation>
+        <translation>IO 模式</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation type="vanished">分割畫面</translation>
+        <translation>分割畫面</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation type="vanished">全螢幕</translation>
+        <translation>全螢幕</translation>
     </message>
     <message>
         <source>Show Log Files</source>
         <translatorcomment>參考自 microsoft terminology</translatorcomment>
-        <translation type="vanished">顯示記錄檔</translation>
+        <translation>顯示記錄檔</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation type="vanished">刪除記錄檔</translation>
+        <translation>刪除記錄檔</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation type="vanished">檔案(&amp;F)</translation>
+        <translation>檔案(&amp;F)</translation>
+    </message>
+    <message>
+        <source>New File From Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="vanished">編輯(&amp;E)</translation>
+        <translation>編輯(&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation type="vanished">動作(&amp;A)</translation>
+        <translation>動作(&amp;A)</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation type="vanished">檢視(&amp;V)</translation>
+        <translation>檢視(&amp;V)</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation type="vanished">選項(&amp;O)</translation>
+        <translation>選項(&amp;O)</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation type="vanished">說明(&amp;H)</translation>
+        <translation>說明(&amp;H)</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>搜尋…</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>重新命名程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>從檔案載入程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>將程式碼片段匯出為檔案</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>未選取程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>未儲存的程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>程式碼片段「%1」已變更。要儲存嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>刪除程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>確定要刪除程式碼片段「%1」？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>載入程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>無法開啟「%1」。有讀取權限嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>匯出程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>匯出程式碼片段：%1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>無法寫入「%1」。有寫入權限嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>程式碼片段名稱不可為空。
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>程式碼片段名稱衝突</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translatorcomment>it&apos;s ok to ignore the warning</translatorcomment>
         <translation>名稱「%1」已被使用。要覆寫現有的片段嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>名稱「%1」已被使用。
 </translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>新增程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>新程式碼片段名稱：</translation>
     </message>
@@ -675,93 +623,68 @@ Git commit hash：%3
 <context>
     <name>Core::Checker</name>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>讀取評判程式原始碼</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
-        <location filename="../src/Core/Checker.cpp" line="99"/>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
-        <location filename="../src/Core/Checker.cpp" line="301"/>
-        <location filename="../src/Core/Checker.cpp" line="302"/>
-        <location filename="../src/Core/Checker.cpp" line="303"/>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>評判程式</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>無法建立暫存目錄</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>讀取 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>儲存 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>開始編譯評判程式</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>完成編譯評判程式</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>編譯評判程式時發生錯誤：
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>無法編譯評判程式：%1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>執行時間過長</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>評判程式以回傳值 %1 結束執行</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>評判程式以未知的回傳值 %1 結束執行</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>在執行測資 #%2 時 %1 含有多於 %3 個字元，超出了輸出長度限制，因此被終止了。您可以在 %4 變更輸出長度限制。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>評判程式被終止了</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>評判程式[%1]</translation>
     </message>
     <message>
-        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>評判工具的程式碼已變更，重新編譯中…</translation>
     </message>
@@ -769,22 +692,18 @@ Git commit hash：%3
 <context>
     <name>Core::Compiler</name>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>原始檔「%1」不存在</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 為空</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>不支援的程式語言：%1</translation>
     </message>
     <message>
-        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>無法啟動編譯器，請將其加入 PATH 環境變數或檢查 %1 的設定。</translation>
     </message>
@@ -792,39 +711,32 @@ Git commit hash：%3
 <context>
     <name>Core::Runner</name>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>原始檔 %1 不存在。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>無法取得執行指令。這可能是軟體錯誤。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>程式以回傳值 %1 結束
 按下任意鍵以離開</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>「在終端機中執行」不支援此平台</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>無法啟動「在終端機中執行」。請於 %1 檢查終端機程式的設定。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>無法執行，請先編譯。</translation>
     </message>
     <message>
-        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>無法建立暫存檔。</translation>
     </message>
@@ -832,12 +744,10 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>正在還原上次的工作階段</translation>
     </message>
     <message>
-        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>正在還原：%1</translation>
     </message>
@@ -845,52 +755,42 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` 不需要參數，或參數應為 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一，但收到了 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] 不是 C++、Python 或 Java 原始碼檔案</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] 不存在。若要開啟一個不存在的檔案的分頁，請使用 `open!`</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] 不是數字</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 超出範圍 [1, %2]</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">不適用</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] 不是有效的檢視模式。應為 &apos;split&apos; 或 &apos;edit&apos; 之一</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 不是有效的語言名稱。應為 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一</translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">沒有作用中的分頁可清除訊息</translation>
     </message>
@@ -898,64 +798,43 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
-        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>CF Tool 已被終止</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>題目編號為 0，將自動以 A 作為題號。若實際題號非為 A，請於目前分頁的右鍵選單中設定題號。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>無法取得 CF Tool 的版本資訊。是否已在偏好設定中正確設定 CF Tool 的路徑？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool 已啟動</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>無法在兩秒內啟動 CF Tool。是否已在偏好設定中正確指定 CF Tool 路徑？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translatorcomment>parse 一詞的翻譯參考自Microsoft Language Portal</translatorcomment>
         <translation>無法剖析網址「%1」</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>CF Tool 失敗</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool 以回傳值 %1 結束</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>競賽 %1 題目 %2</translation>
     </message>
@@ -963,50 +842,34 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>排版工具</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>無法建立暫存目錄</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>排版完成</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>排版工具的處理程序未能在 2 秒內結束。這可能是因為 CP Editor 找不到 %1 程式。您可以在 %2 設定該程式的路徑。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>排版命令 [%1 %2] 以回傳值 %3 結束執行。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>排版工具 [stdout]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>排版工具 [stderr]</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>排版工具的處理程序輸出為空。請確保沒有使用就地修改的選項。</translation>
     </message>
@@ -1014,39 +877,32 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>收到並忽略了 %1 請求</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>接收的請求資料不是 JSON 格式</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>伺服器已關閉</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>已將連接埠設為 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>無法偵聽連接埠 %1。可能已被其他處理程序佔用？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>JSON 剖析器回報錯誤：
 %1</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>已停止伺服器</translation>
     </message>
@@ -1054,42 +910,30 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Language Server「%1」</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Language Server 發出錯誤訊息。關於更多細節，請查閱記錄檔。</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>無法啟動 LSP 處理程序。是否已在 %1 設定 Language Server 程式的路徑？</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>LSP 處理程序逾時</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>LSP 處理程序發生讀取錯誤</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>LSP 處理程序發生寫入錯誤</translation>
     </message>
     <message>
-        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>LSP 處理程序發生了未知的錯誤</translation>
     </message>
@@ -1098,52 +942,52 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation type="vanished">尋找/取代</translation>
+        <translation>尋找/取代</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation type="vanished">表單</translation>
+        <translation>表單</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation type="vanished">尋找：</translation>
+        <translation>尋找：</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation type="vanished">取代為：</translation>
+        <translation>取代為：</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation type="vanished">錯誤訊息</translation>
+        <translation>錯誤訊息</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation type="vanished">方向</translation>
+        <translation>方向</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="vanished">向上</translation>
+        <translation>向上</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="vanished">向下</translation>
+        <translation>向下</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation type="vanished">選項</translation>
+        <translation>選項</translation>
     </message>
     <message>
         <source>Case sensitive</source>
         <translatorcomment>參考 Firefox 的翻譯</translatorcomment>
-        <translation type="vanished">符合大小寫</translation>
+        <translation>符合大小寫</translation>
     </message>
     <message>
         <source>Whole words only</source>
         <translatorcomment>參考 Firefox 的翻譯</translatorcomment>
-        <translation type="vanished">整個文字</translation>
+        <translation>整個文字</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1154,7 +998,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1165,80 +1009,57 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation type="vanished">正規表達式</translation>
+        <translation>正規表達式</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation type="vanished">尋找</translation>
+        <translation>尋找</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="vanished">取代</translation>
+        <translation>取代</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation type="vanished">全部取代</translation>
+        <translation>全部取代</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>自動存檔</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="185"/>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>編譯器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="203"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>請設定語言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="218"/>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="242"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1492"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translatorcomment>runner 譯名暫用微軟的「執行器」</translatorcomment>
         <translation>執行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="226"/>
-        <location filename="../src/mainwindow.cpp" line="274"/>
-        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>語言錯誤，請設定正確的程式語言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>輸入內容皆為空，因此不執行</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>送出</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>確認送出</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1249,132 +1070,103 @@ p, li { white-space: pre-wrap; }
  程式語言：%2</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="328"/>
-        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>無法儲存暫存檔，程式碼未能送出。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>需要安裝 CF Tool 才能將您的程式碼交到 Codeforces。若已安裝，請將其加入 PATH 環境變數或檢查 %1 的設定。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>無標題-%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>未知的屬性：[%1]。請於 %2 確認開頭註解的設定。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>另存新檔</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>開啟 %1 樣板</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1017"/>
-        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>檔案「%1」的字元數超過 %2，因此無法開啟。您可以在 %3 變更開啟檔案的長度限制。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
-        <location filename="../src/mainwindow.cpp" line="1189"/>
-        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>暫存檔</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>無法建立暫存目錄</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>設定編譯命令</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>自訂此分頁的編譯指令：</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>限制執行時間</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>自訂此分頁的執行時間： (ms)</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>讀取 %1 樣板</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>儲存變更</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translatorcomment>參考 Microsoft OneDrive 翻譯</translatorcomment>
         <translation>關閉前先儲存「%1」？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>新檔案</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>設定分頁語言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>設定此分頁使用的程式語言</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1385,147 +1177,131 @@ Do you want to reload it?</source>
 要重新載入嗎？</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>第 %1 列，第 %2 行</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>已選取 %1 列，共 %2 個字元</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>已選取 %1 個字元</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>已開始編譯</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>已完成編譯</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>編譯警告</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>編譯時發生錯誤</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1517"/>
-        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>編譯錯誤</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>是否已正確設定程式碼中 main class 的名稱？若沒有，您可在 %1 進行設定。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>無法啟動編譯：%1</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>編譯被終止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translatorcomment>Review required</translatorcomment>
         <translation>分離式執行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>執行器 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>已開始執行</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>程式在測資 #%1 上執行了 %2ms 後結束</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>執行時間過長</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>程式在測資 #%1 上執行了 %3ms 後，以回傳值 %2 結束</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>在執行測資 #%2 時 %1 含有多於 %3 個字元，超出了輸出長度限制，因此被終止了。您可以在 %4 變更輸出長度限制。</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 已被終止</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>分離式執行器</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translatorcomment>runner 譯名暫用微軟的「執行器」</translatorcomment>
         <translation>測資 #%1 的執行器</translation>
     </message>
     <message>
+        <source>CP Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>cursor info</source>
-        <translation type="vanished">游標資訊</translation>
+        <translation>游標資訊</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation type="vanished">編譯</translation>
+        <translation>編譯</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation type="vanished">執行</translation>
+        <translation>執行</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation type="vanished">編譯並執行</translation>
+        <translation>編譯並執行</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation type="vanished">訊息</translation>
+        <translation>訊息</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="vanished">清除</translation>
+        <translation>清除</translation>
+    </message>
+    <message>
+        <source>C++</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MessageLogger</name>
     <message>
-        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1535,43 +1311,35 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 括號</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>未選擇括號</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>新括號</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translatorcomment>標點符號？</translatorcomment>
         <translation>輸入一對括號（如：{}）：</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>刪除括號</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>確定要刪除括號 %1？</translation>
     </message>
@@ -1579,29 +1347,24 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>括號：%1</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>在 %3 中啟用 %1 以使用 %2。
 若沒有全部勾選，將使用程式碼編輯的全域設定。</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>自動完成</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>自動移除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>按 Tab 鍵跳出</translation>
     </message>
@@ -1609,25 +1372,18 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="41"/>
-        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>選擇檔案</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>可執行檔</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="84"/>
-        <location filename="../src/Settings/PathItem.cpp" line="86"/>
-        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>選擇 %1 原始檔</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>選擇可執行檔</translation>
     </message>
@@ -1635,42 +1391,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>歡迎使用 CP Editor！讓我們開始吧。</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>程式碼編輯器設定</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>C++ 編譯及執行指令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Java 編譯及執行指令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Python 執行指令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>介面設定</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>字型設定</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>您可以閱讀 &lt;a href=&quot;%1&quot;&gt;說明文件&lt;/a&gt; 或瀏覽設定以了解更多資訊。</translation>
     </message>
@@ -1678,42 +1426,34 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>預設值</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>重設</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>套用</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>重置本頁的設定 (Ctrl+D)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>放棄本頁的所有變更 (Ctrl+R)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>儲存本頁的所有變更 (Ctrl+S)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>未儲存的設定</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>設定已變更。要儲存嗎？</translation>
     </message>
@@ -1721,386 +1461,322 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
-        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>偏好設定</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>搜尋…</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>主畫面</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>回到主畫面</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation type="vanished">程式碼編輯</translation>
+        <translation>程式碼編輯</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation type="vanished">程式語言</translation>
+        <translation>程式語言</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="vanished">一般</translation>
+        <translation>一般</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 指令</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 樣板</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 程式碼片段</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 括號設定</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation></translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="vanished">介面</translation>
+        <translation>介面</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="vanished">字型</translation>
+        <translation>字型</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation type="vanished">動作</translation>
+        <translation>動作</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="vanished">存檔</translation>
+        <translation>存檔</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation type="vanished">自動存檔</translation>
+        <translation>自動存檔</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation type="vanished">在終端機中執行</translation>
+        <translation>在終端機中執行</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation type="vanished">儲存工作階段</translation>
+        <translation>儲存工作階段</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation type="vanished">繫結檔案及題目</translation>
+        <translation>繫結檔案及題目</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation type="vanished">測資</translation>
+        <translation>測資</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation type="vanished">載入外部的檔案變更</translation>
+        <translation>載入外部的檔案變更</translation>
+    </message>
+    <message>
+        <source>Stopwatch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stress Testing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generator Template</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation type="vanished">擴充功能</translation>
+        <translation>擴充功能</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation type="vanished">程式碼排版</translation>
+        <translation>程式碼排版</translation>
     </message>
     <message>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
-        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
+        <source>Clang Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>YAPF</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>%1 Server</source>
         <translation></translation>
     </message>
     <message>
+        <source>Competitive Companion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CF Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WakaTime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>File Path</source>
-        <translation type="vanished">檔案路徑</translation>
+        <translation>檔案路徑</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation type="vanished">測資</translation>
+        <translation>測資</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation type="vanished">題目網址</translation>
+        <translation>題目網址</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation type="vanished">預設路徑</translation>
+        <translation>預設路徑</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation type="vanished">快捷鍵</translation>
+        <translation>快捷鍵</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation type="vanished">進階</translation>
+        <translation>進階</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="vanished">更新</translation>
+        <translation>更新</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation type="vanished">限制</translation>
+        <translation>限制</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation type="vanished">網路 Proxy</translation>
+        <translation>網路 Proxy</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Tab 寬度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>指定 Tab 字元的寬度，即縮排的空間</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>游標寬度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>以像素計算的游標寬度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>編輯器字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>程式碼編輯器顯示的字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translatorcomment>參考簡體版翻譯</translatorcomment>
         <translation>使用自訂全域字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>在整個應用程式中使用自訂的字型，而不是系統預設字型。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>自訂全域字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>在整個應用程式中使用的自訂字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>預設語言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>開新分頁時預設的語言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Clang Format 程式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Clang Format 的可執行檔路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Clang Format 引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>傳入 clang-format 的引數。不可包含「-i」。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Clang Format 樣式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Clang Format 的排版樣式選項，通常儲存為 .clang-format 組態檔案。
 您可在 &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt; 了解更多。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>YAPF 程式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>YAPF 的程式。可為 `yapf` （不需引數）或 `python` （需要 `-m yapf` 引數）。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>YAPF 引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>傳入YAPF 程式的引數。不可包含「-i」。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>YAPF 樣式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>YAPF 的排版樣式選項，通常儲存為 .style.yapf 或 setup.conf 組態檔案。
 您可以執行 `yapf --style-help` 以了解更多。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>於手動存檔時排版程式碼</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>當手動存檔時，對程式碼進行排版。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>於自動存檔時排版程式碼</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>當自動存檔時，對程式碼進行排版。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 樣板路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>建立 C++ 檔案時使用的樣板</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>%1 樣板游標初始位置的正規表達式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -2109,53 +1785,34 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 若沒有符合正規表達式的程式碼，游標將被置於樣板結尾。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>%1 樣板游標位置位移類型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>決定位移的參考點為相對於正規表達式的開始或結尾。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>%1 樣板游標位置位移數量</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>相對於符合正規表達式內容的位移字元數（包含空格）。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 編譯命令</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>編譯 C++ 使用的指令。不可包含原始檔的路徑或者「-o &lt;輸出檔&gt;」。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 可執行檔路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -2170,61 +1827,47 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${tmpdir}」或「${tempdir}」代入臨時目錄的絕對路徑。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 執行引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>執行 C++ 程式時的引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>建立 Java 檔案時使用的樣板</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>編譯 Java 程式碼所用的指令。不可包含原始檔及輸出的 class 檔路徑。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>執行 Java 程式時的引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 執行指令</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>啟動 Java 程式的指令。不可包含「-classpath &lt;path&gt; &lt;class name&gt;」。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 Class 名稱</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>程式碼的 main class 名稱。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 Class 路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2238,37 +1881,30 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${tmpdir}」或「${tempdir}」代入臨時目錄的絕對路徑。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>建立新 Python 檔案時使用的樣板</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>執行 Python 程式時提供的引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>啟動 Python 程式的指令。不可包含原始檔的路徑。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>編輯器色彩佈景主題</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>程式碼編輯器的語法標示佈景</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>終端機程式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -2277,12 +1913,10 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 可能的值為 konsole、gnome-terminal、xfce-terminal、xterm 或其他的終端機程式。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>終端機引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -2291,12 +1925,10 @@ Consult your terminal emulator for the suitable arguments.</source>
 請查詢您使用的終端機的相關資料，以使用對應的引數。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>自動完成括弧</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -2305,12 +1937,10 @@ This can be overridden for each parenthesis in each language.</source>
 此設定可被各程式語言的括號設定覆寫。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>自動刪除括弧</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -2319,12 +1949,10 @@ This can be overridden for each parenthesis in each language.</source>
 此設定可被各程式語言的括號設定覆寫。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>按下 Tab 時從一對括號跳出</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -2332,37 +1960,30 @@ This can be overridden for each parenthesis in each language.</source>
 此功能可被各程式語言的括號設定覆寫。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>自動縮排</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>在「{」後換行時縮排。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>啟用自動存檔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>自動存檔間隔 (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>檔案變更後與自動存檔間，或兩次自動存檔間的時間間隔。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>自動存檔間隔類型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -2371,123 +1992,99 @@ After the first modification：計時器僅在編輯程式碼時運作。
 Without modification：不論程式碼是否被修改，每經一段時間自動儲存一次。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translatorcomment>參考 VS Code 翻譯</translatorcomment>
         <translation>自動換行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>當文字內容超出螢幕範圍時，將其分為幾列顯示。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Enable Ctrl+Scroll to change font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
         <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>使用 Beta 版本</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>檢查預覽版本的更新，預覽版包含更多功能，但並不是十分穩定。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>以空白代替 Tab</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>使用空白字元來取代 Tab 字元（\t）。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>存檔時一同儲存測資</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>存檔時一同儲存測試資料，並於開啟檔案時將其載入。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>在程式啟動時檢查更新</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>當 CP Editor 啟動時，檢查是否有新版本。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>主視窗的不透明度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>啟用 Competitive Companion</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>接收 Competitive Companion 傳送的資料，並載入範例測資。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>連接埠</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>從 Competitive Companion 接收資料用的連接埠</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>在新分頁中開啟</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>總是在新分頁開啟 Competitive Companion 傳來的題目。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>使用 Competitive Companion 的執行時間限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>為對應的分頁套用 Competitive Companion 傳遞的時間限制。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>開頭註解的內容</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2498,12 +2095,10 @@ ${time}：剖析題目的時間
 ${json.X.Y}：由 Competitive Companion 提供的屬性，您可以於 https://github.com/jmerle/competitive-companion#explanation 閱讀更多資訊</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>開頭註解的時間格式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2515,71 +2110,58 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>在檔案開頭加上「Powered By CP Editor」註解</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>在檔案一開始的註解加上一行「Powered By CP Editor」。
 這可以讓您用最便宜的方式協助推廣 CP Editor。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>排版程式碼</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>終止所有處理程序</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>編譯並執行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>執行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>編譯</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>變更檢視模式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>使用程式碼片段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>啟動時還原上次的工作階段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>在應用程式啟動時還原上次的工作階段。
 啟用了此功能，就不會在關閉程式時詢問是否儲存未存檔的檔案。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>定期自動儲存目前工作階段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2587,278 +2169,212 @@ kill the application with SIGKILL which could not be handled by the application.
 這對於電腦當機以至於需要切斷電源或程式遭到 SIGKILL 終止的狀況很有效。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>自動儲存工作階段的間隔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>自動儲存目前工作階段的時間間隔。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>CF Tool 可執行檔的路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>顯示評判結果的快顯通知</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>當評判結果揭曉時，顯示快顯通知。此通知在 CP Editor 以外也能見到。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation>啟用 CF Tool</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation>啟用或禁用CF Tool</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>只顯示編譯並執行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>隱藏主視窗的程式碼編輯器底下的「編譯」及「執行」按鈕。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>在 Diff 中顯示 EOLN</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>在 HTML Diff 檢視器中以「¶」表示換行符號。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>更快的存檔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>總是使用 QFile 而非 QSaveFile 進行存檔。
 可以使存檔更快速，然而遺失檔案的風險會稍微增加。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>預設執行時間限制 (ms)</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>執行程式時的預設時間限制。
 若超出時間限制，程式仍在執行，則將其終止。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>輸出長度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>程式輸出的字元數量上限。
 若 stdout 或 stderr 的輸出過長，則將其終止。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>輸出顯示長度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>程式輸出的顯示字元數量上限。
 輸出內容過長時將其省略。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>訊息長度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>主視窗右上角對話窗格的最大訊息長度。
 訊息內容過長時將其省略。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>HTML Diff 檢視器長度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>HTML Diff 檢視器的最大顯示字元數。
 內容過長時，將以純文字顯示。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>開啟檔案的長度限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>開啟原始檔時，可接受的最大字元數。
 不會開啟過長的原始檔。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>測資長度顯示限制</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>測資的顯示字元數量上限。
 內容過長時將其省略，並變成唯讀。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>LSP 可執行檔的路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>C++ Language Server 可執行檔的路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Java Language Server 可執行檔的路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Python Language Server 可執行檔的路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>使用 Language Server 的 Linting</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>在程式碼編輯器中顯示 C++ 的錯誤、警告、資訊及提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>在程式碼編輯器中顯示 Java 的錯誤、警告、資訊及提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>在程式碼編輯器中顯示 Python 的錯誤、警告、資訊及提示</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>使用 Language Server 提供的自動完成</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>使用 Language Server 提供的自動完成結果</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Linting 延遲（ms）</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>控制 Linting 在修改之後延遲的時間</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Language Server 引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>傳遞給 Language Server 程式的引數</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>測資比對規則</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>用於從檔案加入多筆測資時的正規表達式。
 每對正規表達式代表一筆測資。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>輸入檔正則表達式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>用於比對整個輸入檔名的正則表達式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>答案替換</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translatorcomment>captured group 之翻譯待定</translatorcomment>
@@ -2866,12 +2382,10 @@ You can use &quot;\1&quot; for the first captured group.</source>
 可使用「\1」表示首個符合的組別。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>輸入檔儲存路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2887,12 +2401,10 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${1-index}」以索引值 1 開始代入測資。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>答案檔儲存路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2908,278 +2420,223 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${1-index}」以索引值 1 開始代入測資。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>對應題目網址的預設存檔路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>當設定題目網址時，用於儲存檔案的預設路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>題目網址</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>用於比對部分題目網址的正則表達式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>檔案路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>用於存檔路徑的替換表達式（不需檔名後綴）。
 可使用「\1」表示首個符合的組別。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>測資字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>顯示測資用的字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>在程式碼編輯器的底部加上額外邊距</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>在程式碼編輯器的底部加上額外邊距。
 由於技術原因，改變邊距會影響復原記錄。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>訊息字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>顯示訊息紀錄用的字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>在編譯程式時存檔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>除了無標題的分頁，編譯原始檔時順便存檔。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>在執行程式時存檔</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>除了無標題的分頁，執行程式時順便存檔。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>開啟檔案時還原該題網址</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>若檔案有設定題目網址，當再次
 開啟時，也會繼續使用該網址。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>遇到已剖析過的題目網址時開啟對應檔案</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>若檔案有設定題目網址，當再次由
 Competitive Companion 開啟時，也會繼續使用該網址。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>UI 語言</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>顯示於使用者介面的語言。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>變更語系</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>需要重新啟動應用程式以確實套用語系變更。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>UI 佈景</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>整個應用程式的外觀樣式。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>測資輸入為空時依然執行</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>即使測資的輸入為空，還是執行程式。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>測資輸出為空時依然評判答案</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>即使輸出結果或答案為空，還是進行評判。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>測資顯示最大高度</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>在捲軸不出現的情況下，可允許顯示的最多像素數。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>在檢查更新時使用 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Proxy 的類型。選用「System」以依循系統設定。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Proxy 伺服器的位址，如：127.0.0.1</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>連接埠</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Proxy 的連接埠，如：1080</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>帳號</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Proxy 伺服器的帳號。若 Proxy 伺服器毋須認證，可以留空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>密碼</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Proxy 伺服器的密碼。若 Proxy 伺服器毋須認證，可以留空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 編譯器輸出字元集</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>編譯器輸出（錯誤、警告等）的文字編碼</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>預設路徑及名稱</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -3188,38 +2645,30 @@ They can be either manually set or automatically changed after choosing a path f
 它們可以被手動設定，或在選擇動作的路徑後自動改變。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>預設路徑之名稱</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>預設路徑的位址</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>若目前沒有未存檔的內容，自動載入外部的檔案變更</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>當檔案沒有未存檔的內容且在 CP Editor 外發生了變更，則自動將其載入。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>詢問我是否要載入外部的檔案變更</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -3229,345 +2678,208 @@ If this is disabled, external file changes will be ignored unless they are loade
 此功能關閉時，不透過「%1」載入的變更都會被忽略。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>只顯示等寬字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>當選擇字型時，只列出等寬字型</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>自動取消核選已通過的測資</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>當某筆測資評判通過，將其取消核選。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>%1 使用的預設路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>為 %1 選擇路徑時的預設值。
 您可以使用 ${&lt;default path name&gt;} 當作預留位置。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>由 %1 變更的預設路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>選擇 %1 的路徑後變更的預設路徑。
 此為 &lt;default path name&gt; 的清單，以「,」隔開，亦可留空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>這會被 %1 的設定覆寫。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>建立競賽</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>載入單筆測資</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>新增多筆測資</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>將測資存為檔案</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>自訂評判程式</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>匯出及匯入設定值</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>匯出及載入工作階段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>匯出及載入程式碼片段</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>在連線至 GitHub 檢查更新時使用 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>WakaTime 可執行檔的路徑</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>API 金鑰</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>可於 https://wakatime.com/settings/account 取得。
 若您有 ~/.wakatime.cfg 組態檔，可以留空。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>啟用 WakaTime</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>使用 Proxy</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>傳送資料給 WakaTime 時使用 進階-&gt;網路 Proxy。</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
-        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>啟用 Vim 模擬</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>在程式碼編輯器中啟用 Vim 模擬</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Vim 設定</translation>
     </message>
     <message>
-        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Vim RC 的內容。每次啟動 Vim 模擬時都會載入。
@@ -3577,7 +2889,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
-        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>清除快捷鍵</translation>
     </message>
@@ -3585,52 +2896,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>插入一列 (Ctrl+N)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>刪除目前這列 (Ctrl+W)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>移除項目</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>確定要刪除目前這列？</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>上移</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>將目前這列向上移動 (Ctrl+Shift+Up)</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>下移</translation>
     </message>
     <message>
-        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>將目前這列向下移動 (Ctrl+Shift+Down)</translation>
     </message>
@@ -3638,7 +2939,6 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>贊助</translation>
     </message>
@@ -3646,43 +2946,35 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>喜歡 CP Editor 嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>謝謝您使用 CP Editor！</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>如果您想要支持我們的工作，可以：</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>在 GitHub 上幫我們按個星星</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>跟您的朋友介紹 CP Editor</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translatorcomment>It&apos;s ok to ignore Qt Linguist warning.</translatorcomment>
         <translation>我在用一款很讚的IDE @cpeditor_</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>提供我們金錢上的援助</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>提供一些建議，讓我們做得更好</translation>
     </message>
@@ -3690,18 +2982,15 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translatorcomment>It&apos;s ok to ignore Qt Linguist warning</translatorcomment>
         <translation>此錯誤可能是因為缺少 OpenSSL 函式庫引起的。您可以參考 &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; 來取得安裝檔，或了解如何透過套件管理安裝。您必須安裝與此版本「%1」相容的版本。</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>未有新版本。</translation>
     </message>
     <message>
-        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>未發現 %1 版的下載網址。</translation>
     </message>
@@ -3709,66 +2998,52 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="87"/>
-        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>無法開啟「%1」。有寫入權限嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="97"/>
-        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>無法儲存「%1」。有寫入權限嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>檔案「%1」不存在</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>無法開啟「%1」。有讀取權限嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>開啟 %1 所在的資料夾</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translatorcomment>for macOS</translatorcomment>
         <translation>在 Finder 中顯示 %1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translatorcomment>for Windows</translatorcomment>
         <translation>在檔案總管顯示 %1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>在檔案管理員中顯示 %1</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation>C++ 原始檔</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation>Java 原始檔</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation>Python 原始檔</translation>
     </message>
     <message>
-        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation>原始檔</translation>
     </message>
@@ -3776,62 +3051,50 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>建立新比賽</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>比賽內容</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>主目錄</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>子目錄</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>儲存路徑</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>程式語言</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>題目數量</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>主目錄不存在</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>主目錄「%1」不存在。要建立並繼續嗎？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>無法建立目錄</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>無法建立目錄「%1」。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>選擇主目錄</translation>
     </message>
@@ -3839,17 +3102,14 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Diff 檢視器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>輸出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
@@ -3857,33 +3117,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation type="unfinished">重設</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3891,222 +3144,162 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">無法建立暫存目錄</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">讀取 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">儲存 testlib.h</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">編譯器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">執行時間過長</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
-        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4114,72 +3307,58 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>輸入</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>輸出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>執行</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>測試單筆測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>開啟 Diff 檢視器</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>輸入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>輸出 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>刪除測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>確定要刪除測資 #%1？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Diff 檢視器「%1」</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>輸出或答案內容超過 %1 字元，因此不啟用 HTML Diff 檢視器。您可以在 %2 變更長度限制。</translation>
     </message>
@@ -4187,54 +3366,42 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>輸入</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>輸出</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>僅顯示前 %1 個字元。現在測資編輯器是唯讀狀態。您可以在 %2 設定長度限制。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>儲存為檔案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>將測資存為檔案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>從檔案載入</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>在大視窗中編輯</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>編輯測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>複製輸出至答案</translation>
     </message>
@@ -4242,224 +3409,174 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>評判程式：</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>新增測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>新增評判程式</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>未通過 / 通過 / 總計</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>新增自訂 testlib 評判程式</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>從檔案匯入測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>選擇測資檔案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>載入測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>已載入一對測資 [%1] 及 [%2]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>已載入輸入內容 [%1]</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>檔案 %1 因不符合比對規則，而沒有被載入。您可在 %2 調整比對規則。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>核選全部</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>取消核選全部</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>取消核選已通過的</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>反轉核選</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>刪除全部</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>確定要刪除全部測資點？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>刪除空測資點</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>刪除核選的</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>確定刪除所有核選的測資？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>複製測資點</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>貼上測資點</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
-        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>複製輸出至答案</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>確定要複製所有核選的輸出至對應的答案？</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>忽略結尾的空格</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>嚴格相同</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - 比對多個 int64</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - 比對雙精度浮點數（最大誤差 1e-4）</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - 比對雙精度浮點數（最大誤差 1e-6）</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - 比對雙精度浮點數（最大誤差 1e-9）</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - 比對字串</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - 比對 YES、NO（區分大小寫）</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>新增測資</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>已有 %1 筆測資，無法再新增。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>輸入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>儲存輸入 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>儲存答案 #%1</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>載入 %1</translation>
     </message>
@@ -4467,32 +3584,26 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>更新可供使用</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>%1更新 &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; 已可供使用。更新紀錄請見下方。&lt;br /&gt;我們非常建議讓編輯器保持最新版本，以享受酷酷的新功能及錯誤修正。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>Beta</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>穩定版</translation>
     </message>
@@ -4500,37 +3611,30 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>關閉此對話窗並中止更新檢查</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>檢查更新幫手</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>取得版本列表中…</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>錯誤：%1&lt;br /&gt;&lt;br /&gt;檢查更新失敗。請到以下網站自行檢查更新&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; 或 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;。</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation>很棒喔！您使用的已經是最新版的 CP Editor。</translation>
     </message>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -4,55 +4,68 @@
 <context>
     <name>AppWindow</name>
     <message>
+        <location filename="../src/appwindow.cpp" line="73"/>
         <source>Open Recent Files</source>
         <translation>開啟最近使用的檔案</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="79"/>
         <source>No file is opened recently</source>
         <translation>沒有最近開啟的檔案</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="89"/>
         <source>Clear Recent Files</source>
         <translation>清除最近使用的檔案</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="130"/>
         <source>Hot Exit</source>
         <translatorcomment>參照 Visual Studio</translatorcomment>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="131"/>
         <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
         <translation>在上次的工作階段中 CP Editor 被異常地終止了。要還原工作階段嗎？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="318"/>
         <source>Show Main Window</source>
         <translation>顯示主視窗</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="319"/>
         <source>About</source>
         <translation>關於本程式</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="320"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="466"/>
         <source>Opening Files</source>
         <translation>開啟檔案中</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="616"/>
         <source>About CP Editor %1</source>
         <translation>關於 CP Editor %1</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="617"/>
         <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It&apos;s specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; 是一款基於 Qt 技術的程式碼編輯器。針對競程用途專門設計，是讓它與其他編輯器或 IDE 如此不同的原因。CP Editor 將編譯、執行、測試的過程自動化，讓您可以專注在設計演算法。不僅如此，它甚至可以從其他平台取得測試資料，並繳交程式碼至 Codeforces。&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;本程式為自由軟體，請參見原始碼的版權聲明。本軟體不負任何擔保責任，包括對適售性或特定目的適用性所為的擔保。您可以在 &lt;a href=&quot;https://github.com/cpeditor/cpeditor&quot;&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt; 取得 CP Editor 的原始碼。&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="635"/>
         <source>Build Info</source>
         <translation>建置資訊</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="636"/>
         <source>App version: %1
 Build type: %2
 Git commit hash: %3
@@ -65,557 +78,596 @@ Git commit hash：%3
 作業系統：%5</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="639"/>
         <source>Portable Version</source>
         <translation>免安裝版</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="641"/>
         <source>Setup Version</source>
         <translation>安裝版</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="700"/>
         <source>Open Files</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="716"/>
         <source>Save</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="730"/>
         <source>Save All</source>
         <translation>儲存全部</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="764"/>
         <source>Reset preferences</source>
         <translation>重置偏好設定</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="765"/>
         <source>Are you sure you want to reset the all preferences to default?</source>
         <translation>確定要將所有偏好設定重置為預設值？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="778"/>
         <source>Export settings to a file</source>
         <translation>將設定值匯出為檔案</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="779"/>
+        <location filename="../src/appwindow.cpp" line="795"/>
         <source>CP Editor Settings File</source>
         <translation>CP Editor 設定檔</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="787"/>
         <source>Import Settings</source>
         <translation>匯入設定</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="788"/>
         <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
         <translation>從檔案匯入的設定值將覆蓋現有的狀態。確定要繼續？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="794"/>
         <source>Import settings from a file</source>
         <translation>從檔案匯入設定值</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="806"/>
         <source>Export current session to a file</source>
         <translation>將目前的工作階段匯出為檔案</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="807"/>
+        <location filename="../src/appwindow.cpp" line="828"/>
         <source>CP Editor Session File</source>
         <translation>CP Editor 工作階段檔</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="812"/>
         <source>Export Session</source>
         <translation>匯出工作階段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="813"/>
         <source>Failed to export the current session to [%1]</source>
         <translation>無法將目前的工作階段匯出到「%1」</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="820"/>
         <source>Load Session</source>
         <translation>載入工作階段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="821"/>
         <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
         <translation>從檔案載入工作階段，將會關閉目前工作階段中包含未存檔的所有分頁。確定要繼續？</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="827"/>
         <source>Load session from a file</source>
         <translation>從檔案載入工作階段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="891"/>
         <source>CP Editor: An editor specially designed for competitive programming</source>
         <translation>CP Editor：一款專為競程設計的編輯器</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1316"/>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>Snippets</source>
         <translation>程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1317"/>
         <source>There are no snippets for %1. Please add snippets in the preference window.</source>
         <translation>沒有 %1 的程式碼片段。請在偏好設定視窗裡新增一個。</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Use Snippets</source>
         <translation>使用程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1322"/>
         <source>Choose a snippet:</source>
         <translation>選擇程式碼片段：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1377"/>
         <source>There is no snippet named %1 for %2</source>
         <translation>%2 沒有名為「%1」的程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>How to exit full-screen</source>
         <translation>如何退出全螢幕</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1442"/>
         <source>Press F11 key to exit full-screen mode.</source>
         <translation>按下 F11 鍵來退出全螢幕模式。</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1521"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1523"/>
         <source>Close Others</source>
         <translation>關閉其他</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1529"/>
         <source>Close to the Left</source>
         <translatorcomment>參考 Firefox 翻譯</translatorcomment>
         <translation>關閉左方分頁</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1535"/>
         <source>Close to the Right</source>
         <translation>關閉右方分頁</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1540"/>
         <source>Close Saved</source>
         <translation>關閉已存檔的</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1542"/>
         <source>Close All</source>
         <translation>關閉全部</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1547"/>
         <source>Duplicate Tab</source>
         <translatorcomment>「複製」有疑義，應釐清與 Copy 的差異</translatorcomment>
         <translation>建立分頁副本</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1552"/>
         <source>Set Compile Command</source>
         <translation>設定編譯命令</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1554"/>
         <source>Set Time Limit</source>
         <translation>限制執行時間</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1561"/>
         <source>Source File</source>
         <translation>原始檔</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1562"/>
         <source>Executable File</source>
         <translation>可執行檔</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1569"/>
         <source>Copy File Path</source>
         <translation>複製檔案路徑</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1581"/>
         <source>Open Problem in Browser</source>
         <translation>在瀏覽器中開啟題目</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1583"/>
         <source>Copy Problem URL</source>
         <translation>複製題目網址</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1586"/>
         <source>Set Codeforces URL</source>
         <translation>設定 Codeforces 網址</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Set CF URL</source>
         <translation>設定 CF 網址</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1591"/>
         <source>Enter the contest ID:</source>
         <translation>輸入比賽 ID：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1594"/>
         <source>Enter the problem Code (A-Z):</source>
         <translation>輸入題目代號 (A-Z)：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1602"/>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Set Problem URL</source>
         <translation>設定題目網址</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1604"/>
         <source>Enter the new problem URL:</source>
         <translation>輸入新題目網址：</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1694"/>
         <source>EventLogger</source>
         <translation>事件紀錄</translation>
     </message>
     <message>
+        <location filename="../src/appwindow.cpp" line="1695"/>
         <source>All logs except for current session has been deleted</source>
         <translation>除了目前工作階段的所有記錄檔已被刪除</translation>
     </message>
     <message>
         <source>New File</source>
-        <translation>新檔案</translation>
+        <translation type="vanished">新檔案</translation>
     </message>
     <message>
         <source>Open a new tab in the editor</source>
-        <translation>在編輯器中開啟新分頁</translation>
+        <translation type="vanished">在編輯器中開啟新分頁</translation>
     </message>
     <message>
         <source>Save the file on the disk</source>
-        <translation>將檔案儲存到磁碟</translation>
+        <translation type="vanished">將檔案儲存到磁碟</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>另存新檔…</translation>
+        <translation type="vanished">另存新檔…</translation>
     </message>
     <message>
         <source>Save as new file</source>
-        <translation>另存新檔</translation>
+        <translation type="vanished">另存新檔</translation>
     </message>
     <message>
         <source>Save all opened files</source>
-        <translation>儲存所有開啟的檔案</translation>
+        <translation type="vanished">儲存所有開啟的檔案</translation>
     </message>
     <message>
         <source>Close Current</source>
-        <translation>關閉目前分頁</translation>
+        <translation type="vanished">關閉目前分頁</translation>
     </message>
     <message>
         <source>Close current tab</source>
-        <translation>關閉目前分頁</translation>
+        <translation type="vanished">關閉目前分頁</translation>
     </message>
     <message>
         <source>Close saved tabs</source>
-        <translation>關閉已存檔的分頁</translation>
+        <translation type="vanished">關閉已存檔的分頁</translation>
     </message>
     <message>
         <source>Close All the tabs</source>
-        <translation>關閉所有分頁</translation>
+        <translation type="vanished">關閉所有分頁</translation>
     </message>
     <message>
         <source>Quit the application</source>
-        <translation>退出應用程式</translation>
+        <translation type="vanished">退出應用程式</translation>
     </message>
     <message>
         <source>Open File...</source>
-        <translation>開啟檔案…</translation>
+        <translation type="vanished">開啟檔案…</translation>
     </message>
     <message>
         <source>Open files</source>
-        <translation>開啟檔案</translation>
+        <translation type="vanished">開啟檔案</translation>
     </message>
     <message>
         <source>Open Contest...</source>
-        <translation>建立競賽…</translation>
+        <translation type="vanished">建立競賽…</translation>
     </message>
     <message>
         <source>Open a Contest</source>
-        <translation>建立比賽</translation>
+        <translation type="vanished">建立比賽</translation>
     </message>
     <message>
         <source>Indent</source>
-        <translation>增縮排</translation>
+        <translation type="vanished">增縮排</translation>
     </message>
     <message>
         <source>Unindent</source>
-        <translation>退縮排</translation>
+        <translation type="vanished">退縮排</translation>
     </message>
     <message>
         <source>Swap Line Up</source>
-        <translation>上移一列</translation>
+        <translation type="vanished">上移一列</translation>
     </message>
     <message>
         <source>Swap Line Down</source>
-        <translation>下移一列</translation>
+        <translation type="vanished">下移一列</translation>
     </message>
     <message>
         <source>Duplicate Line</source>
-        <translation>建立此列副本</translation>
+        <translation type="vanished">建立此列副本</translation>
     </message>
     <message>
         <source>Delete Line</source>
-        <translation>刪除整列</translation>
+        <translation type="vanished">刪除整列</translation>
     </message>
     <message>
         <source>Toggle Comment</source>
-        <translation>切換註解</translation>
+        <translation type="vanished">切換註解</translation>
     </message>
     <message>
         <source>Toggle Block Comment</source>
-        <translation>切換區塊註解</translation>
+        <translation type="vanished">切換區塊註解</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>編譯</translation>
+        <translation type="vanished">編譯</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>編譯並執行</translation>
+        <translation type="vanished">編譯並執行</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>執行</translation>
+        <translation type="vanished">執行</translation>
     </message>
     <message>
         <source>Format code</source>
-        <translation>排版程式碼</translation>
+        <translation type="vanished">排版程式碼</translation>
     </message>
     <message>
         <source>Run Detached</source>
-        <translation>在終端機中執行</translation>
+        <translation type="vanished">在終端機中執行</translation>
     </message>
     <message>
         <source>Kill Processes</source>
-        <translation>終止處理程序</translation>
+        <translation type="vanished">終止處理程序</translation>
     </message>
     <message>
         <source>Find and Replace</source>
-        <translation>尋找及取代</translation>
+        <translation type="vanished">尋找及取代</translation>
     </message>
     <message>
         <source>Use Snippet...</source>
-        <translation>使用程式碼片段…</translation>
+        <translation type="vanished">使用程式碼片段…</translation>
     </message>
     <message>
         <source>Preferences</source>
-        <translation>偏好設定</translation>
+        <translation type="vanished">偏好設定</translation>
     </message>
     <message>
         <source>Reset Settings</source>
-        <translation>重置設定</translation>
+        <translation type="vanished">重置設定</translation>
     </message>
     <message>
         <source>Export Settings...</source>
-        <translation>匯出設定…</translation>
+        <translation type="vanished">匯出設定…</translation>
     </message>
     <message>
         <source>Import Settings...</source>
-        <translation>匯入設定…</translation>
+        <translation type="vanished">匯入設定…</translation>
     </message>
     <message>
         <source>Export Session...</source>
-        <translation>匯出工作階段…</translation>
+        <translation type="vanished">匯出工作階段…</translation>
     </message>
     <message>
         <source>Load Session...</source>
-        <translation>載入工作階段…</translation>
+        <translation type="vanished">載入工作階段…</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation>使用手冊</translation>
+        <translation type="vanished">使用手冊</translation>
     </message>
     <message>
         <source>Report issues</source>
-        <translation>回報問題</translation>
+        <translation type="vanished">回報問題</translation>
     </message>
     <message>
         <source>About Qt</source>
-        <translation>關於 Qt</translation>
+        <translation type="vanished">關於 Qt</translation>
     </message>
     <message>
         <source>Check for updates</source>
-        <translation>檢查更新</translation>
+        <translation type="vanished">檢查更新</translation>
     </message>
     <message>
         <source>Support us</source>
-        <translation>支持我們</translation>
+        <translation type="vanished">支持我們</translation>
     </message>
     <message>
         <source>Editor Mode</source>
-        <translation>編輯器模式</translation>
+        <translation type="vanished">編輯器模式</translation>
     </message>
     <message>
         <source>IO Mode</source>
-        <translation>IO 模式</translation>
+        <translation type="vanished">IO 模式</translation>
     </message>
     <message>
         <source>Split Mode</source>
-        <translation>分割畫面</translation>
+        <translation type="vanished">分割畫面</translation>
     </message>
     <message>
         <source>Full Screen</source>
-        <translation>全螢幕</translation>
+        <translation type="vanished">全螢幕</translation>
     </message>
     <message>
         <source>Show Log Files</source>
         <translatorcomment>參考自 microsoft terminology</translatorcomment>
-        <translation>顯示記錄檔</translation>
+        <translation type="vanished">顯示記錄檔</translation>
     </message>
     <message>
         <source>Delete Log Files</source>
-        <translation>刪除記錄檔</translation>
+        <translation type="vanished">刪除記錄檔</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>檔案(&amp;F)</translation>
+        <translation type="vanished">檔案(&amp;F)</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>編輯(&amp;E)</translation>
+        <translation type="vanished">編輯(&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Actions</source>
-        <translation>動作(&amp;A)</translation>
+        <translation type="vanished">動作(&amp;A)</translation>
     </message>
     <message>
         <source>&amp;View</source>
-        <translation>檢視(&amp;V)</translation>
+        <translation type="vanished">檢視(&amp;V)</translation>
     </message>
     <message>
         <source>&amp;Options</source>
-        <translation>選項(&amp;O)</translation>
+        <translation type="vanished">選項(&amp;O)</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>說明(&amp;H)</translation>
-    </message>
-    <message>
-        <source>Stress Testing...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with generator template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New File From Template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C++</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with C++ template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Java</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with Java template</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Python</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open a new tab with Python template</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">說明(&amp;H)</translation>
     </message>
 </context>
 <context>
     <name>CodeSnippetsPage</name>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="45"/>
         <source>Search...</source>
         <translation>搜尋…</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="58"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="63"/>
         <source>Del</source>
         <translation>刪除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="68"/>
         <source>Rename Snippet</source>
         <translation>重新命名程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="72"/>
         <source>Load Snippets From Files</source>
         <translation>從檔案載入程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="75"/>
         <source>Extract Snippets To Files</source>
         <translation>將程式碼片段匯出為檔案</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="85"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="115"/>
         <source>No Snippet Selected</source>
         <translation>未選取程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="255"/>
         <source>Unsaved Snippets</source>
         <translation>未儲存的程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="256"/>
         <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
         <translation>程式碼片段「%1」已變更。要儲存嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="287"/>
         <source>Delete Snippet</source>
         <translation>刪除程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="288"/>
         <source>Do you really want to delete the snippet [%1]?</source>
         <translation>確定要刪除程式碼片段「%1」？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="318"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="326"/>
         <source>Load Snippets</source>
         <translation>載入程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="327"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>無法開啟「%1」。有讀取權限嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="342"/>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="372"/>
         <source>Extract Snippets</source>
         <translation>匯出程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="365"/>
         <source>Extract Snippets: %1</source>
         <translation>匯出程式碼片段：%1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="373"/>
         <source>Failed to write to [%1]. Do I have write permission?</source>
         <translation>無法寫入「%1」。有寫入權限嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="394"/>
         <source>Snippet name can&apos;t be empty.
 </source>
         <translation>程式碼片段名稱不可為空。
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="399"/>
         <source>Snippet Name Conflict</source>
         <translation>程式碼片段名稱衝突</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="400"/>
         <source>The name &quot;%1&quot; is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
         <translatorcomment>it&apos;s ok to ignore the warning</translatorcomment>
         <translation>名稱「%1」已被使用。要覆寫現有的片段嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="412"/>
         <source>The name &quot;%1&quot; is already in use.
 </source>
         <translation>名稱「%1」已被使用。
 </translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>Add Snippet</source>
         <translation>新增程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/CodeSnippetsPage.cpp" line="414"/>
         <source>New Snippet Name:</source>
         <translation>新程式碼片段名稱：</translation>
     </message>
@@ -623,68 +675,93 @@ Git commit hash：%3
 <context>
     <name>Core::Checker</name>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="87"/>
         <source>Read Checker</source>
         <translation>讀取評判程式原始碼</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
+        <location filename="../src/Core/Checker.cpp" line="99"/>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
+        <location filename="../src/Core/Checker.cpp" line="301"/>
+        <location filename="../src/Core/Checker.cpp" line="302"/>
+        <location filename="../src/Core/Checker.cpp" line="303"/>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>Checker</source>
         <translation>評判程式</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="94"/>
         <source>Failed to create temporary directory</source>
         <translation>無法建立暫存目錄</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="102"/>
         <source>Read testlib.h</source>
         <translation>讀取 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="105"/>
         <source>Save testlib.h</source>
         <translation>儲存 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="130"/>
         <source>Started compiling the checker</source>
         <translation>開始編譯評判程式</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="148"/>
         <source>The checker is compiled</source>
         <translation>完成編譯評判程式</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="156"/>
         <source>Error occurred while compiling the checker:
 %1</source>
         <translation>編譯評判程式時發生錯誤：
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="161"/>
         <source>Failed to compile the checker: %1</source>
         <translation>無法編譯評判程式：%1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="176"/>
         <source>Time Limit Exceeded</source>
         <translation>執行時間過長</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="194"/>
         <source>Checker exited with exit code %1</source>
         <translation>評判程式以回傳值 %1 結束執行</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="205"/>
         <source>Checker exited with unknown exit code %1</source>
         <translation>評判程式以未知的回傳值 %1 結束執行</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="219"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>在執行測資 #%2 時 %1 含有多於 %3 個字元，超出了輸出長度限制，因此被終止了。您可以在 %4 變更輸出長度限制。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="230"/>
         <source>The checker is killed</source>
         <translation>評判程式被終止了</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="322"/>
         <source>Checker[%1]</source>
         <translation>評判程式[%1]</translation>
     </message>
     <message>
+        <location filename="../src/Core/Checker.cpp" line="333"/>
         <source>The source code of the checker has changed, recompiling...</source>
         <translation>評判工具的程式碼已變更，重新編譯中…</translation>
     </message>
@@ -692,18 +769,22 @@ Git commit hash：%3
 <context>
     <name>Core::Compiler</name>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="62"/>
         <source>The source file [%1] doesn&apos;t exist</source>
         <translation>原始檔「%1」不存在</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="78"/>
         <source>%1 is empty</source>
         <translation>%1 為空</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="96"/>
         <source>Unsupported programming language &quot;%1&quot;</source>
         <translation>不支援的程式語言：%1</translation>
     </message>
     <message>
+        <location filename="../src/Core/Compiler.cpp" line="171"/>
         <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
         <translation>無法啟動編譯器，請將其加入 PATH 環境變數或檢查 %1 的設定。</translation>
     </message>
@@ -711,32 +792,39 @@ Git commit hash：%3
 <context>
     <name>Core::Runner</name>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="69"/>
         <source>The source file %1 doesn&apos;t exist.</source>
         <translation>原始檔 %1 不存在。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="77"/>
         <source>Failed to get run command. It&apos;s probably a bug.</source>
         <translation>無法取得執行指令。這可能是軟體錯誤。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="145"/>
         <source>Program finished with exit code %1
 Press any key to exit</source>
         <translation>程式以回傳值 %1 結束
 按下任意鍵以離開</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="148"/>
         <source>Detached execution is not supported on your platform</source>
         <translation>「在終端機中執行」不支援此平台</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="208"/>
         <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
         <translation>無法啟動「在終端機中執行」。請於 %1 檢查終端機程式的設定。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="213"/>
         <source>Failed to start running. Please compile first.</source>
         <translation>無法執行，請先編譯。</translation>
     </message>
     <message>
+        <location filename="../src/Core/Runner.cpp" line="94"/>
         <source>Failed to create temporary file.</source>
         <translation>無法建立暫存檔。</translation>
     </message>
@@ -744,10 +832,12 @@ Press any key to exit</source>
 <context>
     <name>Core::SessionManager</name>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="84"/>
         <source>Restoring Last Session</source>
         <translation>正在還原上次的工作階段</translation>
     </message>
     <message>
+        <location filename="../src/Core/SessionManager.cpp" line="98"/>
         <source>Restoring: [%1]</source>
         <translation>正在還原：%1</translation>
     </message>
@@ -755,42 +845,52 @@ Press any key to exit</source>
 <context>
     <name>Editor::FakeVimCommands</name>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="96"/>
         <source>`new` requires no argument or one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;, got [%1]</source>
         <translation type="unfinished">`new` 不需要參數，或參數應為 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一，但收到了 [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="118"/>
         <source>[%1] is not C++, Python or Java source file</source>
         <translation type="unfinished">[%1] 不是 C++、Python 或 Java 原始碼檔案</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="124"/>
         <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
         <translation type="unfinished">[%1] 不存在。若要開啟一個不存在的檔案的分頁，請使用 `open!`</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="149"/>
         <source>[%1] is not a number</source>
         <translation type="unfinished">[%1] 不是數字</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="157"/>
         <source>%1 is out of range [1, %2]</source>
         <translation type="unfinished">%1 超出範圍 [1, %2]</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="160"/>
         <source>N/A</source>
         <translation type="unfinished">不適用</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="188"/>
         <source>[%1] is not a valid view mode. It should be one of &apos;split&apos; and &apos;edit&apos;</source>
         <translation type="unfinished">[%1] 不是有效的檢視模式。應為 &apos;split&apos; 或 &apos;edit&apos; 之一</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="199"/>
         <source>%1 is not a valid language name. It should be one of &apos;cpp&apos;, &apos;java&apos; and &apos;python&apos;</source>
         <translation type="unfinished">%1 不是有效的語言名稱。應為 &apos;cpp&apos;、&apos;java&apos; 或 &apos;python&apos; 之一</translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="201"/>
         <source>No active tab to change language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Editor/FakeVimCommands.cpp" line="211"/>
         <source>No active tab to clear messages</source>
         <translation type="unfinished">沒有作用中的分頁可清除訊息</translation>
     </message>
@@ -798,43 +898,64 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CFTool</name>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="64"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="75"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="98"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="157"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="159"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="161"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="164"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
+        <location filename="../src/Extensions/CFTool.cpp" line="182"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="50"/>
         <source>CF Tool was killed</source>
         <translation>CF Tool 已被終止</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="65"/>
         <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
         <translation>題目編號為 0，將自動以 A 作為題號。若實際題號非為 A，請於目前分頁的右鍵選單中設定題號。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="76"/>
         <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>無法取得 CF Tool 的版本資訊。是否已在偏好設定中正確設定 CF Tool 的路徑？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="92"/>
         <source>CF Tool has started</source>
         <translation>CF Tool 已啟動</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="99"/>
         <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
         <translation>無法在兩秒內啟動 CF Tool。是否已在偏好設定中正確指定 CF Tool 路徑？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="104"/>
         <source>Failed to parse the URL [%1]</source>
         <translatorcomment>parse 一詞的翻譯參考自Microsoft Language Portal</translatorcomment>
         <translation>無法剖析網址「%1」</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="177"/>
         <source>CF Tool failed</source>
         <translation>CF Tool 失敗</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="178"/>
         <source>CF Tool finished with non-zero exit code %1</source>
         <translation>CF Tool 以回傳值 %1 結束</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CFTool.cpp" line="188"/>
         <source>Contest %1 Problem %2</source>
         <translation>競賽 %1 題目 %2</translation>
     </message>
@@ -842,34 +963,50 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CodeFormatter</name>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="66"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="69"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="104"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>Formatter</source>
         <translation>排版工具</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="59"/>
         <source>Failed to create temporary directory</source>
         <translation>無法建立暫存目錄</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="81"/>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="91"/>
         <source>Formatting completed</source>
         <translation>排版完成</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="105"/>
         <source>The format process didn&apos;t finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
         <translation>排版工具的處理程序未能在 2 秒內結束。這可能是因為 CP Editor 找不到 %1 程式。您可以在 %2 設定該程式的路徑。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="119"/>
         <source>The format command [%1 %2] finished with exit code %3.</source>
         <translation>排版命令 [%1 %2] 以回傳值 %3 結束執行。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="125"/>
         <source>Formatter[stdout]</source>
         <translation>排版工具 [stdout]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="128"/>
         <source>Formatter[stderr]</source>
         <translation>排版工具 [stderr]</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CodeFormatter.cpp" line="137"/>
         <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
         <translation>排版工具的處理程序輸出為空。請確保沒有使用就地修改的選項。</translation>
     </message>
@@ -877,32 +1014,39 @@ Press any key to exit</source>
 <context>
     <name>Extensions::CompanionServer</name>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="75"/>
         <source>A %1 request is received and ignored</source>
         <translation>收到並忽略了 %1 請求</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="79"/>
         <source>The request received is not JSON</source>
         <translation>接收的請求資料不是 JSON 格式</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="105"/>
         <source>Server is closed</source>
         <translation>伺服器已關閉</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="116"/>
         <source>Port is set to %1</source>
         <translation>已將連接埠設為 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="120"/>
         <source>Failed to listen to port %1. Is there another process listening?</source>
         <translation>無法偵聽連接埠 %1。可能已被其他處理程序佔用？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="149"/>
         <source>JSON parser reported errors:
 %1</source>
         <translation>JSON 剖析器回報錯誤：
 %1</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/CompanionServer.cpp" line="156"/>
         <source>Stopped Server</source>
         <translation>已停止伺服器</translation>
     </message>
@@ -910,30 +1054,42 @@ Press any key to exit</source>
 <context>
     <name>Extensions::LanguageServer</name>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="284"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="297"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>Language Server [%1]</source>
         <translation>Language Server「%1」</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="285"/>
         <source>Language server sent an error. Please check log for details.</source>
         <translation>Language Server 發出錯誤訊息。關於更多細節，請查閱記錄檔。</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="298"/>
         <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
         <translation>無法啟動 LSP 處理程序。是否已在 %1 設定 Language Server 程式的路徑？</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="305"/>
         <source>LSP Process timed out</source>
         <translation>LSP 處理程序逾時</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="308"/>
         <source>LSP Process Read Error</source>
         <translation>LSP 處理程序發生讀取錯誤</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="311"/>
         <source>LSP Process Write Error</source>
         <translation>LSP 處理程序發生寫入錯誤</translation>
     </message>
     <message>
+        <location filename="../src/Extensions/LanguageServer.cpp" line="314"/>
         <source>An unknown error has occurred in LSP Process</source>
         <translation>LSP 處理程序發生了未知的錯誤</translation>
     </message>
@@ -942,52 +1098,52 @@ Press any key to exit</source>
     <name>FindReplaceDialog</name>
     <message>
         <source>Find/Replace</source>
-        <translation>尋找/取代</translation>
+        <translation type="vanished">尋找/取代</translation>
     </message>
 </context>
 <context>
     <name>FindReplaceForm</name>
     <message>
         <source>Form</source>
-        <translation>表單</translation>
+        <translation type="vanished">表單</translation>
     </message>
     <message>
         <source>Find:</source>
-        <translation>尋找：</translation>
+        <translation type="vanished">尋找：</translation>
     </message>
     <message>
         <source>Replace with:</source>
-        <translation>取代為：</translation>
+        <translation type="vanished">取代為：</translation>
     </message>
     <message>
         <source>errorLabel</source>
-        <translation>錯誤訊息</translation>
+        <translation type="vanished">錯誤訊息</translation>
     </message>
     <message>
         <source>Direction</source>
-        <translation>方向</translation>
+        <translation type="vanished">方向</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation>向上</translation>
+        <translation type="vanished">向上</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation>向下</translation>
+        <translation type="vanished">向下</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>選項</translation>
+        <translation type="vanished">選項</translation>
     </message>
     <message>
         <source>Case sensitive</source>
         <translatorcomment>參考 Firefox 的翻譯</translatorcomment>
-        <translation>符合大小寫</translation>
+        <translation type="vanished">符合大小寫</translation>
     </message>
     <message>
         <source>Whole words only</source>
         <translatorcomment>參考 Firefox 的翻譯</translatorcomment>
-        <translation>整個文字</translation>
+        <translation type="vanished">整個文字</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -998,7 +1154,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://doc.trolltech.com/qregexp.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+        <translation type="vanished">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1009,57 +1165,80 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Regular Expression</source>
-        <translation>正規表達式</translation>
+        <translation type="vanished">正規表達式</translation>
     </message>
     <message>
         <source>Find</source>
-        <translation>尋找</translation>
+        <translation type="vanished">尋找</translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation>取代</translation>
+        <translation type="vanished">取代</translation>
     </message>
     <message>
         <source>Replace All</source>
-        <translation>全部取代</translation>
+        <translation type="vanished">全部取代</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../src/mainwindow.cpp" line="82"/>
         <source>Auto Save</source>
         <translation>自動存檔</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="185"/>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compiler</source>
         <translation>編譯器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="203"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
         <source>Please set the language</source>
         <translation>請設定語言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="218"/>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="242"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1492"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Runner</source>
         <translatorcomment>runner 譯名暫用微軟的「執行器」</translatorcomment>
         <translation>執行器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="226"/>
+        <location filename="../src/mainwindow.cpp" line="274"/>
+        <location filename="../src/mainwindow.cpp" line="1498"/>
         <source>Wrong language, please set the language</source>
         <translation>語言錯誤，請設定正確的程式語言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="242"/>
         <source>All inputs are empty, nothing to run</source>
         <translation>輸入內容皆為空，因此不執行</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="311"/>
         <source>Submit</source>
         <translation>送出</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="318"/>
         <source>Sure to submit</source>
         <translation>確認送出</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="319"/>
         <source>Are you sure you want to submit this solution to Codeforces?
 
  URL: %1
@@ -1070,103 +1249,132 @@ p, li { white-space: pre-wrap; }
  程式語言：%2</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="328"/>
+        <location filename="../src/mainwindow.cpp" line="342"/>
         <source>CF Tool</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="329"/>
         <source>Failed to save the temp file, and the solution is not submitted.</source>
         <translation>無法儲存暫存檔，程式碼未能送出。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="343"/>
         <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
         <translation>需要安裝 CF Tool 才能將您的程式碼交到 Codeforces。若已安裝，請將其加入 PATH 環境變數或檢查 %1 的設定。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="374"/>
         <source>Untitled-%1</source>
         <translation>無標題-%1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="642"/>
         <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
         <translation>未知的屬性：[%1]。請於 %2 確認開頭註解的設定。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="798"/>
         <source>Save as</source>
         <translation>另存新檔</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="867"/>
         <source>Open %1 Template</source>
         <translation>開啟 %1 樣板</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1017"/>
+        <location filename="../src/mainwindow.cpp" line="1025"/>
         <source>Open File</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1026"/>
         <source>The file [%1] contains more than %2 characters, so it&apos;s not opened. You can change the open file length limit at %3.</source>
         <translation>檔案「%1」的字元數超過 %2，因此無法開啟。您可以在 %3 變更開啟檔案的長度限制。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1119"/>
         <source>Save File</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
+        <location filename="../src/mainwindow.cpp" line="1189"/>
+        <location filename="../src/mainwindow.cpp" line="1193"/>
         <source>Temp File</source>
         <translation>暫存檔</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1175"/>
         <source>Failed to create the temporary directory</source>
         <translation>無法建立暫存目錄</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Set Compile Command</source>
         <translation>設定編譯命令</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1209"/>
         <source>Custom compile command for this tab:</source>
         <translation>自訂此分頁的編譯指令：</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Set Time Limit</source>
         <translation>限制執行時間</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1218"/>
         <source>Custom time limit for this tab: (ms)</source>
         <translation>自訂此分頁的執行時間： (ms)</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1229"/>
         <source>Read %1 Template</source>
         <translation>讀取 %1 樣板</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1250"/>
         <source>Save changes</source>
         <translation>儲存變更</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>Save changes to [%1] before closing?</source>
         <translatorcomment>參考 Microsoft OneDrive 翻譯</translatorcomment>
         <translation>關閉前先儲存「%1」？</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1251"/>
         <source>New File</source>
         <translation>新檔案</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1254"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set Tab language</source>
         <translation>設定分頁語言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1280"/>
         <source>Set the language to use in this Tab</source>
         <translation>設定此分頁使用的程式語言</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1320"/>
         <source>[%1]
 
 has been changed on disk.
@@ -1177,131 +1385,147 @@ Do you want to reload it?</source>
 要重新載入嗎？</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1360"/>
         <source>Line %1, Column %2</source>
         <translation>第 %1 列，第 %2 行</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1372"/>
         <source>%1 lines, %2 characters selected</source>
         <translation>已選取 %1 列，共 %2 個字元</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1374"/>
         <source>%1 characters selected</source>
         <translation>已選取 %1 個字元</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1471"/>
         <source>Compilation has started</source>
         <translation>已開始編譯</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1478"/>
         <source>Compilation has finished</source>
         <translation>已完成編譯</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1481"/>
         <source>Compile Warnings</source>
         <translation>編譯警告</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1514"/>
         <source>Error occurred while compiling</source>
         <translation>編譯時發生錯誤</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1517"/>
+        <location filename="../src/mainwindow.cpp" line="1521"/>
         <source>Compile Errors</source>
         <translation>編譯錯誤</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1522"/>
         <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
         <translation>是否已正確設定程式碼中 main class 的名稱？若沒有，您可在 %1 進行設定。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1531"/>
         <source>Failed to start compilation: %1</source>
         <translation>無法啟動編譯：%1</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1536"/>
         <source>Compilation is killed</source>
         <translation>編譯被終止</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1544"/>
         <source>Detached Runner</source>
         <translatorcomment>Review required</translatorcomment>
         <translation>分離式執行器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1545"/>
         <source>Runner[%1]</source>
         <translation>執行器 [%1]</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1550"/>
         <source>Execution has started</source>
         <translation>已開始執行</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1560"/>
         <source>Execution for test case #%1 has finished in %2ms</source>
         <translation>程式在測資 #%1 上執行了 %2ms 後結束</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1571"/>
         <source>Time Limit Exceeded</source>
         <translation>執行時間過長</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1577"/>
         <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
         <translation>程式在測資 #%1 上執行了 %3ms 後，以回傳值 %2 結束</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1584"/>
         <source>/stderr</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1597"/>
         <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
         <translation>在執行測資 #%2 時 %1 含有多於 %3 個字元，超出了輸出長度限制，因此被終止了。您可以在 %4 變更輸出長度限制。</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1609"/>
         <source>%1 has been killed</source>
         <translation>%1 已被終止</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Detached runner</source>
         <translation>分離式執行器</translation>
     </message>
     <message>
+        <location filename="../src/mainwindow.cpp" line="1610"/>
         <source>Runner for testcase #%1</source>
         <translatorcomment>runner 譯名暫用微軟的「執行器」</translatorcomment>
         <translation>測資 #%1 的執行器</translation>
     </message>
     <message>
-        <source>CP Editor</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>cursor info</source>
-        <translation>游標資訊</translation>
+        <translation type="vanished">游標資訊</translation>
     </message>
     <message>
         <source>Compile</source>
-        <translation>編譯</translation>
+        <translation type="vanished">編譯</translation>
     </message>
     <message>
         <source>Run</source>
-        <translation>執行</translation>
+        <translation type="vanished">執行</translation>
     </message>
     <message>
         <source>Compile and Run</source>
-        <translation>編譯並執行</translation>
+        <translation type="vanished">編譯並執行</translation>
     </message>
     <message>
         <source>Messages</source>
-        <translation>訊息</translation>
+        <translation type="vanished">訊息</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>清除</translation>
-    </message>
-    <message>
-        <source>C++</source>
-        <translation></translation>
+        <translation type="vanished">清除</translation>
     </message>
 </context>
 <context>
     <name>MessageLogger</name>
     <message>
+        <location filename="../src/Core/MessageLogger.cpp" line="52"/>
         <source>
 ... The message is too long</source>
         <translation>
@@ -1311,35 +1535,43 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesesPage</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="90"/>
         <source>%1 Parentheses</source>
         <translation>%1 括號</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="109"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="114"/>
         <source>Del</source>
         <translation>刪除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="136"/>
         <source>No Parenthesis Selected</source>
         <translation>未選擇括號</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>New Parenthesis</source>
         <translation>新括號</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="172"/>
         <source>Enter a parenthesis (e.g. {}):</source>
         <translatorcomment>標點符號？</translatorcomment>
         <translation>輸入一對括號（如：{}）：</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="185"/>
         <source>Delete Parenthesis</source>
         <translation>刪除括號</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="186"/>
         <source>Do you really want to delete the parenthesis %1?</source>
         <translation>確定要刪除括號 %1？</translation>
     </message>
@@ -1347,24 +1579,29 @@ Do you want to reload it?</source>
 <context>
     <name>ParenthesisWidget</name>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="39"/>
         <source>Parenthesis: %1</source>
         <translation>括號：%1</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="60"/>
         <source>Enable %1 for %2 in %3.
 If it&apos;s partially checked, the global setting in Code Edit will be used.</source>
         <translation>在 %3 中啟用 %1 以使用 %2。
 若沒有全部勾選，將使用程式碼編輯的全域設定。</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="68"/>
         <source>Auto Complete</source>
         <translation>自動完成</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="69"/>
         <source>Auto Remove</source>
         <translation>自動移除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/ParenthesesPage.cpp" line="70"/>
         <source>Tab Jump Out</source>
         <translation>按 Tab 鍵跳出</translation>
     </message>
@@ -1372,18 +1609,25 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PathItem</name>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="41"/>
+        <location filename="../src/Settings/PathItem.cpp" line="82"/>
         <source>Choose a file</source>
         <translation>選擇檔案</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="71"/>
         <source>Excutable Files</source>
         <translation>可執行檔</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="84"/>
+        <location filename="../src/Settings/PathItem.cpp" line="86"/>
+        <location filename="../src/Settings/PathItem.cpp" line="88"/>
         <source>Choose a %1 source file</source>
         <translation>選擇 %1 原始檔</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PathItem.cpp" line="90"/>
         <source>Choose an excutable file</source>
         <translation>選擇可執行檔</translation>
     </message>
@@ -1391,34 +1635,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesHomePage</name>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="50"/>
         <source>Welcome to CP Editor! Let&apos;s get started.</source>
         <translation>歡迎使用 CP Editor！讓我們開始吧。</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="58"/>
         <source>Code Editor Settings</source>
         <translation>程式碼編輯器設定</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="59"/>
         <source>C++ Compile and Run Commands</source>
         <translation>C++ 編譯及執行指令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="60"/>
         <source>Java Compile and Run Commands</source>
         <translation>Java 編譯及執行指令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="61"/>
         <source>Python Run Commands</source>
         <translation>Python 執行指令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="62"/>
         <source>Appearance Settings</source>
         <translation>介面設定</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="63"/>
         <source>Font Settings</source>
         <translation>字型設定</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesHomePage.cpp" line="69"/>
         <source>You can read the &lt;a href=&quot;%1&quot;&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
         <translation>您可以閱讀 &lt;a href=&quot;%1&quot;&gt;說明文件&lt;/a&gt; 或瀏覽設定以了解更多資訊。</translation>
     </message>
@@ -1426,34 +1678,42 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesPage</name>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="40"/>
         <source>Default</source>
         <translation>預設值</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="42"/>
         <source>Reset</source>
         <translation>重設</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="44"/>
         <source>Apply</source>
         <translation>套用</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="59"/>
         <source>Restore the default settings on the current page. (Ctrl+D)</source>
         <translation>重置本頁的設定 (Ctrl+D)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="60"/>
         <source>Discard all changes on the current page. (Ctrl+R)</source>
         <translation>放棄本頁的所有變更 (Ctrl+R)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="61"/>
         <source>Save the changes on the current page. (Ctrl+S)</source>
         <translation>儲存本頁的所有變更 (Ctrl+S)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>Unsaved Settings</source>
         <translation>未儲存的設定</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesPage.cpp" line="82"/>
         <source>The settings are changed. Do you want to save the settings or discard them?</source>
         <translation>設定已變更。要儲存嗎？</translation>
     </message>
@@ -1461,322 +1721,386 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
 <context>
     <name>PreferencesWindow</name>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="130"/>
+        <location filename="../src/Settings/SettingsManager.cpp" line="230"/>
         <source>Preferences</source>
         <translation>偏好設定</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="146"/>
         <source>Search...</source>
         <translation>搜尋…</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="150"/>
         <source>Home</source>
         <translation>主畫面</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="152"/>
         <source>Go to the home page</source>
         <translation>回到主畫面</translation>
     </message>
     <message>
         <source>Code Edit</source>
-        <translation>程式碼編輯</translation>
+        <translation type="vanished">程式碼編輯</translation>
     </message>
     <message>
         <source>Language</source>
-        <translation>程式語言</translation>
+        <translation type="vanished">程式語言</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>一般</translation>
+        <translation type="vanished">一般</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
         <source>C++</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="197"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
         <source>%1 Commands</source>
         <translation>%1 指令</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="199"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
         <source>%1 Template</source>
         <translation>%1 樣板</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="202"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
         <source>%1 Snippets</source>
         <translation>%1 程式碼片段</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="204"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
         <source>%1 Parentheses</source>
         <translation>%1 括號設定</translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="209"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="211"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="214"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="216"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
         <source>Java</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="221"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="223"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="226"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="228"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>Python</source>
         <translation></translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation>介面</translation>
+        <translation type="vanished">介面</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation>字型</translation>
+        <translation type="vanished">字型</translation>
     </message>
     <message>
         <source>Actions</source>
-        <translation>動作</translation>
+        <translation type="vanished">動作</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>存檔</translation>
+        <translation type="vanished">存檔</translation>
     </message>
     <message>
         <source>Auto Save</source>
-        <translation>自動存檔</translation>
+        <translation type="vanished">自動存檔</translation>
     </message>
     <message>
         <source>Detached Execution</source>
-        <translation>在終端機中執行</translation>
+        <translation type="vanished">在終端機中執行</translation>
     </message>
     <message>
         <source>Save Session</source>
-        <translation>儲存工作階段</translation>
+        <translation type="vanished">儲存工作階段</translation>
     </message>
     <message>
         <source>Bind file and problem</source>
-        <translation>繫結檔案及題目</translation>
+        <translation type="vanished">繫結檔案及題目</translation>
     </message>
     <message>
         <source>Test Cases</source>
-        <translation>測資</translation>
+        <translation type="vanished">測資</translation>
     </message>
     <message>
         <source>Load External File Changes</source>
-        <translation>載入外部的檔案變更</translation>
+        <translation type="vanished">載入外部的檔案變更</translation>
     </message>
     <message>
         <source>Extensions</source>
-        <translation>擴充功能</translation>
+        <translation type="vanished">擴充功能</translation>
     </message>
     <message>
         <source>Code Formatting</source>
-        <translation>程式碼排版</translation>
+        <translation type="vanished">程式碼排版</translation>
     </message>
     <message>
-        <source>Clang Format</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>YAPF</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Language Server</source>
-        <translation></translation>
-    </message>
-    <message>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="265"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="266"/>
+        <location filename="../src/Settings/PreferencesWindow.cpp" line="267"/>
         <source>%1 Server</source>
         <translation></translation>
     </message>
     <message>
-        <source>Competitive Companion</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>CF Tool</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>File Path</source>
-        <translation>檔案路徑</translation>
+        <translation type="vanished">檔案路徑</translation>
     </message>
     <message>
         <source>Testcases</source>
-        <translation>測資</translation>
+        <translation type="vanished">測資</translation>
     </message>
     <message>
         <source>Problem URL</source>
-        <translation>題目網址</translation>
+        <translation type="vanished">題目網址</translation>
     </message>
     <message>
         <source>Default Paths</source>
-        <translation>預設路徑</translation>
+        <translation type="vanished">預設路徑</translation>
     </message>
     <message>
         <source>Key Bindings</source>
-        <translation>快捷鍵</translation>
+        <translation type="vanished">快捷鍵</translation>
     </message>
     <message>
         <source>Advanced</source>
-        <translation>進階</translation>
+        <translation type="vanished">進階</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation>更新</translation>
+        <translation type="vanished">更新</translation>
     </message>
     <message>
         <source>Limits</source>
-        <translation>限制</translation>
+        <translation type="vanished">限制</translation>
     </message>
     <message>
         <source>Network Proxy</source>
-        <translation>網路 Proxy</translation>
-    </message>
-    <message>
-        <source>WakaTime</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Stopwatch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Stress Testing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Generator Template</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">網路 Proxy</translation>
     </message>
 </context>
 <context>
     <name>SettingsInfo</name>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>Tab Width</source>
         <translation>Tab 寬度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="38"/>
         <source>The width of the tab character, or the number of spaces of an indent</source>
         <translation>指定 Tab 字元的寬度，即縮排的空間</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>Cursor Width</source>
         <translation>游標寬度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="39"/>
         <source>The width of the cursor in pixels</source>
         <translation>以像素計算的游標寬度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="40"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="60"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="70"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="77"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="94"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="97"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="98"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="99"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="117"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="160"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="161"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="176"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="177"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="178"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="180"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="181"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="183"/>
         <source></source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>Editor Font</source>
         <translation>編輯器字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="41"/>
         <source>The font of the code editor</source>
         <translation>程式碼編輯器顯示的字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use Custom Application Font</source>
         <translatorcomment>參考簡體版翻譯</translatorcomment>
         <translation>使用自訂全域字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="42"/>
         <source>Use a custom font for the whole application instead of the default system font.</source>
         <translation>在整個應用程式中使用自訂的字型，而不是系統預設字型。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>Custom Application Font</source>
         <translation>自訂全域字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="43"/>
         <source>The custom font for the whole application</source>
         <translation>在整個應用程式中使用的自訂字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>Default Language</source>
         <translation>預設語言</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="44"/>
         <source>The default language used when opening new tabs</source>
         <translation>開新分頁時預設的語言</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>Clang Format Program</source>
         <translation>Clang Format 程式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="45"/>
         <source>The path to the Clang Format executable file</source>
         <translation>Clang Format 的可執行檔路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>Clang Format Arguments</source>
         <translation>Clang Format 引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="46"/>
         <source>The arguments passed to clang-format. It should NOT contain &quot;-i&quot;.</source>
         <translation>傳入 clang-format 的引數。不可包含「-i」。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>Clang Format Style</source>
         <translation>Clang Format 樣式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="47"/>
         <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
 You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
         <translation>Clang Format 的排版樣式選項，通常儲存為 .clang-format 組態檔案。
 您可在 &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt; 了解更多。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>YAPF Program</source>
         <translation>YAPF 程式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="48"/>
         <source>The program of YAPF. It could be `yapf` (which doesn&apos;t need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
         <translation>YAPF 的程式。可為 `yapf` （不需引數）或 `python` （需要 `-m yapf` 引數）。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>YAPF Arguments</source>
         <translation>YAPF 引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="49"/>
         <source>The arguments passed to the YAPF program. It should NOT contain &quot;-i&quot;.</source>
         <translation>傳入YAPF 程式的引數。不可包含「-i」。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>YAPF Style</source>
         <translation>YAPF 樣式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="50"/>
         <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
 You can learn about it by running `yapf --style-help`.</source>
         <translation>YAPF 的排版樣式選項，通常儲存為 .style.yapf 或 setup.conf 組態檔案。
 您可以執行 `yapf --style-help` 以了解更多。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format code on manual save</source>
         <translation>於手動存檔時排版程式碼</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="51"/>
         <source>Format the code when saving it manually.</source>
         <translation>當手動存檔時，對程式碼進行排版。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format code on auto-save</source>
         <translation>於自動存檔時排版程式碼</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="52"/>
         <source>Format the code when auto-saving it.</source>
         <translation>當自動存檔時，對程式碼進行排版。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>%1 Template Path</source>
         <translation>%1 樣板路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="53"/>
         <source>The template used when creating a new C++ file</source>
         <translation>建立 C++ 檔案時使用的樣板</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
         <source>%1 Template Cursor Position Regex</source>
         <translation>%1 樣板游標初始位置的正規表達式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="54"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="67"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="72"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>The regular expression which matches a part of the code template.
 When opening a template, the position of the cursor is the position of the regex with an offset.
 The cursor will be at the end of the template if there&apos;s no match of the regex.</source>
@@ -1785,34 +2109,53 @@ The cursor will be at the end of the template if there&apos;s no match of the re
 若沒有符合正規表達式的程式碼，游標將被置於樣板結尾。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
         <source>%1 Template Cursor Position Offset Type</source>
         <translation>%1 樣板游標位置位移類型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="55"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="68"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="73"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
         <translation>決定位移的參考點為相對於正規表達式的開始或結尾。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
         <source>%1 Template Cursor Position Offset Characters</source>
         <translation>%1 樣板游標位置位移數量</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="56"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="69"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="74"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
         <translation>相對於符合正規表達式內容的位移字元數（包含空格）。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>%1 Compile Command</source>
         <translation>%1 編譯命令</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="57"/>
         <source>The command used to compile C++. It should NOT include the path to the source file or &quot;-o &lt;output file&gt;&quot;.</source>
         <translation>編譯 C++ 使用的指令。不可包含原始檔的路徑或者「-o &lt;輸出檔&gt;」。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>%1 Executable File Path</source>
         <translation>%1 可執行檔路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="58"/>
         <source>The path of the compiled executable file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 No &quot;.exe&quot; is needed.
@@ -1827,47 +2170,61 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${tmpdir}」或「${tempdir}」代入臨時目錄的絕對路徑。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>%1 Run Arguments</source>
         <translation>%1 執行引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="59"/>
         <source>The runtime arguments when executing a C++ program</source>
         <translation>執行 C++ 程式時的引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="61"/>
         <source>The template used when creating a new Java file</source>
         <translation>建立 Java 檔案時使用的樣板</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="62"/>
         <source>The command used to compile Java.
 It should NOT include the path to the source file or the path of the compiled class file.</source>
         <translation>編譯 Java 程式碼所用的指令。不可包含原始檔及輸出的 class 檔路徑。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="63"/>
         <source>The runtime arguments when executing a Java program</source>
         <translation>執行 Java 程式時的引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>%1 Run Command</source>
         <translation>%1 執行指令</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="64"/>
         <source>The command to start a Java program. It should NOT include &quot;-classpath &lt;path&gt; &lt;class name&gt;&quot;.</source>
         <translation>啟動 Java 程式的指令。不可包含「-classpath &lt;path&gt; &lt;class name&gt;」。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>%1 Class Name</source>
         <translation>%1 Class 名稱</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="65"/>
         <source>The name of the main class of your solution.</source>
         <translation>程式碼的 main class 名稱。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>%1 Class Path</source>
         <translation>%1 Class 路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="66"/>
         <source>The path of the parent directory of the compiled class file.
 It&apos;s relative to the source file, or the temporary directory if the tab is untitled.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -1881,30 +2238,37 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${tmpdir}」或「${tempdir}」代入臨時目錄的絕對路徑。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="71"/>
         <source>The template used when creating a new Python file</source>
         <translation>建立新 Python 檔案時使用的樣板</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="75"/>
         <source>The runtime arguments when executing a Python program</source>
         <translation>執行 Python 程式時提供的引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="76"/>
         <source>The command to start a Python program. It should NOT include the path to the source file.</source>
         <translation>啟動 Python 程式的指令。不可包含原始檔的路徑。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>Editor Theme</source>
         <translation>編輯器色彩佈景主題</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="78"/>
         <source>The syntax highlight theme of the code editor</source>
         <translation>程式碼編輯器的語法標示佈景</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>Terminal Program</source>
         <translation>終端機程式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="80"/>
         <source>The terminal emulator to use when running in detached mode.
 This is usually the name or the path of the terminal emulator.
 Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
@@ -1913,10 +2277,12 @@ Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any ot
 可能的值為 konsole、gnome-terminal、xfce-terminal、xterm 或其他的終端機程式。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Terminal Arguments</source>
         <translation>終端機引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="81"/>
         <source>Arguments used to execute a given command in the terminal emulator.
 This is &quot;-e&quot; for most terminal emulators, including konsole, xterm, xfce-terminal but can be &quot;--&quot; for gnome-terminal.
 Consult your terminal emulator for the suitable arguments.</source>
@@ -1925,10 +2291,12 @@ Consult your terminal emulator for the suitable arguments.</source>
 請查詢您使用的終端機的相關資料，以使用對應的引數。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Auto Complete Parentheses</source>
         <translation>自動完成括弧</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="82"/>
         <source>Automatically complete a pair of parentheses when typing the left element of it,
 and move out of it when typing the right element of it.
 This can be overridden for each parenthesis in each language.</source>
@@ -1937,10 +2305,12 @@ This can be overridden for each parenthesis in each language.</source>
 此設定可被各程式語言的括號設定覆寫。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Auto Remove Parentheses</source>
         <translation>自動刪除括弧</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="83"/>
         <source>Automatically delete the whole pair of parentheses when deleting
 the left element of it if the two elements are adjacent.
 This can be overridden for each parenthesis in each language.</source>
@@ -1949,10 +2319,12 @@ This can be overridden for each parenthesis in each language.</source>
 此設定可被各程式語言的括號設定覆寫。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>Jump out of a parenthesis by pressing Tab</source>
         <translation>按下 Tab 時從一對括號跳出</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="84"/>
         <source>When this is enabled, you can use Tab instead of the
 closing parenthesis to jump out of a parenthesis.
 This can be overridden for each parenthesis in each language.</source>
@@ -1960,30 +2332,37 @@ This can be overridden for each parenthesis in each language.</source>
 此功能可被各程式語言的括號設定覆寫。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Auto Indent</source>
         <translation>自動縮排</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="85"/>
         <source>Add an indent when entering a new line after a &quot;{&quot;.</source>
         <translation>在「{」後換行時縮排。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="86"/>
         <source>Enable Auto Save</source>
         <translation>啟用自動存檔</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>Auto Save Interval (ms)</source>
         <translation>自動存檔間隔 (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="87"/>
         <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
         <translation>檔案變更後與自動存檔間，或兩次自動存檔間的時間間隔。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>Auto Save Interval Type</source>
         <translation>自動存檔間隔類型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="88"/>
         <source>After the last modification: the timer will be reset after a modification to the code.
 After the first modification: the timer will start after a modification if at that time the timer is not running.
 Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
@@ -1992,91 +2371,123 @@ After the first modification：計時器僅在編輯程式碼時運作。
 Without modification：不論程式碼是否被修改，每經一段時間自動儲存一次。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap Text</source>
         <translatorcomment>參考 VS Code 翻譯</translatorcomment>
         <translation>自動換行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="89"/>
         <source>Wrap a line into several lines if it doesn&apos;t fit into the screen.</source>
         <translation>當文字內容超出螢幕範圍時，將其分為幾列顯示。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Enable Ctrl+Scroll to change font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="90"/>
+        <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Use the beta version</source>
         <translation>使用 Beta 版本</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="91"/>
         <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
         <translation>檢查預覽版本的更新，預覽版包含更多功能，但並不是十分穩定。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Replace tabs by spaces</source>
         <translation>以空白代替 Tab</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="92"/>
         <source>Use spaces instead of a tab character.</source>
         <translation>使用空白字元來取代 Tab 字元（\t）。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save Testcases on Save</source>
         <translation>存檔時一同儲存測資</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="93"/>
         <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
         <translation>存檔時一同儲存測試資料，並於開啟檔案時將其載入。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check for updates on startup</source>
         <translation>在程式啟動時檢查更新</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="95"/>
         <source>Check whether there&apos;s a new version of CP Editor when starting CP Editor.</source>
         <translation>當 CP Editor 啟動時，檢查是否有新版本。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>Opacity</source>
         <translation>不透明度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="96"/>
         <source>The opacity of the main window</source>
         <translation>主視窗的不透明度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Enable Competitive Companion</source>
         <translation>啟用 Competitive Companion</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="100"/>
         <source>Receive data sent by Competitive Companion and load the example test cases.</source>
         <translation>接收 Competitive Companion 傳送的資料，並載入範例測資。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>Connection Port</source>
         <translation>連接埠</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="101"/>
         <source>The port used to receive data from Competitive Companion</source>
         <translation>從 Competitive Companion 接收資料用的連接埠</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open New Tabs</source>
         <translation>在新分頁中開啟</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="102"/>
         <source>Open a new tab for each problem parsed by Competitive Companion.</source>
         <translation>總是在新分頁開啟 Competitive Companion 傳來的題目。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit from Competitive Companion</source>
         <translation>使用 Competitive Companion 的執行時間限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="103"/>
         <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
         <translation>為對應的分頁套用 Competitive Companion 傳遞的時間限制。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>Content of the head comments</source>
         <translation>開頭註解的內容</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="104"/>
         <source>The comments added at the head of the code when parsing a problem.
 Available place holders are:
 ${time}: the time when parsing the problem
@@ -2087,10 +2498,12 @@ ${time}：剖析題目的時間
 ${json.X.Y}：由 Competitive Companion 提供的屬性，您可以於 https://github.com/jmerle/competitive-companion#explanation 閱讀更多資訊</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>Time format for the head comments</source>
         <translation>開頭註解的時間格式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="105"/>
         <source>The format of the ${time} place holder in the head comments.
 You can read the Qt documentation for available expressions:
 https://doc.qt.io/qt-5/qdate.html#toString
@@ -2102,58 +2515,71 @@ https://doc.qt.io/qt-5/qdate.html#toString
 https://doc.qt.io/qt-5/qtime.html#toString</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add &quot;Powered By CP Editor&quot; in the head comments</source>
         <translation>在檔案開頭加上「Powered By CP Editor」註解</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="106"/>
         <source>Add a line saying &quot;Powered By CP Editor&quot; in the head comments.
 This doesn&apos;t cost you anything, but helps more people to know CP Editor.</source>
         <translation>在檔案一開始的註解加上一行「Powered By CP Editor」。
 這可以讓您用最便宜的方式協助推廣 CP Editor。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="107"/>
         <source>Format Codes</source>
         <translation>排版程式碼</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="108"/>
         <source>Kill All Processes</source>
         <translation>終止所有處理程序</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="109"/>
         <source>Compile and Run</source>
         <translation>編譯並執行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="110"/>
         <source>Run Only</source>
         <translation>執行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="111"/>
         <source>Compile Only</source>
         <translation>編譯</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="112"/>
         <source>Change View Mode</source>
         <translation>變更檢視模式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="113"/>
         <source>Use Snippets</source>
         <translation>使用程式碼片段</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore last session at startup</source>
         <translation>啟動時還原上次的工作階段</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="114"/>
         <source>Restore the last session when the application starts.
 When this is enabled, you won&apos;t be asked whether to save unsaved files when exiting.</source>
         <translation>在應用程式啟動時還原上次的工作階段。
 啟用了此功能，就不會在關閉程式時詢問是否儲存未存檔的檔案。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically</source>
         <translation>定期自動儲存目前工作階段</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="115"/>
         <source>Auto-save the current session periodically instead of only save when the application exists.
 This is useful if your computer is frozen and you have to cut off the power or
 kill the application with SIGKILL which could not be handled by the application.</source>
@@ -2161,212 +2587,278 @@ kill the application with SIGKILL which could not be handled by the application.
 這對於電腦當機以至於需要切斷電源或程式遭到 SIGKILL 終止的狀況很有效。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>Auto-save Session Interval</source>
         <translation>自動儲存工作階段的間隔</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="116"/>
         <source>The time interval between two auto-saves of the current session.</source>
         <translation>自動儲存目前工作階段的時間間隔。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>Path</source>
         <translation>路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="118"/>
         <source>The path to the CF Tool executable file</source>
         <translation>CF Tool 可執行檔的路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show toast messages for submission verdicts</source>
         <translation>顯示評判結果的快顯通知</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="119"/>
         <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
         <translation>當評判結果揭曉時，顯示快顯通知。此通知在 CP Editor 以外也能見到。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable CF Tool</source>
         <translation>啟用 CF Tool</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="120"/>
         <source>Enable or disable CF Tool Integration.</source>
         <translation>啟用或禁用CF Tool</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Show Compile And Run Only</source>
         <translation>只顯示編譯並執行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="121"/>
         <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
         <translation>隱藏主視窗的程式碼編輯器底下的「編譯」及「執行」按鈕。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Display EOLN In Diff</source>
         <translation>在 Diff 中顯示 EOLN</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="122"/>
         <source>Use &quot;¶&quot; to represent for the new line character in the HTML Diff Viewer.</source>
         <translation>在 HTML Diff 檢視器中以「¶」表示換行符號。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Save Files Faster</source>
         <translation>更快的存檔</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="123"/>
         <source>Always use QFile instead of QSaveFile to save files.
 This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
         <translation>總是使用 QFile 而非 QSaveFile 進行存檔。
 可以使存檔更快速，然而遺失檔案的風險會稍微增加。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>Default Time Limit (ms)</source>
         <translation>預設執行時間限制 (ms)</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="124"/>
         <source>The default time limit when executing the program.
 The program will be killed if it doesn&apos;t terminate in the time limit.</source>
         <translation>執行程式時的預設時間限制。
 若超出時間限制，程式仍在執行，則將其終止。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>Output Length Limit</source>
         <translation>輸出長度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="125"/>
         <source>The maximum number of characters in the output of the program.
 The program will be killed if either of its stdout or stderr is too long.</source>
         <translation>程式輸出的字元數量上限。
 若 stdout 或 stderr 的輸出過長，則將其終止。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>Output Display Length Limit</source>
         <translation>輸出顯示長度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="126"/>
         <source>The maximum number of characters to be displayed for the output of the program.
 If the output is too long, it will be elided.</source>
         <translation>程式輸出的顯示字元數量上限。
 輸出內容過長時將其省略。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>Message Length Limit</source>
         <translation>訊息長度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="127"/>
         <source>The maximum number of characters in each message in the top-right corner of the main window.
 The message will be elided if it&apos;s too long.</source>
         <translation>主視窗右上角對話窗格的最大訊息長度。
 訊息內容過長時將其省略。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>HTML Diff Viewer Length Limit</source>
         <translation>HTML Diff 檢視器長度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="128"/>
         <source>The maximum number of characters in the HTML Diff Viewer.
 The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
         <translation>HTML Diff 檢視器的最大顯示字元數。
 內容過長時，將以純文字顯示。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>Open File Length Limit</source>
         <translation>開啟檔案的長度限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="129"/>
         <source>The maximum number of characters in a source file to open.
 A source file won&apos;t be opened if it&apos;s too long.</source>
         <translation>開啟原始檔時，可接受的最大字元數。
 不會開啟過長的原始檔。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>Display Test Case Length Limit</source>
         <translation>測資長度顯示限制</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="130"/>
         <source>The maximum number of characters in a test case to be displayed.
 A test case will be elided and read-only if it&apos;s too long.</source>
         <translation>測資的顯示字元數量上限。
 內容過長時將其省略，並變成唯讀。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>Path to LSP executable</source>
         <translation>LSP 可執行檔的路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="131"/>
         <source>The path to the C++ Language Server executable</source>
         <translation>C++ Language Server 可執行檔的路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="132"/>
         <source>The path to the Java Language Server executable</source>
         <translation>Java Language Server 可執行檔的路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="133"/>
         <source>The path to the Python Language Server executable</source>
         <translation>Python Language Server 可執行檔的路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Use Linting with Language Server</source>
         <translation>使用 Language Server 的 Linting</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="134"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
         <translation>在程式碼編輯器中顯示 C++ 的錯誤、警告、資訊及提示</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="135"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
         <translation>在程式碼編輯器中顯示 Java 的錯誤、警告、資訊及提示</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="136"/>
         <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
         <translation>在程式碼編輯器中顯示 Python 的錯誤、警告、資訊及提示</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use auto-complete with Language Server</source>
         <translation>使用 Language Server 提供的自動完成</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="137"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="138"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="139"/>
         <source>Use autocomplete results from Language server</source>
         <translation>使用 Language Server 提供的自動完成結果</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in Linting (ms)</source>
         <translation>Linting 延遲（ms）</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="140"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="141"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="142"/>
         <source>Delay in linting in milliseconds after last modification to code</source>
         <translation>控制 Linting 在修改之後延遲的時間</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments for Language Server</source>
         <translation>Language Server 引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="143"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="144"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="145"/>
         <source>Arguments to pass to Language server executable</source>
         <translation>傳遞給 Language Server 程式的引數</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Testcases Matching Rules</source>
         <translation>測資比對規則</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Pairs of regular expressions used when adding pairs of test cases from files.
 Each pair of regular expressions represents a test case.</source>
         <translation>用於從檔案加入多筆測資時的正規表達式。
 每對正規表達式代表一筆測資。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Input Regex</source>
         <translation>輸入檔正則表達式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The regular expression which matches the whole input file name</source>
         <translation>用於比對整個輸入檔名的正則表達式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>Answer Replace</source>
         <translation>答案替換</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="146"/>
         <source>The replace expression for the answer file name.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translatorcomment>captured group 之翻譯待定</translatorcomment>
@@ -2374,10 +2866,12 @@ You can use &quot;\1&quot; for the first captured group.</source>
 可使用「\1」表示首個符合的組別。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>Input File Save Path</source>
         <translation>輸入檔儲存路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="147"/>
         <source>The path where the input files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2393,10 +2887,12 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${1-index}」以索引值 1 開始代入測資。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>Answer File Save Path</source>
         <translation>答案檔儲存路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="148"/>
         <source>The path where the answer files are saved.
 This setting is a relative path to the source file.
 You can use &quot;${filename}&quot; for the complete file name,
@@ -2412,223 +2908,278 @@ You can use &quot;${filename}&quot; for the complete file name,
 使用「${1-index}」以索引值 1 開始代入測資。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>Default File Paths For Problem URLs</source>
         <translation>對應題目網址的預設存檔路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The default file path used when saving a new file while the problem URL is set</source>
         <translation>當設定題目網址時，用於儲存檔案的預設路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>Problem URL</source>
         <translation>題目網址</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The regular expression which matches a part of the problem URL</source>
         <translation>用於比對部分題目網址的正則表達式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>File Path</source>
         <translation>檔案路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="149"/>
         <source>The replace expression for the file path, without file name suffix.
 You can use &quot;\1&quot; for the first captured group.</source>
         <translation>用於存檔路徑的替換表達式（不需檔名後綴）。
 可使用「\1」表示首個符合的組別。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>Test Cases Font</source>
         <translation>測資字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="150"/>
         <source>The font of test cases</source>
         <translation>顯示測資用的字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add extra margin at the bottom of the code editor</source>
         <translation>在程式碼編輯器的底部加上額外邊距</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="151"/>
         <source>Add an extra margin with the height of a page at the bottom of the code editor.
 Due to technical reasons, changing the height of the margin affects the undo history.</source>
         <translation>在程式碼編輯器的底部加上額外邊距。
 由於技術原因，改變邊距會影響復原記錄。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>Message Logger Font</source>
         <translation>訊息字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="152"/>
         <source>The font of the message logger</source>
         <translation>顯示訊息紀錄用的字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save File On Compilation</source>
         <translation>在編譯程式時存檔</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="153"/>
         <source>Save the source file when compiling it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>除了無標題的分頁，編譯原始檔時順便存檔。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save File On Execution</source>
         <translation>在執行程式時存檔</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="154"/>
         <source>Save the source file when running it. It won&apos;t be saved if the tab is untitled.</source>
         <translation>除了無標題的分頁，執行程式時順便存檔。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>Restore the problem URL when opening a file</source>
         <translation>開啟檔案時還原該題網址</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="155"/>
         <source>If a problem URL was set for a file, when you open
 that file again, the problem URL will be restored.</source>
         <translation>若檔案有設定題目網址，當再次
 開啟時，也會繼續使用該網址。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>Open the old file when parsing an old problem URL</source>
         <translation>遇到已剖析過的題目網址時開啟對應檔案</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="156"/>
         <source>If a problem URL was set for a file, when parsing that problem
 from Competitive Companion again, the old file will be opened.</source>
         <translation>若檔案有設定題目網址，當再次由
 Competitive Companion 開啟時，也會繼續使用該網址。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>UI Language</source>
         <translation>UI 語言</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>The language displayed in the UI.</source>
         <translation>顯示於使用者介面的語言。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>Change Locale</source>
         <translation>變更語系</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="157"/>
         <source>You need to restart the application to completely apply the locale change.</source>
         <translation>需要重新啟動應用程式以確實套用語系變更。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>UI Style</source>
         <translation>UI 佈景</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="158"/>
         <source>The style of the whole application.</source>
         <translation>整個應用程式的外觀樣式。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your codes on empty test cases</source>
         <translation>測資輸入為空時依然執行</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="162"/>
         <source>Run your code on all non-hidden test cases even if the input is empty.</source>
         <translation>即使測資的輸入為空，還是執行程式。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer on test cases with empty output</source>
         <translation>測資輸出為空時依然評判答案</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="163"/>
         <source>Check your answer even if your output or the expected output is empty.</source>
         <translation>即使輸出結果或答案為空，還是進行評判。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>Test Case Maximum Height</source>
         <translation>測資顯示最大高度</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="164"/>
         <source>The maximum height of a test case without a scrollbar in pixels.</source>
         <translation>在捲軸不出現的情況下，可允許顯示的最多像素數。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy for checking updates</source>
         <translation>在檢查更新時使用 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>The type of the proxy. &quot;System&quot; for using the system proxy.</source>
         <translation>Proxy 的類型。選用「System」以依循系統設定。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="166"/>
         <source>network-proxy</source>
         <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>Host Name</source>
         <translation>位址</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>The hostname of the proxy, e.g. 127.0.0.1</source>
         <translation>Proxy 伺服器的位址，如：127.0.0.1</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="167"/>
         <source>network-proxy</source>
         <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>Port</source>
         <translation>連接埠</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>The port of the proxy, e.g. 1080</source>
         <translation>Proxy 的連接埠，如：1080</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="168"/>
         <source>network-proxy</source>
         <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>User</source>
         <translation>帳號</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>The user of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Proxy 伺服器的帳號。若 Proxy 伺服器毋須認證，可以留空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="169"/>
         <source>network-proxy</source>
         <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>Password</source>
         <translation>密碼</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>The password of the proxy server. It can be empty if the proxy server doesn&apos;t require authentication.</source>
         <translation>Proxy 伺服器的密碼。若 Proxy 伺服器毋須認證，可以留空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="170"/>
         <source>network-proxy</source>
         <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>%1 Compiler Output Codec</source>
         <translation>%1 編譯器輸出字元集</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="171"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="172"/>
         <source>Text codec of the compiler output (errors, warnings, etc.)</source>
         <translation>編譯器輸出（錯誤、警告等）的文字編碼</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Default Path Names And Paths</source>
         <translation>預設路徑及名稱</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>A list of default paths.
 They can be used in actions&apos; corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
 They can be either manually set or automatically changed after choosing a path for an action.</source>
@@ -2637,30 +3188,38 @@ They can be either manually set or automatically changed after choosing a path f
 它們可以被手動設定，或在選擇動作的路徑後自動改變。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The name of a default path</source>
         <translation>預設路徑之名稱</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
         <source>The path of a default path</source>
         <translation>預設路徑的位址</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Auto-load external file changes if there&apos;s no unsaved modification</source>
         <translation>若目前沒有未存檔的內容，自動載入外部的檔案變更</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="174"/>
         <source>Automatically load file changes that are not made in CP Editor if there&apos;s no unsaved modification in CP Editor.</source>
         <translation>當檔案沒有未存檔的內容且在 CP Editor 外發生了變更，則自動將其載入。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>Ask whether to load external file changes</source>
         <translation>詢問我是否要載入外部的檔案變更</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="175"/>
         <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
 &quot;%1&quot;, ask for whether to load the changes.
 If this is disabled, external file changes will be ignored unless they are loaded by
@@ -2670,208 +3229,345 @@ If this is disabled, external file changes will be ignored unless they are loade
 此功能關閉時，不透過「%1」載入的變更都會被忽略。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show Only Monospaced Font</source>
         <translation>只顯示等寬字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="179"/>
         <source>Show only monospaced fonts when choosing a font</source>
         <translation>當選擇字型時，只列出等寬字型</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Auto Uncheck Accepted Testcases</source>
         <translation>自動取消核選已通過的測資</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="182"/>
         <source>Automatically uncheck test cases when they get accepted.</source>
         <translation>當某筆測資評判通過，將其取消核選。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>Default path used for %1</source>
         <translation>%1 使用的預設路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
         <source>Open File</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
         <source>The default path used when choosing a path for %1.
 You can use ${&lt;default path name&gt;} as a place holder.</source>
         <translation>為 %1 選擇路徑時的預設值。
 您可以使用 ${&lt;default path name&gt;} 當作預留位置。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Default paths changed by %1</source>
         <translation>由 %1 變更的預設路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>The default paths changed after choosing a path for %1.
 It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
         <translation>選擇 %1 的路徑後變更的預設路徑。
 此為 &lt;default path name&gt; 的清單，以「,」隔開，亦可留空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
         <source>Save File</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
         <source>It can be overridden by %1.</source>
         <translation>這會被 %1 的設定覆寫。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
         <source>Open Contest</source>
         <translation>建立競賽</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
         <source>Load Single Test Case</source>
         <translation>載入單筆測資</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
         <source>Add Pairs Of Test Cases</source>
         <translation>新增多筆測資</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
         <source>Save Test Case To A File</source>
         <translation>將測資存為檔案</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
         <source>Custom Checker</source>
         <translation>自訂評判程式</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
         <source>Export And Import Settings</source>
         <translation>匯出及匯入設定值</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
         <source>Export And Load Session</source>
         <translation>匯出及載入工作階段</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>Extract And Load Snippets</source>
         <translation>匯出及載入程式碼片段</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>Enable proxy to connect to GitHub while checking updates</source>
         <translation>在連線至 GitHub 檢查更新時使用 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="165"/>
         <source>network-proxy</source>
         <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
         <translation>網路 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="186"/>
         <source>The path to the WakaTime executable file</source>
         <translation>WakaTime 可執行檔的路徑</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Api Key</source>
         <translation>API 金鑰</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="187"/>
         <source>Can be found at https://wakatime.com/settings/account.
 It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
         <translation>可於 https://wakatime.com/settings/account 取得。
 若您有 ~/.wakatime.cfg 組態檔，可以留空。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Enable WakaTime</source>
         <translation>啟用 WakaTime</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Proxy</source>
         <translation>使用 Proxy</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="189"/>
         <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
         <translation>傳送資料給 WakaTime 時使用 進階-&gt;網路 Proxy。</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Display Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>Start/Stop stopwatch on tab switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="191"/>
         <source>When switching to a different tab, automatically start the stopwatch
 on the current tab and pause the stopwatch on the previous tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Show stopwatch result only when the button is pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="192"/>
         <source>Hide the time of the stopwatch and only show the time when the &quot;Show&quot; button is pressed.
 This may reduce distractions caused by stopwatch updates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="79"/>
         <source>Highlight lines containing diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="193"/>
         <source>Color of error messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="194"/>
         <source>Color of warning messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="188"/>
         <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="190"/>
         <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="173"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="200"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="201"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="202"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="203"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="204"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="205"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="206"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="207"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="208"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="209"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="210"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="211"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="212"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="213"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="214"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="215"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="216"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="217"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="218"/>
+        <location filename="../build/generated/SettingsInfo.cpp" line="219"/>
         <source>default-paths</source>
         <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>The programming language used for the generator template.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>The path to the generator template file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="197"/>
         <source>Template Cursor Position Regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="198"/>
         <source>Template Cursor Position Offset Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="199"/>
         <source>Template Cursor Position Offset Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="195"/>
         <source>Programming language for the template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="196"/>
         <source>Path to the template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable Vim Emulation</source>
         <translation>啟用 Vim 模擬</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="184"/>
         <source>Enable vim emulation in Code Editor</source>
         <translation>在程式碼編輯器中啟用 Vim 模擬</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>Vim Configuration</source>
         <translation>Vim 設定</translation>
     </message>
     <message>
+        <location filename="../build/generated/SettingsInfo.cpp" line="185"/>
         <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Vim RC 的內容。每次啟動 Vim 模擬時都會載入。
@@ -2881,6 +3577,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>ShortcutItem</name>
     <message>
+        <location filename="../src/Settings/ShortcutItem.cpp" line="35"/>
         <source>Clear the shortcut</source>
         <translation>清除快捷鍵</translation>
     </message>
@@ -2888,42 +3585,52 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>StringListsItem</name>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="51"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="53"/>
         <source>Insert a row (Ctrl+N)</source>
         <translation>插入一列 (Ctrl+N)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="68"/>
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="70"/>
         <source>Delete the current row (Ctrl+W)</source>
         <translation>刪除目前這列 (Ctrl+W)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Remove Item</source>
         <translation>移除項目</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="76"/>
         <source>Do you really want to delete the current row?</source>
         <translation>確定要刪除目前這列？</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="87"/>
         <source>Move Up</source>
         <translation>上移</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="89"/>
         <source>Move the current row up (Ctrl+Shift+Up)</source>
         <translation>將目前這列向上移動 (Ctrl+Shift+Up)</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="110"/>
         <source>Move Down</source>
         <translation>下移</translation>
     </message>
     <message>
+        <location filename="../src/Settings/StringListsItem.cpp" line="112"/>
         <source>Move the current row down (Ctrl+Shift+Down)</source>
         <translation>將目前這列向下移動 (Ctrl+Shift+Down)</translation>
     </message>
@@ -2931,6 +3638,7 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportEntry</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="57"/>
         <source>Donate</source>
         <translation>贊助</translation>
     </message>
@@ -2938,35 +3646,43 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>SupportUsDialog</name>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="72"/>
         <source>Like CP Editor?</source>
         <translation>喜歡 CP Editor 嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="79"/>
         <source>Thank you for using CP Editor!</source>
         <translation>謝謝您使用 CP Editor！</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="90"/>
         <source>To support us, you can:</source>
         <translation>如果您想要支持我們的工作，可以：</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="95"/>
         <source>Give us a star on GitHub</source>
         <translation>在 GitHub 上幫我們按個星星</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="100"/>
         <source>Share CP Editor with your friends</source>
         <translation>跟您的朋友介紹 CP Editor</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="103"/>
         <source>I&apos;m using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
         <translatorcomment>It&apos;s ok to ignore Qt Linguist warning.</translatorcomment>
         <translation>我在用一款很讚的IDE @cpeditor_</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="107"/>
         <source>Financially support us</source>
         <translation>提供我們金錢上的援助</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/SupportUsDialog.cpp" line="110"/>
         <source>Provide some suggestions to help us do better</source>
         <translation>提供一些建議，讓我們做得更好</translation>
     </message>
@@ -2974,15 +3690,18 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Telemetry::UpdateChecker</name>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="119"/>
         <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
         <translatorcomment>It&apos;s ok to ignore Qt Linguist warning</translatorcomment>
         <translation>此錯誤可能是因為缺少 OpenSSL 函式庫引起的。您可以參考 &lt;a href=&quot;https://wiki.openssl.org/index.php/Binaries&quot;&gt;the OpenSSLWiki&lt;/a&gt; 來取得安裝檔，或了解如何透過套件管理安裝。您必須安裝與此版本「%1」相容的版本。</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="153"/>
         <source>No release is found.</source>
         <translation>未有新版本。</translation>
     </message>
     <message>
+        <location filename="../src/Telemetry/UpdateChecker.cpp" line="168"/>
         <source>No download URL of the version [%1] is found.</source>
         <translation>未發現 %1 版的下載網址。</translation>
     </message>
@@ -2990,52 +3709,66 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Util::FileUtil</name>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="87"/>
+        <location filename="../src/Util/FileUtil.cpp" line="110"/>
         <source>Failed to open [%1]. Do I have write permission?</source>
         <translation>無法開啟「%1」。有寫入權限嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="97"/>
+        <location filename="../src/Util/FileUtil.cpp" line="119"/>
         <source>Failed to save to [%1]. Do I have write permission?</source>
         <translation>無法儲存「%1」。有寫入權限嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="138"/>
         <source>The file [%1] does not exist</source>
         <translation>檔案「%1」不存在</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="148"/>
         <source>Failed to open [%1]. Do I have read permission?</source>
         <translation>無法開啟「%1」。有讀取權限嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="188"/>
         <source>Open Containing Folder of %1</source>
         <translation>開啟 %1 所在的資料夾</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="204"/>
         <source>Reveal %1 in Finder</source>
         <translatorcomment>for macOS</translatorcomment>
         <translation>在 Finder 中顯示 %1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="211"/>
         <source>Reveal %1 in Explorer</source>
         <translatorcomment>for Windows</translatorcomment>
         <translation>在檔案總管顯示 %1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="251"/>
         <source>Reveal %1 in File Manager</source>
         <translation>在檔案管理員中顯示 %1</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="39"/>
         <source>C++ Source Files</source>
         <translation>C++ 原始檔</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="41"/>
         <source>Java Source Files</source>
         <translation>Java 原始檔</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="43"/>
         <source>Python Source Files</source>
         <translation>Python 原始檔</translation>
     </message>
     <message>
+        <location filename="../src/Util/FileUtil.cpp" line="45"/>
         <source>Source Files</source>
         <translation>原始檔</translation>
     </message>
@@ -3043,50 +3776,62 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::ContestDialog</name>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="42"/>
         <source>Create a new contest</source>
         <translation>建立新比賽</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="46"/>
         <source>Contest Details</source>
         <translation>比賽內容</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="53"/>
         <source>Main Directory</source>
         <translation>主目錄</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="64"/>
         <source>Subdirectory</source>
         <translation>子目錄</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="71"/>
         <source>Save Path</source>
         <translation>儲存路徑</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="75"/>
         <source>Language</source>
         <translation>程式語言</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="80"/>
         <source>Number of Problems</source>
         <translation>題目數量</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="120"/>
         <source>Main Directory doesn&apos;t exist</source>
         <translation>主目錄不存在</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="121"/>
         <source>The Main Directory [%1] doesn&apos;t exist. Do you want to create it and continue?</source>
         <translation>主目錄「%1」不存在。要建立並繼續嗎？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="131"/>
         <source>Failed to create directory</source>
         <translation>無法建立目錄</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="132"/>
         <source>Failed to create the directory [%1].</source>
         <translation>無法建立目錄「%1」。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/ContestDialog.cpp" line="144"/>
         <source>Choose Main Directory</source>
         <translation>選擇主目錄</translation>
     </message>
@@ -3094,14 +3839,17 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::DiffViewer</name>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="37"/>
         <source>Diff Viewer</source>
         <translation>Diff 檢視器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="41"/>
         <source>Output</source>
         <translation>輸出</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/DiffViewer.cpp" line="51"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
@@ -3109,26 +3857,33 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::Stopwatch</name>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="38"/>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="159"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="162"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="165"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="39"/>
         <source>Reset</source>
         <translation type="unfinished">重設</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="34"/>
         <source>Stopwatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/Stopwatch.cpp" line="37"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3136,162 +3891,222 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::StressTesting</name>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="65"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="332"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="393"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="394"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="395"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Stress Testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="72"/>
         <source>Generator Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="94"/>
         <source>Example: &quot;10 [5..100] abacaba&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="103"/>
         <source>Standard Program Path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="122"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="125"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="258"/>
         <source>Invalid arguments pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="336"/>
         <source>Read Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="338"/>
         <source>Read Standard Program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="342"/>
         <source>Failed to open generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="349"/>
         <source>Failed to open standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="358"/>
         <source>Failed to create temporary directory</source>
         <translation type="unfinished">無法建立暫存目錄</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="398"/>
         <source>Read testlib.h</source>
         <translation type="unfinished">讀取 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="401"/>
         <source>Save testlib.h</source>
         <translation type="unfinished">儲存 testlib.h</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>Compiler</source>
         <translation type="unfinished">編譯器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="571"/>
         <source>Running with arguments &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="412"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="755"/>
         <source>Generator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="414"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="759"/>
         <source>User program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="416"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="763"/>
         <source>Standard program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="640"/>
         <source>Time Limit Exceeded</source>
         <translation type="unfinished">執行時間過長</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="643"/>
         <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="670"/>
         <source>The program was killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="679"/>
         <source>Output limit exceeded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="548"/>
         <source>All tests finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="422"/>
         <source>%1 compilation has started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="427"/>
         <source>%1 compilation has finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="436"/>
         <source>%1 compilation error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="443"/>
         <source>%1 compilation failed: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="450"/>
         <source>%1 compilation killed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="700"/>
         <source>Counterexample Found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="67"/>
+        <location filename="../src/Widgets/StressTesting.cpp" line="172"/>
         <source>User Program: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="713"/>
         <source>Add to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="714"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="715"/>
         <source>Stop stress testing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="738"/>
         <source>Counterexample added to testcases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="535"/>
         <source>Elapsed: %1:%2  |  Completed: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="772"/>
         <source>Select generator from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="776"/>
         <source>Select standard program from opened files...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="91"/>
         <source>Use Generator Arguments:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Widgets/StressTesting.cpp" line="320"/>
         <source>Please select a generator and a standard program</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3299,58 +4114,72 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCase</name>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="55"/>
         <source>Input</source>
         <translation>輸入</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="56"/>
         <source>Output</source>
         <translation>輸出</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="57"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="59"/>
         <source>Run</source>
         <translation>執行</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="62"/>
         <source>Del</source>
         <translation>刪除</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="110"/>
         <source>Test on a single testcase</source>
         <translation>測試單筆測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="111"/>
         <source>Open the Diff Viewer</source>
         <translation>開啟 Diff 檢視器</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="176"/>
         <source>Input #%1</source>
         <translation>輸入 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="177"/>
         <source>Output #%1</source>
         <translation>輸出 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="178"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="293"/>
         <source>Delete Testcase</source>
         <translation>刪除測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="294"/>
         <source>Are you sure you want to delete test case #%1?</source>
         <translation>確定要刪除測資 #%1？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="302"/>
         <source>Diff Viewer[%1]</source>
         <translation>Diff 檢視器「%1」</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCase.cpp" line="303"/>
         <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
         <translation>輸出或答案內容超過 %1 字元，因此不啟用 HTML Diff 檢視器。您可以在 %2 變更長度限制。</translation>
     </message>
@@ -3358,42 +4187,54 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCaseEdit</name>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="117"/>
         <source>Input</source>
         <translation>輸入</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="122"/>
         <source>Output</source>
         <translation>輸出</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="127"/>
         <source>Expected</source>
         <translation>答案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="132"/>
         <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
         <translation>僅顯示前 %1 個字元。現在測資編輯器是唯讀狀態。您可以在 %2 設定長度限制。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="177"/>
         <source>Save to file</source>
         <translation>儲存為檔案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="182"/>
         <source>Save test case to file</source>
         <translation>將測資存為檔案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="187"/>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="189"/>
         <source>Load From File</source>
         <translation>從檔案載入</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="194"/>
         <source>Edit in Bigger Window</source>
         <translation>在大視窗中編輯</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="197"/>
         <source>Edit Testcase</source>
         <translation>編輯測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCaseEdit.cpp" line="205"/>
         <source>Copy Output to Expected</source>
         <translation>複製輸出至答案</translation>
     </message>
@@ -3401,174 +4242,224 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::TestCases</name>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="48"/>
         <source>Test Cases</source>
         <translation>測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="50"/>
         <source>Checker:</source>
         <translation>評判程式：</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="51"/>
         <source>Add Test</source>
         <translation>新增測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="52"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="53"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="539"/>
         <source>Add Checker</source>
         <translation>新增評判程式</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="72"/>
         <source>Unaccepted / Accepted / Total</source>
         <translation>未通過 / 通過 / 總計</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="73"/>
         <source>Add a custom testlib checker</source>
         <translation>新增自訂 testlib 評判程式</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="79"/>
         <source>Add Pairs of Testcases From Files</source>
         <translation>從檔案匯入測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="81"/>
         <source>Choose Testcase Files</source>
         <translation>選擇測資檔案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="108"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="109"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="130"/>
         <source>Testcases</source>
         <translation>測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="113"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="143"/>
         <source>Load Testcases</source>
         <translation>載入測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="114"/>
         <source>A pair of testcases [%1] and [%2] is loaded</source>
         <translation>已載入一對測資 [%1] 及 [%2]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="134"/>
         <source>An input [%1] is loaded</source>
         <translation>已載入輸入內容 [%1]</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="144"/>
         <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
         <translation>檔案 %1 因不符合比對規則，而沒有被載入。您可在 %2 調整比對規則。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="154"/>
         <source>Check All</source>
         <extracomment>Here &quot;Check&quot; means to check the checkbox</extracomment>
         <translation>核選全部</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="160"/>
         <source>Uncheck All</source>
         <translation>取消核選全部</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="166"/>
         <source>Uncheck Accepted</source>
         <translation>取消核選已通過的</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="174"/>
         <source>Invert</source>
         <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
         <translation>反轉核選</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="180"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Delete All</source>
         <translation>刪除全部</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="182"/>
         <source>Are you sure you want to delete all test cases?</source>
         <translation>確定要刪除全部測資點？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="193"/>
         <source>Delete Empty</source>
         <translation>刪除空測資點</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="205"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="208"/>
         <source>Delete Checked</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>刪除核選的</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="209"/>
         <source>Are you sure you want to delete all checked test cases?</source>
         <translation>確定刪除所有核選的測資？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="223"/>
         <source>Copy Test Cases</source>
         <translation>複製測資點</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="228"/>
         <source>Paste Test Cases</source>
         <translation>貼上測資點</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="233"/>
+        <location filename="../src/Widgets/TestCases.cpp" line="236"/>
         <source>Copy Output to Expected</source>
         <translation>複製輸出至答案</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="238"/>
         <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
         <extracomment>Here &quot;checked&quot; means the checkbox is checked</extracomment>
         <translation>確定要複製所有核選的輸出至對應的答案？</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Ignore trailing spaces</source>
         <translation>忽略結尾的空格</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>Strictly the same</source>
         <translation>嚴格相同</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="256"/>
         <source>ncmp - Compare int64s</source>
         <translation>ncmp - 比對多個 int64</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="257"/>
         <source>rcmp4 - Compare doubles, max error 1e-4</source>
         <translation>rcmp4 - 比對雙精度浮點數（最大誤差 1e-4）</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="258"/>
         <source>rcmp6 - Compare doubles, max error 1e-6</source>
         <translation>rcmp6 - 比對雙精度浮點數（最大誤差 1e-6）</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>rcmp9 - Compare doubles, max error 1e-9</source>
         <translation>rcmp9 - 比對雙精度浮點數（最大誤差 1e-9）</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="259"/>
         <source>wcmp - Compare tokens</source>
         <translation>wcmp - 比對字串</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="260"/>
         <source>nyesno - Compare YES/NOs, case insensitive</source>
         <translation>nyesno - 比對 YES、NO（區分大小寫）</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="291"/>
         <source>Add Test Case</source>
         <translation>新增測資</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="292"/>
         <source>There are already %1 test cases, you can&apos;t add more.</source>
         <translation>已有 %1 筆測資，無法再新增。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="369"/>
         <source>Input #%1</source>
         <translation>輸入 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="370"/>
         <source>Expected #%1</source>
         <translation>答案 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="385"/>
         <source>Save Input #%1</source>
         <translation>儲存輸入 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="387"/>
         <source>Save Expected #%1</source>
         <translation>儲存答案 #%1</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/TestCases.cpp" line="403"/>
         <source>Load %1</source>
         <translation>載入 %1</translation>
     </message>
@@ -3576,26 +4467,32 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdatePresenter</name>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="38"/>
         <source>Download</source>
         <translation>下載</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="39"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="52"/>
         <source>New update available</source>
         <translation>更新可供使用</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="65"/>
         <source>A new %1 update &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won&apos;t miss the awesome new features and bug fixes.</source>
         <translation>%1更新 &lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt; 已可供使用。更新紀錄請見下方。&lt;br /&gt;我們非常建議讓編輯器保持最新版本，以享受酷酷的新功能及錯誤修正。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>beta</source>
         <translation>Beta</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdatePresenter.cpp" line="67"/>
         <source>stable</source>
         <translation>穩定版</translation>
     </message>
@@ -3603,30 +4500,37 @@ Not all vim commands are supported, please check https://github.com/cpeditor/Fak
 <context>
     <name>Widgets::UpdateProgressDialog</name>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="38"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="39"/>
         <source>Close this dialog and abort the update check</source>
         <translation>關閉此對話窗並中止更新檢查</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="47"/>
         <source>Update Checker</source>
         <translation>檢查更新幫手</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="57"/>
         <source>Fetching the list of releases...</source>
         <translation>取得版本列表中…</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="65"/>
         <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
         <translation>錯誤：%1&lt;br /&gt;&lt;br /&gt;檢查更新失敗。請到以下網站自行檢查更新&lt;br /&gt;&lt;a href=&quot;https://cpeditor.org/download&quot;&gt;https://cpeditor.org/download&lt;/a&gt; 或 &lt;a href=&quot;https://github.com/cpeditor/cpeditor/releases&quot;&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;。</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="75"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
+        <location filename="../src/Widgets/UpdateProgressDialog.cpp" line="76"/>
         <source>Hooray!! You are already using the latest release of CP Editor.</source>
         <translation>很棒喔！您使用的已經是最新版的 CP Editor。</translation>
     </message>


### PR DESCRIPTION
## Description
Added a new setting in `Preferences -> Appearance -> General` to enable or disable changing the editor font size using `Ctrl + Mouse Wheel`. 

Specific changes:
- Added `"Ctrl Scroll Zoom"` to `settings.json`.
- Registered the setting in the UI via `PreferencesWindow.cpp`.
- Updated `CodeEditor::wheelEvent` to check `SettingsManager::get("Ctrl Scroll Zoom").toBool()` before applying `zoomIn(1)` or `zoomOut(1)`.

## Related Issues / Pull Requests
Fixes #1249

## Motivation and Context
By default, CP Editor allows zooming with Ctrl+Scroll. However, this can often lead to accidental font resizing while navigating the code or scrolling quickly. This PR gives users the option to lock the font size by disabling this shortcut.

## How Has This Been Tested?
- Tested locally on Windows 11 (MSYS2 / MinGW 64-bit).
- Verified that toggling the checkbox immediately enables/disables the zoom behavior.
- Verified that normal scrolling (without Ctrl) works perfectly fine regardless of the setting.

## Screenshots (if appropriate)
<img width="1920" height="1080" alt="cpeditor_ALjMNcxvsU" src="https://github.com/user-attachments/assets/bc421ccd-2147-4d49-a0a2-a0cfbf6a2b54" />

## Checklist
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
Thank you for reviewing! Let me know if any further changes are required.