### PR TITLE
fix: Elide tab contents and update references to qt6 linguistic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ The translations are in the [translations](translations) directory. It's recomme
 
 If you want to add a new language, you can ask the developers for help. For example, you can open an issue for the language you want (it will be better if you can contribute the translations after we finish the preparation for you).
 
-If you want to go a step further: The translated strings are wrapped in `tr()` in the source codes. When the codes are changed, you can run [updateTranslation.sh](tools/updateTranslation.sh) or [updateTranslation.bat](tools/updateTranslation.bat) to update the translations. You can read [Qt Linguist Manual](https://doc.qt.io/qt-5/qtlinguist-index.html) if you are interested in it.
+If you want to go a step further: The translated strings are wrapped in `tr()` in the source codes. When the codes are changed, you can run [updateTranslation.sh](tools/updateTranslation.sh) or [updateTranslation.bat](tools/updateTranslation.bat) to update the translations. You can read [Qt Linguist Manual](https://doc.qt.io/qt-6/qtlinguist-index.html) if you are interested in it.
 
 ## The settings system
 

--- a/CONTRIBUTING_ja-JP.md
+++ b/CONTRIBUTING_ja-JP.md
@@ -34,7 +34,7 @@
 
 新しい言語を追加したい場合、開発者に助けを求めることができます。例えば、希望する言語について issue を開くことができます（私たちが準備を終えた後に、あなたが翻訳を提供してくれるとよりよいでしょう）。
 
-さらにもう一歩踏み込むなら 翻訳された文字列は、ソースコード中で `tr()` でラップされます。コードが変更されたら、 [updateTranslation.sh](tools/updateTranslation.sh) または [updateTranslation.bat](tools/updateTranslation.bat) を実行して翻訳を更新することができます。興味のある方は [Qt Linguist Manual](https://doc.qt.io/qt-5/qtlinguist-index.html) を読んでみてください。
+さらにもう一歩踏み込むなら 翻訳された文字列は、ソースコード中で `tr()` でラップされます。コードが変更されたら、 [updateTranslation.sh](tools/updateTranslation.sh) または [updateTranslation.bat](tools/updateTranslation.bat) を実行して翻訳を更新することができます。興味のある方は [Qt Linguist Manual](https://doc.qt.io/qt-6/qtlinguist-index.html) を読んでみてください。
 
 ## 設定システム
 

--- a/CONTRIBUTING_pt-BR.md
+++ b/CONTRIBUTING_pt-BR.md
@@ -35,7 +35,7 @@ As traduções estão no diretório [translations](translations). É recomendado
 
 Se quiser adicionar um novo idioma, peça ajuda aos desenvolvedores. Por exemplo, você pode abrir um problema solicitando o idioma desejado (será ainda melhor se você puder contribuir com as traduções após prepararmos tudo).
 
-Se quiser ir mais longe: As strings traduzidas estão envoltas em `tr()` no código-fonte. Quando o código é alterado, você pode executar [updateTranslation.sh](tools/updateTranslation.sh) ou [updateTranslation.bat](tools/updateTranslation.bat) para atualizar as traduções. Leia o [Manual do Qt Linguist](https://doc.qt.io/qt-5/qtlinguist-index.html) se estiver interessado.
+Se quiser ir mais longe: As strings traduzidas estão envoltas em `tr()` no código-fonte. Quando o código é alterado, você pode executar [updateTranslation.sh](tools/updateTranslation.sh) ou [updateTranslation.bat](tools/updateTranslation.bat) para atualizar as traduções. Leia o [Manual do Qt Linguist](https://doc.qt.io/qt-6/qtlinguist-index.html) se estiver interessado.
 
 ## O sistema de configurações
 

--- a/CONTRIBUTING_ru-RU.md
+++ b/CONTRIBUTING_ru-RU.md
@@ -34,7 +34,7 @@ The translations are in the [translations](translations) directory. It's recomme
 
 If you want to add a new language, you can ask the developers for help. For example, you can open an issue for the language you want (it will be better if you can contribute the translations after we finish the preparation for you).
 
-If you want to go a step further: The translated strings are wrapped in `tr()` in the source codes. When the codes are changed, you can run [updateTranslation.sh](tools/updateTranslation.sh) or [updateTranslation.bat](tools/updateTranslation.bat) to update the translations. You can read [Qt Linguist Manual](https://doc.qt.io/qt-5/qtlinguist-index.html) if you are interested in it.
+If you want to go a step further: The translated strings are wrapped in `tr()` in the source codes. When the codes are changed, you can run [updateTranslation.sh](tools/updateTranslation.sh) or [updateTranslation.bat](tools/updateTranslation.bat) to update the translations. You can read [Qt Linguist Manual](https://doc.qt.io/qt-6/qtlinguist-index.html) if you are interested in it.
 
 ## The settings system
 

--- a/CONTRIBUTING_zh-CN.md
+++ b/CONTRIBUTING_zh-CN.md
@@ -32,7 +32,7 @@
 
 翻译文本在 [translations](translations) 文件夹中。你应当用 Qt Linguist 编辑它们。只不过，如果你只是想修正一个笔误，你可以使用任何文本编辑器。在 Qt Linguist 中，当你完成了一条翻译，你可以按 <kbd>Ctrl + Enter</kbd> 来把当前条目标记为已完成并跳转到下一个未完成的条目。如果一个条目不需要翻译（例如，"C++"），你只需将翻译留空即可。你应当修复所有在 Qt Linguist 中显示的警告。
 
-如果你想更深入地了解：需翻译的文本在源代码中用 `tr()` 括起；在代码改变后，你可以运行 [updateTranslation.sh](tools/updateTranslation.sh) 或 [updateTranslation.bat](tools/updateTranslation.bat) 来更新翻译文本。如果感兴趣的话，你可以阅读 [Qt Linguist 使用手册](https://doc.qt.io/qt-5/qtlinguist-index.html)。
+如果你想更深入地了解：需翻译的文本在源代码中用 `tr()` 括起；在代码改变后，你可以运行 [updateTranslation.sh](tools/updateTranslation.sh) 或 [updateTranslation.bat](tools/updateTranslation.bat) 来更新翻译文本。如果感兴趣的话，你可以阅读 [Qt Linguist 使用手册](https://doc.qt.io/qt-6/qtlinguist-index.html)。
 
 ## 设置系统
 

--- a/CONTRIBUTING_zh-TW.md
+++ b/CONTRIBUTING_zh-TW.md
@@ -35,7 +35,7 @@
 
 若您想要加上新語言，可以向開發者們尋求協助，舉例來說，您可以提出議題來討論欲翻譯的語言（若您可以等候我們做好前期準備，再開始提交檔案，這會是個較好的做法）。
 
-若您想更進一步：翻譯的字串被包在原始碼中的 `tr()`，當原始碼變更，您可以執行 [updateTranslation.sh](tools/updateTranslation.sh) 或 [updateTranslation.bat](tools/updateTranslation.bat) 來更新翻譯內容。如果您對此感興趣，可以閱讀 [Qt Linguist 使用手冊](https://doc.qt.io/qt-5/qtlinguist-index.html)。
+若您想更進一步：翻譯的字串被包在原始碼中的 `tr()`，當原始碼變更，您可以執行 [updateTranslation.sh](tools/updateTranslation.sh) 或 [updateTranslation.bat](tools/updateTranslation.bat) 來更新翻譯內容。如果您對此感興趣，可以閱讀 [Qt Linguist 使用手冊](https://doc.qt.io/qt-6/qtlinguist-index.html)。
 
 ## 設定
 

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -167,6 +167,9 @@ void AppWindow::finishConstruction()
         openTab("");
     ui->tabWidget->tabBar()->installEventFilter(this);
 
+    // Prevent horizontal overflow when many tabs are open
+    ui->tabWidget->tabBar()->setExpanding(false);
+
 #ifdef Q_OS_WIN
     // This is necessary because of setWindowOpacity(0.99) earlier
     if (SettingsHelper::getOpacity() == 100)

--- a/ui/appwindow.ui
+++ b/ui/appwindow.ui
@@ -21,7 +21,7 @@
        <enum>QTabWidget::Triangular</enum>
       </property>
       <property name="elideMode">
-       <enum>Qt::ElideNone</enum>
+       <enum>Qt::ElideMiddle</enum>
       </property>
       <property name="documentMode">
        <bool>false</bool>


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->

Attempting to fix #1479 

## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [ ] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
