### PR TITLE
i18n: add Hindi translation and fix duplicated search keyword. Fixes #664

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+-   Add Hindi translation for Application (`hi_IN.ts`)
 -   Add vim emulation with [custom commands](https://cpeditor.org/docs/preferences/code-edit/#custom-vim-commands). (#220 and #1270)
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ qt_standard_project_setup(I18N_TRANSLATED_LANGUAGES el_GR es_MX pt_BR ru_RU zh_C
 set(TS_FILES
     translations/el_GR.ts
     translations/es_MX.ts
+    translations/hi_IN.ts
     translations/pt_BR.ts
     translations/ru_RU.ts
     translations/zh_CN.ts

--- a/src/Core/Translator.cpp
+++ b/src/Core/Translator.cpp
@@ -26,13 +26,15 @@ namespace Core
 {
 const static QMap<QString, QString> locales = {
     {"Νέα Ελληνικά", "el_GR"}, {"Español", "es_MX"},  {"Português brasileiro", "pt_BR"},
-    {"Русский", "ru_RU"},      {"简体中文", "zh_CN"}, {"正體中文", "zh_TW"}};
+    {"Русский", "ru_RU"},      {"简体中文", "zh_CN"}, {"正體中文", "zh_TW"},
+    {"हिन्दी", "hi_IN"}};
 
 const static QMap<QString, QString> suffixes = {{"el_GR", ""},       {"es_MX", ""},       {"pt_BR", "_pt-BR"},
-                                                {"ru_RU", "_ru-RU"}, {"zh_CN", "_zh-CN"}, {"zh_TW", "_zh-TW"}};
+                                                {"ru_RU", "_ru-RU"}, {"zh_CN", "_zh-CN"}, {"zh_TW", "_zh-TW"},
+                                                {"hi_IN", ""}};
 
-const static QMap<QString, QString> code = {{"el_GR", ""},   {"es_MX", ""},   {"pt_BR", ""},
-                                            {"ru_RU", "ru"}, {"zh_CN", "zh"}, {"zh_TW", "zh_TW"}};
+const static QMap<QString, QString> code = {{"el_GR", ""},   {"es_MX", ""},      {"pt_BR", ""},  {"ru_RU", "ru"},
+                                            {"zh_CN", "zh"}, {"zh_TW", "zh_TW"}, {"hi_IN", "hi"}};
 
 QTranslator *Translator::translator = nullptr;
 

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -1002,7 +1002,7 @@
     "type": "QString",
     "ui": "QComboBox",
     "default": "system",
-    "param": "QStringList { \"system\", \"Νέα Ελληνικά\", \"English\", \"Español\", \"Português brasileiro\", \"Русский\", \"简体中文\", \"正體中文\" }",
+    "param": "QStringList { \"system\", \"Νέα Ελληνικά\", \"English\", \"हिन्दी\", \"Español\", \"Português brasileiro\", \"Русский\", \"简体中文\", \"正體中文\" }",
     "tip": "The language displayed in the UI.",
     "onApply": "Core::Translator::setLocale(); QMessageBox::warning(parent, tr(\"Change Locale\"), tr(\"You need to restart the application to completely apply the locale change.\"));"
   },

--- a/translations/hi_IN.ts
+++ b/translations/hi_IN.ts
@@ -1,0 +1,3615 @@
+<?xml version='1.0' encoding='utf-8'?>
+<TS version="2.1" language="hi_IN">
+<context>
+    <name>AppWindow</name>
+    <message>
+        <source>Open Recent Files</source>
+        <translation>ओपन रीसेंट फाइल्स</translation>
+    </message>
+    <message>
+        <source>No file is opened recently</source>
+        <translation>हाल ही में कोई फाइल ओपन नहीं की गई है</translation>
+    </message>
+    <message>
+        <source>Clear Recent Files</source>
+        <translation>हालिया फ़ाइलें साफ़ करें</translation>
+    </message>
+    <message>
+        <source>Hot Exit</source>
+        <translation>हॉट एग्जिट</translation>
+    </message>
+    <message>
+        <source>In the last session, CP Editor was abnormally killed, do you want to restore the last session?</source>
+        <translation>पिछले सेशन में, CP Editor अचानक बंद हो गया था, क्या आप पिछला सेशन रीस्टोर करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Show Main Window</source>
+        <translation>मुख्य विंडो दिखाएं</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>परिचय</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>बाहर निकलें</translation>
+    </message>
+    <message>
+        <source>Opening Files</source>
+        <translation>फ़ाइलें ओपन करना</translation>
+    </message>
+    <message>
+        <source>About CP Editor %1</source>
+        <translation>CP Editor %1 के बारे में</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; is a native Qt-based code editor. It's specially designed for competitive programming, unlike other editors/IDEs which are mainly for developers. It helps you focus on your algorithm and automates the compilation, executing and testing. It even fetches test cases for you from different platforms and submits solutions to Codeforces!&lt;/p&gt;&lt;p&gt;Copyright (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. The source code for CP Editor is available at &lt;a href="https://github.com/cpeditor/cpeditor"&gt; https://github.com/cpeditor/cpeditor&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;b&gt;CP Editor&lt;/b&gt; एक नेटिव Qt-आधारित कोड एडिटर है। इसे विशेष रूप से कॉम्पिटिटिव प्रोग्रामिंग के लिए डिज़ाइन किया गया है, जो अन्य एडिटर्स/IDE से अलग है जो मुख्य रूप से डेवलपर्स के लिए होते हैं। यह आपको अपने एल्गोरिदम पर ध्यान केंद्रित करने में मदद करता है और कंपाइलेशन, एग्जीक्यूटिंग और टेस्टिंग को ऑटोमेट करता है। यह आपके लिए विभिन्न प्लेटफॉर्म्स से टेस्ट केसेस भी फेच करता है और Codeforces पर सॉल्यूशन्स सबमिट करता है!&lt;/p&gt;&lt;p&gt;कॉपीराइट (C) 2019-2021 Ashar Khan &amp;lt;ashar786khan@gmail.com&amp;gt;&lt;/p&gt;&lt;p&gt;यह एक फ्री सॉफ्टवेयर है; कॉपी करने की शर्तों के लिए सोर्स देखें। इसकी कोई वारंटी नहीं है; यहाँ तक कि मर्चेंटेबिलिटी या किसी विशेष उद्देश्य के लिए फिटनेस के लिए भी नहीं। CP Editor का सोर्स कोड &lt;a href="https://github.com/cpeditor/cpeditor"&gt;https://github.com/cpeditor/cpeditor&lt;/a&gt; पर उपलब्ध है।&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Build Info</source>
+        <translation>बिल्ड जानकारी</translation>
+    </message>
+    <message>
+        <source>App version: %1
+Build type: %2
+Git commit hash: %3
+Build time: %4
+OS: %5</source>
+        <translation>ऐप वर्ज़न: %1
+बिल्ड टाइप: %2
+गिट कमिट हैश: %3
+बिल्ड टाइम: %4
+OS: %5</translation>
+    </message>
+    <message>
+        <source>Portable Version</source>
+        <translation>पोर्टेबल वर्ज़न</translation>
+    </message>
+    <message>
+        <source>Setup Version</source>
+        <translation>सेटअप वर्ज़न</translation>
+    </message>
+    <message>
+        <source>Open Files</source>
+        <translation>फ़ाइलें खोलें</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>सेव करें</translation>
+    </message>
+    <message>
+        <source>Save All</source>
+        <translation>सब सेव करें</translation>
+    </message>
+    <message>
+        <source>Reset preferences</source>
+        <translation>प्रिफरेंसेज रीसेट करें</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to reset the all preferences to default?</source>
+        <translation>क्या आप वाकई सभी प्रेफरेंस को डिफ़ॉल्ट पर रीसेट करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Export settings to a file</source>
+        <translation>सेटिंग्स को एक फ़ाइल में एक्सपोर्ट करें</translation>
+    </message>
+    <message>
+        <source>CP Editor Settings File</source>
+        <translation>सीपी एडिटर सेटिंग्स फाइल</translation>
+    </message>
+    <message>
+        <source>Import Settings</source>
+        <translation>इंपोर्ट सेटिंग्स</translation>
+    </message>
+    <message>
+        <source>All current settings will lose after importing settings from a file. Are you sure to continue?</source>
+        <translation>किसी फ़ाइल से सेटिंग्स इम्पोर्ट करने के बाद सभी वर्तमान सेटिंग्स खो जाएंगी। क्या आप जारी रखने के लिए सुनिश्चित हैं?</translation>
+    </message>
+    <message>
+        <source>Import settings from a file</source>
+        <translation>एक फाइल से सेटिंग्स इंपोर्ट करें</translation>
+    </message>
+    <message>
+        <source>Export current session to a file</source>
+        <translation>वर्तमान सेशन को एक फ़ाइल में एक्सपोर्ट करें</translation>
+    </message>
+    <message>
+        <source>CP Editor Session File</source>
+        <translation>सीपी एडिटर सेशन फाइल</translation>
+    </message>
+    <message>
+        <source>Export Session</source>
+        <translation>एक्सपोर्ट सेशन</translation>
+    </message>
+    <message>
+        <source>Failed to export the current session to [%1]</source>
+        <translation>वर्तमान सेशन को [%1] पर एक्सपोर्ट करने में विफल रहा।</translation>
+    </message>
+    <message>
+        <source>Load Session</source>
+        <translation>लोड सेशन</translation>
+    </message>
+    <message>
+        <source>Loading a session from a file will close all tabs in the current session without saving the files. Are you sure to continue?</source>
+        <translation>फाइल से सेशन लोड करने पर वर्तमान सेशन के सभी टैब सेव किए बिना बंद हो जाएंगे। क्या आप आगे बढ़ना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Load session from a file</source>
+        <translation>एक फाइल से सेशन लोड करें</translation>
+    </message>
+    <message>
+        <source>CP Editor: An editor specially designed for competitive programming</source>
+        <translation>CP Editor: कॉम्पिटिटिव प्रोग्रामिंग के लिए विशेष रूप से डिज़ाइन किया गया एक एडिटर</translation>
+    </message>
+    <message>
+        <source>Snippets</source>
+        <translation>स्निपेट्स</translation>
+    </message>
+    <message>
+        <source>There are no snippets for %1. Please add snippets in the preference window.</source>
+        <translation>%1 के लिए कोई स्निपेट्स नहीं हैं। कृपया प्रेफरेंस विंडो में स्निपेट्स जोड़ें।</translation>
+    </message>
+    <message>
+        <source>Use Snippets</source>
+        <translation>स्निपेट्स का उपयोग करें</translation>
+    </message>
+    <message>
+        <source>Choose a snippet:</source>
+        <translation>एक स्निपेट चुनें:</translation>
+    </message>
+    <message>
+        <source>There is no snippet named %1 for %2</source>
+        <translation>%2 के लिए %1 नाम का कोई स्निपेट नहीं है</translation>
+    </message>
+    <message>
+        <source>How to exit full-screen</source>
+        <translation>फुल-स्क्रीन से एग्जिट कैसे करें</translation>
+    </message>
+    <message>
+        <source>Press F11 key to exit full-screen mode.</source>
+        <translation>फुल-स्क्रीन मोड से बाहर निकलने के लिए F11 की (key) दबाएं।</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>क्लोज़</translation>
+    </message>
+    <message>
+        <source>Close Others</source>
+        <translation>क्लोज अदर्स</translation>
+    </message>
+    <message>
+        <source>Close to the Left</source>
+        <translation>बाईं ओर क्लोज करें</translation>
+    </message>
+    <message>
+        <source>Close to the Right</source>
+        <translation>राइट के क्लोज़</translation>
+    </message>
+    <message>
+        <source>Close Saved</source>
+        <translation>क्लोज सेव्ड</translation>
+    </message>
+    <message>
+        <source>Close All</source>
+        <translation>क्लोज ऑल</translation>
+    </message>
+    <message>
+        <source>Duplicate Tab</source>
+        <translation>डुप्लिकेट टैब</translation>
+    </message>
+    <message>
+        <source>Set Compile Command</source>
+        <translation>कम्पाइल कमांड सेट करें</translation>
+    </message>
+    <message>
+        <source>Set Time Limit</source>
+        <translation>टाइम लिमिट सेट करें</translation>
+    </message>
+    <message>
+        <source>Source File</source>
+        <translation>सोर्स फ़ाइल</translation>
+    </message>
+    <message>
+        <source>Executable File</source>
+        <translation>एक्जीक्यूटेबल फाइल</translation>
+    </message>
+    <message>
+        <source>Copy File Path</source>
+        <translation>कॉपी फ़ाइल पाथ</translation>
+    </message>
+    <message>
+        <source>Open Problem in Browser</source>
+        <translation>ब्राउज़र में प्रॉब्लम ओपन करें</translation>
+    </message>
+    <message>
+        <source>Copy Problem URL</source>
+        <translation>कॉपी प्रॉब्लम URL</translation>
+    </message>
+    <message>
+        <source>Set Codeforces URL</source>
+        <translation>कोडफोर्सेस (Codeforces) यूआरएल (URL) सेट करें</translation>
+    </message>
+    <message>
+        <source>Set CF URL</source>
+        <translation>CF URL सेट करें</translation>
+    </message>
+    <message>
+        <source>Enter the contest ID:</source>
+        <translation>कॉन्टेस्ट ID दर्ज करें:</translation>
+    </message>
+    <message>
+        <source>Enter the problem Code (A-Z):</source>
+        <translation>प्रॉब्लम कोड (A-Z) दर्ज करें:</translation>
+    </message>
+    <message>
+        <source>Set Problem URL</source>
+        <translation>प्रॉब्लम URL सेट करें</translation>
+    </message>
+    <message>
+        <source>Enter the new problem URL:</source>
+        <translation>नया प्रॉब्लम URL दर्ज करें:</translation>
+    </message>
+    <message>
+        <source>EventLogger</source>
+        <translation>इवेंटलॉगर</translation>
+    </message>
+    <message>
+        <source>All logs except for current session has been deleted</source>
+        <translation>वर्तमान सेशन को छोड़कर सभी लॉग्स डिलीट कर दिए गए हैं।</translation>
+    </message>
+    <message>
+        <source>New File</source>
+        <translation>न्यू फाइल</translation>
+    </message>
+    <message>
+        <source>Open a new tab in the editor</source>
+        <translation>एडिटर में एक नया टैब ओपन करें</translation>
+    </message>
+    <message>
+        <source>Generator</source>
+        <translation>जेनरेटर</translation>
+    </message>
+    <message>
+        <source>Open a new tab with generator template</source>
+        <translation>जेनरेटर टेम्प्लेट के साथ एक नई टैब खोलें</translation>
+    </message>
+    <message>
+        <source>C++</source>
+        <translation>C++</translation>
+    </message>
+    <message>
+        <source>Open a new tab with C++ template</source>
+        <translation>C++ टेम्पलेट के साथ एक नया टैब ओपन करें</translation>
+    </message>
+    <message>
+        <source>Java</source>
+        <translation>जावा</translation>
+    </message>
+    <message>
+        <source>Open a new tab with Java template</source>
+        <translation>Java टेम्पलेट के साथ एक नया टैब ओपन करें</translation>
+    </message>
+    <message>
+        <source>Python</source>
+        <translation>पायथन</translation>
+    </message>
+    <message>
+        <source>Open a new tab with Python template</source>
+        <translation>Python टेम्पलेट के साथ एक नया टैब ओपन करें</translation>
+    </message>
+    <message>
+        <source>Save the file on the disk</source>
+        <translation>फ़ाइल को डिस्क पर सेव करें</translation>
+    </message>
+    <message>
+        <source>Save As...</source>
+        <translation>सेव ऐज़...</translation>
+    </message>
+    <message>
+        <source>Save as new file</source>
+        <translation>नई फ़ाइल के रूप में सेव करें</translation>
+    </message>
+    <message>
+        <source>Save all opened files</source>
+        <translation>सभी ओपन की गई फाइल्स को सेव करें</translation>
+    </message>
+    <message>
+        <source>Close Current</source>
+        <translation>करंट क्लोज करें</translation>
+    </message>
+    <message>
+        <source>Close current tab</source>
+        <translation>वर्तमान टैब क्लोज़ करें</translation>
+    </message>
+    <message>
+        <source>Close saved tabs</source>
+        <translation>सेव्ड टैब्स बंद करें</translation>
+    </message>
+    <message>
+        <source>Close All the tabs</source>
+        <translation>सभी टैब्स बंद करें</translation>
+    </message>
+    <message>
+        <source>Quit the application</source>
+        <translation>एप्लीकेशन क्विट करें</translation>
+    </message>
+    <message>
+        <source>Open File...</source>
+        <translation>ओपन फाइल...</translation>
+    </message>
+    <message>
+        <source>Open files</source>
+        <translation>ओपन फाइल्स</translation>
+    </message>
+    <message>
+        <source>Open Contest...</source>
+        <translation>ओपन कॉन्टेस्ट...</translation>
+    </message>
+    <message>
+        <source>Open a Contest</source>
+        <translation>ओपन अ कॉन्टेस्ट</translation>
+    </message>
+    <message>
+        <source>Indent</source>
+        <translation>इंडेंट</translation>
+    </message>
+    <message>
+        <source>Unindent</source>
+        <translation>अनइंडेंट</translation>
+    </message>
+    <message>
+        <source>Swap Line Up</source>
+        <translation>स्वैप लाइन अप</translation>
+    </message>
+    <message>
+        <source>Swap Line Down</source>
+        <translation>स्वैप लाइन डाउन</translation>
+    </message>
+    <message>
+        <source>Duplicate Line</source>
+        <translation>डुप्लिकेट लाइन</translation>
+    </message>
+    <message>
+        <source>Delete Line</source>
+        <translation>डिलीट लाइन</translation>
+    </message>
+    <message>
+        <source>Toggle Comment</source>
+        <translation>टोगल कमेंट</translation>
+    </message>
+    <message>
+        <source>Toggle Block Comment</source>
+        <translation>टॉगल ब्लॉक कमेंट</translation>
+    </message>
+    <message>
+        <source>Compile</source>
+        <translation>कंपाइल</translation>
+    </message>
+    <message>
+        <source>Compile and Run</source>
+        <translation>कंपाइल एंड रन</translation>
+    </message>
+    <message>
+        <source>Run</source>
+        <translation>रन</translation>
+    </message>
+    <message>
+        <source>Format code</source>
+        <translation>फॉर्मेट कोड</translation>
+    </message>
+    <message>
+        <source>Run Detached</source>
+        <translation>रन डिटैच्ड</translation>
+    </message>
+    <message>
+        <source>Kill Processes</source>
+        <translation>किल प्रोसेसेज</translation>
+    </message>
+    <message>
+        <source>Find and Replace</source>
+        <translation>फाइंड एंड रिप्लेस</translation>
+    </message>
+    <message>
+        <source>Use Snippet...</source>
+        <translation>स्निपेट का उपयोग करें...</translation>
+    </message>
+    <message>
+        <source>Stress Testing...</source>
+        <translation>स्ट्रेस टेस्टिंग...</translation>
+    </message>
+    <message>
+        <source>Preferences</source>
+        <translation>प्रेफरेंसेज</translation>
+    </message>
+    <message>
+        <source>Reset Settings</source>
+        <translation>रीसेट सेटिंग्स</translation>
+    </message>
+    <message>
+        <source>Export Settings...</source>
+        <translation>एक्सपोर्ट सेटिंग्स...</translation>
+    </message>
+    <message>
+        <source>Import Settings...</source>
+        <translation>सेटिंग्स इम्पोर्ट करें...</translation>
+    </message>
+    <message>
+        <source>Export Session...</source>
+        <translation>एक्सपोर्ट सेशन...</translation>
+    </message>
+    <message>
+        <source>Load Session...</source>
+        <translation>लोड सेशन...</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation>मैनुअल</translation>
+    </message>
+    <message>
+        <source>Report issues</source>
+        <translation>इश्यूज़ रिपोर्ट करें</translation>
+    </message>
+    <message>
+        <source>About Qt</source>
+        <translation>Qt के बारे में</translation>
+    </message>
+    <message>
+        <source>Check for updates</source>
+        <translation>अपडेट्स के लिए चेक करें</translation>
+    </message>
+    <message>
+        <source>Support us</source>
+        <translation>सपोर्ट अस</translation>
+    </message>
+    <message>
+        <source>Editor Mode</source>
+        <translation>एडिटर मोड</translation>
+    </message>
+    <message>
+        <source>IO Mode</source>
+        <translation>आईओ मोड</translation>
+    </message>
+    <message>
+        <source>Split Mode</source>
+        <translation>स्प्लिट मोड</translation>
+    </message>
+    <message>
+        <source>Full Screen</source>
+        <translation>फुल स्क्रीन</translation>
+    </message>
+    <message>
+        <source>Show Log Files</source>
+        <translation>लॉग फाइल्स दिखाएं</translation>
+    </message>
+    <message>
+        <source>Delete Log Files</source>
+        <translation>लॉग फाइल्स डिलीट करें</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>फ़ाइल (&amp;F)</translation>
+    </message>
+    <message>
+        <source>New File From Template</source>
+        <translation>टेम्पलेट से नई फाइल</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>&amp;एडिट</translation>
+    </message>
+    <message>
+        <source>&amp;Actions</source>
+        <translation>&amp;एक्शन्स</translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation>&amp;व्यू</translation>
+    </message>
+    <message>
+        <source>&amp;Options</source>
+        <translation>"&amp;ऑप्शन्स"</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;हेल्प</translation>
+    </message>
+</context>
+<context>
+    <name>CodeSnippetsPage</name>
+    <message>
+        <source>Search...</source>
+        <translation>सर्च...</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>ऐड</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>डेल</translation>
+    </message>
+    <message>
+        <source>Rename Snippet</source>
+        <translation>रीनेम स्निपेट</translation>
+    </message>
+    <message>
+        <source>Load Snippets From Files</source>
+        <translation>फाइलों से स्निपेट्स लोड करें</translation>
+    </message>
+    <message>
+        <source>Extract Snippets To Files</source>
+        <translation>स्निपेट्स को फाइल्स में एक्सट्रैक्ट करें</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation>मोर</translation>
+    </message>
+    <message>
+        <source>No Snippet Selected</source>
+        <translation>कोई स्निपेट सिलेक्टेड नहीं है</translation>
+    </message>
+    <message>
+        <source>Unsaved Snippets</source>
+        <translation>अनसेव्ड स्निपेट्स</translation>
+    </message>
+    <message>
+        <source>The snippet [%1] has been changed. Do you want to save it or discard the changes?</source>
+        <translation>स्निपेट [%1] बदल दिया गया है। क्या आप इसे सेव करना चाहते हैं या बदलावों को डिस्कार्ड करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Delete Snippet</source>
+        <translation>स्निपेट डिलीट करें</translation>
+    </message>
+    <message>
+        <source>Do you really want to delete the snippet [%1]?</source>
+        <translation>क्या आप वाकई स्निपेट [%1] को डिलीट करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Load Snippets</source>
+        <translation>लोड स्निपेट्स</translation>
+    </message>
+    <message>
+        <source>Failed to open [%1]. Do I have read permission?</source>
+        <translation>[%1] को ओपन करने में विफल। क्या मेरे पास रीड परमिशन है?</translation>
+    </message>
+    <message>
+        <source>Extract Snippets</source>
+        <translation>एक्सट्रैक्ट स्निपेट्स</translation>
+    </message>
+    <message>
+        <source>Extract Snippets: %1</source>
+        <translation>एक्सट्रैक्ट स्निपेट्स: %1</translation>
+    </message>
+    <message>
+        <source>Failed to write to [%1]. Do I have write permission?</source>
+        <translation>[%1] में लिखने में विफल रहा। क्या मेरे पास राइट परमिशन है?</translation>
+    </message>
+    <message>
+        <source>Snippet name can't be empty.
+</source>
+        <translation>स्निपेट नेम खाली नहीं हो सकता।</translation>
+    </message>
+    <message>
+        <source>Snippet Name Conflict</source>
+        <translation>स्निपेट नेम कॉन्फ्लिक्ट</translation>
+    </message>
+    <message>
+        <source>The name "%1" is already in use. Do you want to override it? (The old snippet with this name will be deleted.)</source>
+        <translation>"%1" नाम पहले से उपयोग में है। क्या आप इसे ओवरराइड करना चाहते हैं? (इस नाम वाला पुराना स्निपेट डिलीट हो जाएगा।)</translation>
+    </message>
+    <message>
+        <source>The name "%1" is already in use.
+</source>
+        <translation>"%1" नाम पहले से ही उपयोग में है।</translation>
+    </message>
+    <message>
+        <source>Add Snippet</source>
+        <translation>ऐड स्निपेट</translation>
+    </message>
+    <message>
+        <source>New Snippet Name:</source>
+        <translation>न्यू स्निपेट नेम:</translation>
+    </message>
+</context>
+<context>
+    <name>Core::Checker</name>
+    <message>
+        <source>Read Checker</source>
+        <translation>रीड चेकर</translation>
+    </message>
+    <message>
+        <source>Checker</source>
+        <translation>चेकर</translation>
+    </message>
+    <message>
+        <source>Failed to create temporary directory</source>
+        <translation>टेंपरेरी डायरेक्टरी बनाने में विफल</translation>
+    </message>
+    <message>
+        <source>Read testlib.h</source>
+        <translation>testlib.h पढ़ें</translation>
+    </message>
+    <message>
+        <source>Save testlib.h</source>
+        <translation>testlib.h को सेव करें</translation>
+    </message>
+    <message>
+        <source>Started compiling the checker</source>
+        <translation>चेकर को कंपाइल करना शुरू किया</translation>
+    </message>
+    <message>
+        <source>The checker is compiled</source>
+        <translation>चेकर कंपाइल हो गया है</translation>
+    </message>
+    <message>
+        <source>Error occurred while compiling the checker:
+%1</source>
+        <translation>चेकर को कंपाइल (compile) करते समय त्रुटि हुई:
+%1</translation>
+    </message>
+    <message>
+        <source>Failed to compile the checker: %1</source>
+        <translation>चेकर को कंपाइल करने में विफल: %1</translation>
+    </message>
+    <message>
+        <source>Time Limit Exceeded</source>
+        <translation>टाइम लिमिट एक्सीडेड</translation>
+    </message>
+    <message>
+        <source>Checker exited with exit code %1</source>
+        <translation>चेकर %1 एग्जिट कोड के साथ एग्जिट हो गया।</translation>
+    </message>
+    <message>
+        <source>Checker exited with unknown exit code %1</source>
+        <translation>चेकर %1 अननोन एग्जिट कोड के साथ एग्जिट हो गया।</translation>
+    </message>
+    <message>
+        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
+        <translation>टेस्टकेस #%2 पर चल रही प्रोसेस का %1, %3 कैरेक्टर्स से अधिक है, जो आउटपुट लेंथ लिमिट से लंबा है, इसलिए प्रोसेस को किल कर दिया गया है। आप %4 पर आउटपुट लेंथ लिमिट को बदल सकते हैं।</translation>
+    </message>
+    <message>
+        <source>The checker is killed</source>
+        <translation>चेकर को किल कर दिया गया है</translation>
+    </message>
+    <message>
+        <source>Checker[%1]</source>
+        <translation>चेकर[%1]</translation>
+    </message>
+    <message>
+        <source>The source code of the checker has changed, recompiling...</source>
+        <translation>चेकर का सोर्स कोड बदल गया है, री-कंपाइल हो रहा है...</translation>
+    </message>
+</context>
+<context>
+    <name>Core::Compiler</name>
+    <message>
+        <source>The source file [%1] doesn't exist</source>
+        <translation>सोर्स फाइल [%1] मौजूद नहीं है।</translation>
+    </message>
+    <message>
+        <source>%1 is empty</source>
+        <translation>%1 खाली है</translation>
+    </message>
+    <message>
+        <source>Unsupported programming language "%1"</source>
+        <translation>असमर्थित प्रोग्रामिंग लैंग्वेज "%1"</translation>
+    </message>
+    <message>
+        <source>Failed to start the compiler. Please check %1 or add the compiler in the PATH environment variable.</source>
+        <translation>कंपाइलर शुरू करने में विफल रहा। कृपया %1 की जाँच करें या PATH एनवायरनमेंट वेरिएबल में कंपाइलर जोड़ें।</translation>
+    </message>
+</context>
+<context>
+    <name>Core::Runner</name>
+    <message>
+        <source>The source file %1 doesn't exist.</source>
+        <translation>सोर्स फाइल %1 मौजूद नहीं है।</translation>
+    </message>
+    <message>
+        <source>Failed to get run command. It's probably a bug.</source>
+        <translation>रन कमांड प्राप्त करने में विफल। यह संभवतः एक बग है।</translation>
+    </message>
+    <message>
+        <source>Failed to create temporary file.</source>
+        <translation>टेम्परेरी फाइल बनाने में विफल।</translation>
+    </message>
+    <message>
+        <source>Program finished with exit code %1
+Press any key to exit</source>
+        <translation>प्रोग्राम %1 एग्जिट कोड के साथ समाप्त हुआ
+बाहर निकलने के लिए कोई भी की (key) दबाएं</translation>
+    </message>
+    <message>
+        <source>Detached execution is not supported on your platform</source>
+        <translation>आपके प्लेटफॉर्म पर डिटैच्ड एक्जीक्यूशन समर्थित नहीं है।</translation>
+    </message>
+    <message>
+        <source>Failed to start detached execution. Please check your terminal emulator settings in %1.</source>
+        <translation>डिटैच्ड एग्जीक्यूशन शुरू करने में विफल। कृपया %1 में अपनी टर्मिनल एमुलेटर सेटिंग्स की जाँच करें।</translation>
+    </message>
+    <message>
+        <source>Failed to start running. Please compile first.</source>
+        <translation>रनिंग शुरू करने में विफल। कृपया पहले कंपाइल करें।</translation>
+    </message>
+</context>
+<context>
+    <name>Core::SessionManager</name>
+    <message>
+        <source>Restoring Last Session</source>
+        <translation>लास्ट सेशन रिस्टोर किया जा रहा है</translation>
+    </message>
+    <message>
+        <source>Restoring: [%1]</source>
+        <translation>रिस्टोरिंग: [%1]</translation>
+    </message>
+</context>
+<context>
+    <name>Editor::FakeVimCommands</name>
+    <message>
+        <source>`new` requires no argument or one of 'cpp', 'java' and 'python', got [%1]</source>
+        <translation>`new` के लिए किसी आर्ग्युमेंट की आवश्यकता नहीं है या 'cpp', 'java' और 'python' में से एक की आवश्यकता है, [%1] प्राप्त हुआ</translation>
+    </message>
+    <message>
+        <source>[%1] is not C++, Python or Java source file</source>
+        <translation>"[%1] C++, Python या Java सोर्स फाइल नहीं है"</translation>
+    </message>
+    <message>
+        <source>[%1] does not exist. To open a tab with a non-existing file, use `open!` instead</source>
+        <translation>[%1] मौजूद नहीं है। किसी ऐसी फाइल के साथ टैब खोलने के लिए जो मौजूद नहीं है, इसके बजाय `open!` का उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>[%1] is not a number</source>
+        <translation>"[%1] एक नंबर नहीं है"</translation>
+    </message>
+    <message>
+        <source>%1 is out of range [1, %2]</source>
+        <translation>"%1, [1, %2] की रेंज से बाहर है"</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation>लागू नहीं</translation>
+    </message>
+    <message>
+        <source>[%1] is not a valid view mode. It should be one of 'split' and 'edit'</source>
+        <translation>"[%1] एक वैध व्यू मोड नहीं है। इसे 'split' और 'edit' में से एक होना चाहिए"</translation>
+    </message>
+    <message>
+        <source>%1 is not a valid language name. It should be one of 'cpp', 'java' and 'python'</source>
+        <translation>"%1 एक वैध लैंग्वेज नाम नहीं है। इसे 'cpp', 'java' या 'python' में से कोई एक होना चाहिए"</translation>
+    </message>
+    <message>
+        <source>No active tab to change language</source>
+        <translation>भाषा बदलने के लिए कोई एक्टिव टैब नहीं है</translation>
+    </message>
+    <message>
+        <source>No active tab to clear messages</source>
+        <translation>मैसेज क्लियर करने के लिए कोई एक्टिव टैब नहीं है</translation>
+    </message>
+</context>
+<context>
+    <name>Extensions::CFTool</name>
+    <message>
+        <source>CF Tool</source>
+        <translation>सीएफ टूल</translation>
+    </message>
+    <message>
+        <source>CF Tool was killed</source>
+        <translation>CF टूल को किल्ड कर दिया गया है।</translation>
+    </message>
+    <message>
+        <source>The problem code is 0, now use A automatically. If the actual problem code is not A, please set the problem code manually in the right-click menu of the current tab.</source>
+        <translation>प्रॉब्लम कोड 0 है, अब ऑटोमैटिकली A का उपयोग करें। यदि वास्तविक प्रॉब्लम कोड A नहीं है, तो कृपया वर्तमान टैब के राइट-क्लिक मेनू में प्रॉब्लम कोड को मैन्युअल रूप से सेट करें।</translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CF Tool. Have you set the correct path to CF Tool in Preferences?</source>
+        <translation>CF टूल का वर्शन प्राप्त करने में विफल। क्या आपने प्रेफरेंस में CF टूल का सही पाथ सेट किया है?</translation>
+    </message>
+    <message>
+        <source>CF Tool has started</source>
+        <translation>CF टूल स्टार्ट हो गया है</translation>
+    </message>
+    <message>
+        <source>Failed to start CF Tool in 2 seconds. Have you set the correct path to CF Tool in Preferences?</source>
+        <translation>CF Tool को 2 सेकंड में स्टार्ट करने में विफल। क्या आपने प्रेफरेंसेज़ में CF Tool का सही पाथ सेट किया है?</translation>
+    </message>
+    <message>
+        <source>Failed to parse the URL [%1]</source>
+        <translation>URL [%1] को पार्स करने में विफल रहा</translation>
+    </message>
+    <message>
+        <source>CF Tool failed</source>
+        <translation>CF टूल फेल हो गया</translation>
+    </message>
+    <message>
+        <source>CF Tool finished with non-zero exit code %1</source>
+        <translation>CF टूल %1 नॉन-जीरो एग्जिट कोड के साथ समाप्त हुआ।</translation>
+    </message>
+    <message>
+        <source>Contest %1 Problem %2</source>
+        <translation>कॉन्टेस्ट %1 प्रॉब्लम %2</translation>
+    </message>
+</context>
+<context>
+    <name>Extensions::CodeFormatter</name>
+    <message>
+        <source>Formatter</source>
+        <translation>फॉर्मेटर</translation>
+    </message>
+    <message>
+        <source>Failed to create temporary directory</source>
+        <translation>टेम्परेरी डायरेक्टरी बनाने में विफल</translation>
+    </message>
+    <message>
+        <source>Formatting completed</source>
+        <translation>फॉर्मेटिंग पूरी हुई</translation>
+    </message>
+    <message>
+        <source>The format process didn't finish in 2 seconds. This is probably because the %1 program is not found by CP Editor. You can set the path to the program at %2.</source>
+        <translation>फॉर्मेट प्रोसेस 2 सेकंड में फिनिश नहीं हुई। यह शायद इसलिए है क्योंकि %1 प्रोग्राम CP Editor को नहीं मिल रहा है। आप %2 पर प्रोग्राम का पाथ सेट कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>The format command [%1 %2] finished with exit code %3.</source>
+        <translation>फॉर्मेट कमांड [%1 %2] एग्जिट कोड %3 के साथ समाप्त हुआ।</translation>
+    </message>
+    <message>
+        <source>Formatter[stdout]</source>
+        <translation>फॉर्मेटर[stdout]</translation>
+    </message>
+    <message>
+        <source>Formatter[stderr]</source>
+        <translation>फॉर्मेटर[stderr]</translation>
+    </message>
+    <message>
+        <source>The output of the format process is empty. Please ensure there is no in-place modification option in the formatting arguments.</source>
+        <translation>फॉर्मेट प्रक्रिया का आउटपुट खाली है। कृपया सुनिश्चित करें कि फॉर्मेटिंग आर्गुमेंट्स में कोई इन-प्लेस मॉडिफिकेशन विकल्प नहीं है।</translation>
+    </message>
+</context>
+<context>
+    <name>Extensions::CompanionServer</name>
+    <message>
+        <source>A %1 request is received and ignored</source>
+        <translation>एक %1 रिक्वेस्ट प्राप्त हुई और उसे इग्नोर कर दिया गया है</translation>
+    </message>
+    <message>
+        <source>The request received is not JSON</source>
+        <translation>प्राप्त अनुरोध JSON नहीं है।</translation>
+    </message>
+    <message>
+        <source>Server is closed</source>
+        <translation>सर्वर बंद है</translation>
+    </message>
+    <message>
+        <source>Port is set to %1</source>
+        <translation>पोर्ट को %1 पर सेट किया गया है</translation>
+    </message>
+    <message>
+        <source>Failed to listen to port %1. Is there another process listening?</source>
+        <translation>पोर्ट %1 पर लिसन करने में विफल। क्या कोई अन्य प्रोसेस लिसन कर रही है?</translation>
+    </message>
+    <message>
+        <source>JSON parser reported errors:
+%1</source>
+        <translation>JSON पार्सर ने एरर्स रिपोर्ट किए:
+%1</translation>
+    </message>
+    <message>
+        <source>Stopped Server</source>
+        <translation>स्टॉप्ड सर्वर</translation>
+    </message>
+</context>
+<context>
+    <name>Extensions::LanguageServer</name>
+    <message>
+        <source>Language Server [%1]</source>
+        <translation>लैंग्वेज सर्वर [%1]</translation>
+    </message>
+    <message>
+        <source>Language server sent an error. Please check log for details.</source>
+        <translation>लैंग्वेज सर्वर ने एक एरर भेजा। कृपया विवरण के लिए लॉग जांचें।</translation>
+    </message>
+    <message>
+        <source>Failed to start LSP Process. Have you set the path to the Language Server program at %1?</source>
+        <translation>LSP प्रोसेस स्टार्ट करने में विफल रहा। क्या आपने %1 पर लैंग्वेज सर्वर प्रोग्राम का पाथ सेट किया है?</translation>
+    </message>
+    <message>
+        <source>LSP Process timed out</source>
+        <translation>LSP प्रोसेस टाइम आउट हो गया</translation>
+    </message>
+    <message>
+        <source>LSP Process Read Error</source>
+        <translation>LSP प्रोसेस रीड एरर</translation>
+    </message>
+    <message>
+        <source>LSP Process Write Error</source>
+        <translation>एलएसपी प्रोसेस राइट एरर</translation>
+    </message>
+    <message>
+        <source>An unknown error has occurred in LSP Process</source>
+        <translation>LSP प्रोसेस में एक अननोन एरर हुई है</translation>
+    </message>
+</context>
+<context>
+    <name>FindReplaceDialog</name>
+    <message>
+        <source>Find/Replace</source>
+        <translation>फ़ाइंड/रिप्लेस</translation>
+    </message>
+</context>
+<context>
+    <name>FindReplaceForm</name>
+    <message>
+        <source>Form</source>
+        <translation>फॉर्म</translation>
+    </message>
+    <message>
+        <source>Find:</source>
+        <translation>फाइंड:</translation>
+    </message>
+    <message>
+        <source>Replace with:</source>
+        <translation>रिप्लेस विद:</translation>
+    </message>
+    <message>
+        <source>errorLabel</source>
+        <translation>एरर लेबल</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>डायरेक्शन</translation>
+    </message>
+    <message>
+        <source>Up</source>
+        <translation>अप</translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation>डाउन</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>ऑप्शन्स</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>केस सेंसिटिव</translation>
+    </message>
+    <message>
+        <source>Whole words only</source>
+        <translation>होल वर्ड्स ओनली</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;style type="text/css"&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;whether the text to search should be interpreted as a regular expression.&lt;/p&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;/p&gt;
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;You may want to take a look at the syntax of regular expressions:&lt;/p&gt;
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;a href="http://doc.trolltech.com/qregexp.html"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;style type="text/css"&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'Sans'; font-size:10pt; font-weight:400; font-style:normal;"&gt;
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;क्या सर्च किए जाने वाले टेक्स्ट को रेगुलर एक्सप्रेशन के रूप में इंटरप्रेट किया जाना चाहिए।&lt;/p&gt;
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;/p&gt;
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;आप रेगुलर एक्सप्रेशन्स के सिंटैक्स को देख सकते हैं:&lt;/p&gt;
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;a href="http://doc.trolltech.com/qregexp.html"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;http://doc.trolltech.com/qregexp.html&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Regular Expression</source>
+        <translation>रेगुलर एक्सप्रेशन</translation>
+    </message>
+    <message>
+        <source>Find</source>
+        <translation>फाइंड</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>रिप्लेस</translation>
+    </message>
+    <message>
+        <source>Replace All</source>
+        <translation>रिप्लेस ऑल</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>Auto Save</source>
+        <translation>ऑटो सेव</translation>
+    </message>
+    <message>
+        <source>Compiler</source>
+        <translation>कंपाइलर</translation>
+    </message>
+    <message>
+        <source>Please set the language</source>
+        <translation>कृपया लैंग्वेज सेट करें</translation>
+    </message>
+    <message>
+        <source>Runner</source>
+        <translation>रनर</translation>
+    </message>
+    <message>
+        <source>Wrong language, please set the language</source>
+        <translation>गलत लैंग्वेज, कृपया लैंग्वेज सेट करें</translation>
+    </message>
+    <message>
+        <source>All inputs are empty, nothing to run</source>
+        <translation>सभी इनपुट्स खाली हैं, रन करने के लिए कुछ नहीं है।</translation>
+    </message>
+    <message>
+        <source>Submit</source>
+        <translation>सबमिट</translation>
+    </message>
+    <message>
+        <source>Sure to submit</source>
+        <translation>सबमिट करने के लिए निश्चित हैं?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to Codeforces?
+
+ URL: %1
+ Language: %2</source>
+        <translation>क्या आप वाकई इस सॉल्यूशन को कोडफोर्सेस पर सबमिट करना चाहते हैं?
+
+यूआरएल: %1
+लैंग्वेज: %2</translation>
+    </message>
+    <message>
+        <source>CF Tool</source>
+        <translation>CF टूल</translation>
+    </message>
+    <message>
+        <source>Failed to save the temp file, and the solution is not submitted.</source>
+        <translation>टेम्प फाइल सेव करने में विफल रहा, और सॉल्यूशन सबमिट नहीं हुआ है।</translation>
+    </message>
+    <message>
+        <source>You need to install CF Tool to submit your code to Codeforces. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation>आपको कोडफोर्सेस पर अपना कोड सबमिट करने के लिए सीएफ टूल इंस्टॉल करने की आवश्यकता है। यदि पहले से इंस्टॉल है, तो आप इसे पाथ एनवायरनमेंट वेरिएबल में जोड़ सकते हैं या %1 पर अपनी सेटिंग्स की जांच कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Untitled-%1</source>
+        <translation>अनटाइटल्ड-%1</translation>
+    </message>
+    <message>
+        <source>Unknown attribute: [%1]. Please check the head comments setting at %2.</source>
+        <translation>अज्ञात एट्रीब्यूट: [%1]। कृपया %2 पर हेड कमेंट्स सेटिंग जांचें।</translation>
+    </message>
+    <message>
+        <source>Save as</source>
+        <translation>सेव एज़</translation>
+    </message>
+    <message>
+        <source>Open %1 Template</source>
+        <translation>%1 टेम्पलेट खोलें</translation>
+    </message>
+    <message>
+        <source>Open File</source>
+        <translation>फाइल खोलें</translation>
+    </message>
+    <message>
+        <source>The file [%1] contains more than %2 characters, so it's not opened. You can change the open file length limit at %3.</source>
+        <translation>फाइल [%1] में %2 से अधिक कैरेक्टर हैं, इसलिए इसे खोला नहीं गया है। आप %3 पर ओपन फाइल लेंथ लिमिट बदल सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Save File</source>
+        <translation>फाइल सेव करें</translation>
+    </message>
+    <message>
+        <source>Temp File</source>
+        <translation>टेम्प फाइल</translation>
+    </message>
+    <message>
+        <source>Failed to create the temporary directory</source>
+        <translation>टेम्परेरी डायरेक्टरी बनाने में विफल</translation>
+    </message>
+    <message>
+        <source>Set Compile Command</source>
+        <translation>कंपाइल कमांड सेट करें</translation>
+    </message>
+    <message>
+        <source>Custom compile command for this tab:</source>
+        <translation>इस टैब के लिए कस्टम कंपाइल कमांड:</translation>
+    </message>
+    <message>
+        <source>Set Time Limit</source>
+        <translation>टाइम लिमिट सेट करें</translation>
+    </message>
+    <message>
+        <source>Custom time limit for this tab: (ms)</source>
+        <translation>इस टैब के लिए कस्टम टाइम लिमिट: (ms)</translation>
+    </message>
+    <message>
+        <source>Read %1 Template</source>
+        <translation>%1 टेम्पलेट रीड करें</translation>
+    </message>
+    <message>
+        <source>Save changes</source>
+        <translation>बदलावों को सेव करें</translation>
+    </message>
+    <message>
+        <source>Save changes to [%1] before closing?</source>
+        <translation>बंद करने से पहले [%1] के बदलावों को सेव करें?</translation>
+    </message>
+    <message>
+        <source>New File</source>
+        <translation>नई फाइल</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>सेव करें</translation>
+    </message>
+    <message>
+        <source>Set Tab language</source>
+        <translation>टैब लैंग्वेज सेट करें</translation>
+    </message>
+    <message>
+        <source>Set the language to use in this Tab</source>
+        <translation>इस टैब में इस्तेमाल करने के लिए लैंग्वेज सेट करें</translation>
+    </message>
+    <message>
+        <source>Reload</source>
+        <translation>रीलोड करें</translation>
+    </message>
+    <message>
+        <source>[%1]
+
+has been changed on disk.
+Do you want to reload it?</source>
+        <translation>[%1]
+
+डिस्क पर बदल गया है।
+क्या आप इसे रीलोड करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Line %1, Column %2</source>
+        <translation>लाइन %1, कॉलम %2</translation>
+    </message>
+    <message>
+        <source>%1 lines, %2 characters selected</source>
+        <translation>%1 लाइनें, %2 कैरेक्टर्स सिलेक्ट किए गए</translation>
+    </message>
+    <message>
+        <source>%1 characters selected</source>
+        <translation>%1 कैरेक्टर्स सिलेक्ट किए गए</translation>
+    </message>
+    <message>
+        <source>Compilation has started</source>
+        <translation>कंपाइलेशन शुरू हो गया है</translation>
+    </message>
+    <message>
+        <source>Compilation has finished</source>
+        <translation>कंपाइलेशन समाप्त हो गया है</translation>
+    </message>
+    <message>
+        <source>Compile Warnings</source>
+        <translation>कंपाइल वार्निंग्स</translation>
+    </message>
+    <message>
+        <source>Error occurred while compiling</source>
+        <translation>कंपाइल करते समय एरर आया</translation>
+    </message>
+    <message>
+        <source>Compile Errors</source>
+        <translation>कंपाइल एरर्स</translation>
+    </message>
+    <message>
+        <source>Have you set a proper name for the main class in your solution? If not, you can set it at %1.</source>
+        <translation>क्या आपने अपने सॉल्यूशन में मेन क्लास के लिए एक सही नाम सेट किया है? यदि नहीं, तो आप इसे %1 पर सेट कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Failed to start compilation: %1</source>
+        <translation>कंपाइलेशन शुरू करने में विफल: %1</translation>
+    </message>
+    <message>
+        <source>Compilation is killed</source>
+        <translation>कंपाइलेशन किल्ड हो गया है</translation>
+    </message>
+    <message>
+        <source>Detached Runner</source>
+        <translation>डिटैच्ड रनर</translation>
+    </message>
+    <message>
+        <source>Runner[%1]</source>
+        <translation>रनर[%1]</translation>
+    </message>
+    <message>
+        <source>Execution has started</source>
+        <translation>एक्जीक्यूशन शुरू हो गया है</translation>
+    </message>
+    <message>
+        <source>Execution for test case #%1 has finished in %2ms</source>
+        <translation>टेस्ट केस #%1 के लिए एक्जीक्यूशन %2ms में समाप्त हो गया है</translation>
+    </message>
+    <message>
+        <source>Time Limit Exceeded</source>
+        <translation>टाइम लिमिट एक्सीडेड</translation>
+    </message>
+    <message>
+        <source>Execution for test case #%1 has finished with non-zero exitcode %2 in %3ms</source>
+        <translation>टेस्ट केस #%1 के लिए एक्जीक्यूशन नॉन-जीरो एग्जिट कोड %2 के साथ %3ms में समाप्त हो गया है</translation>
+    </message>
+    <message>
+        <source>/stderr</source>
+        <translation>/stderr</translation>
+    </message>
+    <message>
+        <source>The %1 of the process running on the testcase #%2 contains more than %3 characters, which is longer than the output length limit, so the process is killed. You can change the output length limit at %4.</source>
+        <translation>टेस्टकेस #%2 पर रन हो रहे प्रोसेस के %1 में %3 से अधिक कैरेक्टर्स हैं, जो कि आउटपुट लेंथ लिमिट से अधिक लंबा है, इसलिए प्रोसेस को किल कर दिया गया है। आप %4 पर आउटपुट लेंथ लिमिट को बदल सकते हैं।</translation>
+    </message>
+    <message>
+        <source>%1 has been killed</source>
+        <translation>%1 को किल कर दिया गया है</translation>
+    </message>
+    <message>
+        <source>Detached runner</source>
+        <translation>डिटैच्ड रनर</translation>
+    </message>
+    <message>
+        <source>Runner for testcase #%1</source>
+        <translation>टेस्टकेस #%1 के लिए रनर</translation>
+    </message>
+    <message>
+        <source>CP Editor</source>
+        <translation>CP एडिटर</translation>
+    </message>
+    <message>
+        <source>cursor info</source>
+        <translation>कर्सर इन्फो</translation>
+    </message>
+    <message>
+        <source>Compile</source>
+        <translation>कंपाइल</translation>
+    </message>
+    <message>
+        <source>Run</source>
+        <translation>रन</translation>
+    </message>
+    <message>
+        <source>Compile and Run</source>
+        <translation>कंपाइल और रन</translation>
+    </message>
+    <message>
+        <source>Messages</source>
+        <translation>मैसेज</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation>क्लियर</translation>
+    </message>
+    <message>
+        <source>C++</source>
+        <translation>C++</translation>
+    </message>
+</context>
+<context>
+    <name>MessageLogger</name>
+    <message>
+        <source>
+... The message is too long</source>
+        <translation>
+... मैसेज बहुत लंबा है</translation>
+    </message>
+</context>
+<context>
+    <name>ParenthesesPage</name>
+    <message>
+        <source>%1 Parentheses</source>
+        <translation>%1 पैरेंट्थीसिस</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>ऐड</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>डेल</translation>
+    </message>
+    <message>
+        <source>No Parenthesis Selected</source>
+        <translation>कोई पैरेंट्थीसिस सिलेक्ट नहीं है</translation>
+    </message>
+    <message>
+        <source>New Parenthesis</source>
+        <translation>नया पैरेंट्थीसिस</translation>
+    </message>
+    <message>
+        <source>Enter a parenthesis (e.g. {}):</source>
+        <translation>एक पैरेंट्थीसिस एंटर करें (जैसे {}):</translation>
+    </message>
+    <message>
+        <source>Delete Parenthesis</source>
+        <translation>पैरेंट्थिसिस डिलीट करें</translation>
+    </message>
+    <message>
+        <source>Do you really want to delete the parenthesis %1?</source>
+        <translation>क्या आप वाकई पैरेंट्थिसिस %1 डिलीट करना चाहते हैं?</translation>
+    </message>
+</context>
+<context>
+    <name>ParenthesisWidget</name>
+    <message>
+        <source>Parenthesis: %1</source>
+        <translation>पैरेंट्थिसिस: %1</translation>
+    </message>
+    <message>
+        <source>Enable %1 for %2 in %3.
+If it's partially checked, the global setting in Code Edit will be used.</source>
+        <translation>%3 में %2 के लिए %1 इनेबल करें।
+यदि यह आंशिक रूप से चेक किया गया है, तो कोड एडिट में ग्लोबल सेटिंग का उपयोग किया जाएगा।</translation>
+    </message>
+    <message>
+        <source>Auto Complete</source>
+        <translation>ऑटो कम्पलीट</translation>
+    </message>
+    <message>
+        <source>Auto Remove</source>
+        <translation>ऑटो रिमूव</translation>
+    </message>
+    <message>
+        <source>Tab Jump Out</source>
+        <translation>टैब जंप आउट</translation>
+    </message>
+</context>
+<context>
+    <name>PathItem</name>
+    <message>
+        <source>Choose a file</source>
+        <translation>एक फाइल चुनें</translation>
+    </message>
+    <message>
+        <source>Excutable Files</source>
+        <translation>एक्सीक्यूटेबल फाइल्स</translation>
+    </message>
+    <message>
+        <source>Choose a %1 source file</source>
+        <translation>एक %1 सोर्स फाइल चुनें</translation>
+    </message>
+    <message>
+        <source>Choose an excutable file</source>
+        <translation>एक एक्सीक्यूटेबल फाइल चुनें</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesHomePage</name>
+    <message>
+        <source>Welcome to CP Editor! Let's get started.</source>
+        <translation>CP Editor में आपका स्वागत है! आइए शुरू करें।</translation>
+    </message>
+    <message>
+        <source>Code Editor Settings</source>
+        <translation>कोड एडिटर सेटिंग्स</translation>
+    </message>
+    <message>
+        <source>C++ Compile and Run Commands</source>
+        <translation>C++ कंपाइल और रन कमांड्स</translation>
+    </message>
+    <message>
+        <source>Java Compile and Run Commands</source>
+        <translation>Java कंपाइल और रन कमांड्स</translation>
+    </message>
+    <message>
+        <source>Python Run Commands</source>
+        <translation>पायथन रन कमांड्स</translation>
+    </message>
+    <message>
+        <source>Appearance Settings</source>
+        <translation>अपीयरेंस सेटिंग्स</translation>
+    </message>
+    <message>
+        <source>Font Settings</source>
+        <translation>फॉन्ट सेटिंग्स</translation>
+    </message>
+    <message>
+        <source>You can read the &lt;a href="%1"&gt;documentation&lt;/a&gt; or go through the settings for more information.</source>
+        <translation>आप अधिक जानकारी के लिए &lt;a href="%1"&gt;डॉक्यूमेंटेशन&lt;/a&gt; पढ़ सकते हैं या सेटिंग्स देख सकते हैं।</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesPage</name>
+    <message>
+        <source>Default</source>
+        <translation>डिफ़ॉल्ट</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>रीसेट</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>अप्लाई</translation>
+    </message>
+    <message>
+        <source>Restore the default settings on the current page. (Ctrl+D)</source>
+        <translation>वर्तमान पेज पर डिफ़ॉल्ट सेटिंग्स को रिस्टोर करें। (Ctrl+D)</translation>
+    </message>
+    <message>
+        <source>Discard all changes on the current page. (Ctrl+R)</source>
+        <translation>वर्तमान पेज पर सभी बदलावों को डिस्कार्ड करें। (Ctrl+R)</translation>
+    </message>
+    <message>
+        <source>Save the changes on the current page. (Ctrl+S)</source>
+        <translation>वर्तमान पेज पर बदलावों को सेव करें। (Ctrl+S)</translation>
+    </message>
+    <message>
+        <source>Unsaved Settings</source>
+        <translation>अनसेव्ड सेटिंग्स</translation>
+    </message>
+    <message>
+        <source>The settings are changed. Do you want to save the settings or discard them?</source>
+        <translation>सेटिंग्स बदल गई हैं। क्या आप सेटिंग्स को सेव करना चाहते हैं या उन्हें डिस्कार्ड करना चाहते हैं?</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesWindow</name>
+    <message>
+        <source>Preferences</source>
+        <translation>प्रेफरेंसेस</translation>
+    </message>
+    <message>
+        <source>Search...</source>
+        <translation>सर्च...</translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation>होम</translation>
+    </message>
+    <message>
+        <source>Go to the home page</source>
+        <translation>होम पेज पर जाएं</translation>
+    </message>
+    <message>
+        <source>Code Edit</source>
+        <translation>कोड एडिट</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>भाषा</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>सामान्य</translation>
+    </message>
+    <message>
+        <source>C++</source>
+        <translation>C++</translation>
+    </message>
+    <message>
+        <source>%1 Commands</source>
+        <translation>%1 कमांड्स</translation>
+    </message>
+    <message>
+        <source>%1 Template</source>
+        <translation>%1 टेम्पलेट</translation>
+    </message>
+    <message>
+        <source>%1 Snippets</source>
+        <translation>%1 स्निपेट्स</translation>
+    </message>
+    <message>
+        <source>%1 Parentheses</source>
+        <translation>%1 पैरेनथिसिस</translation>
+    </message>
+    <message>
+        <source>Java</source>
+        <translation>Java</translation>
+    </message>
+    <message>
+        <source>Python</source>
+        <translation>Python</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>अपीयरेंस</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation>फॉन्ट</translation>
+    </message>
+    <message>
+        <source>Actions</source>
+        <translation>एक्शन्स</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>सेव करें</translation>
+    </message>
+    <message>
+        <source>Auto Save</source>
+        <translation>ऑटो सेव</translation>
+    </message>
+    <message>
+        <source>Detached Execution</source>
+        <translation>डिटैच्ड एग्जीक्यूशन</translation>
+    </message>
+    <message>
+        <source>Save Session</source>
+        <translation>सेशन सेव करें</translation>
+    </message>
+    <message>
+        <source>Bind file and problem</source>
+        <translation>फ़ाइल और प्रॉब्लम को बाइंड करें</translation>
+    </message>
+    <message>
+        <source>Test Cases</source>
+        <translation>टेस्ट केसेस</translation>
+    </message>
+    <message>
+        <source>Load External File Changes</source>
+        <translation>एक्सटर्नल फ़ाइल चेंजस लोड करें</translation>
+    </message>
+    <message>
+        <source>Stopwatch</source>
+        <translation>स्टॉपवॉच</translation>
+    </message>
+    <message>
+        <source>Stress Testing</source>
+        <translation>स्ट्रेस टेस्टिंग</translation>
+    </message>
+    <message>
+        <source>Generator Template</source>
+        <translation>जनरेटर टेम्पलेट</translation>
+    </message>
+    <message>
+        <source>Extensions</source>
+        <translation>एक्सटेंशन</translation>
+    </message>
+    <message>
+        <source>Code Formatting</source>
+        <translation>कोड फॉर्मेटिंग</translation>
+    </message>
+    <message>
+        <source>Clang Format</source>
+        <translation>क्लैंग फॉर्मेट</translation>
+    </message>
+    <message>
+        <source>YAPF</source>
+        <translation>YAPF</translation>
+    </message>
+    <message>
+        <source>Language Server</source>
+        <translation>लैंग्वेज सर्वर</translation>
+    </message>
+    <message>
+        <source>%1 Server</source>
+        <translation>%1 सर्वर</translation>
+    </message>
+    <message>
+        <source>Competitive Companion</source>
+        <translation>कंपिटिटिव कम्पेनियन</translation>
+    </message>
+    <message>
+        <source>CF Tool</source>
+        <translation>CF टूल</translation>
+    </message>
+    <message>
+        <source>WakaTime</source>
+        <translation>WakaTime</translation>
+    </message>
+    <message>
+        <source>File Path</source>
+        <translation>फ़ाइल पाथ</translation>
+    </message>
+    <message>
+        <source>Testcases</source>
+        <translation>टेस्टकेसेस</translation>
+    </message>
+    <message>
+        <source>Problem URL</source>
+        <translation>प्रॉब्लम URL</translation>
+    </message>
+    <message>
+        <source>Default Paths</source>
+        <translation>डिफ़ॉल्ट पाथ्स</translation>
+    </message>
+    <message>
+        <source>Key Bindings</source>
+        <translation>की बाइंडिंग्स</translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation>एडवांस्ड</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation>अपडेट</translation>
+    </message>
+    <message>
+        <source>Limits</source>
+        <translation>लिमिट्स</translation>
+    </message>
+    <message>
+        <source>Network Proxy</source>
+        <translation>नेटवर्क प्रॉक्सी</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsInfo</name>
+    <message>
+        <source>Tab Width</source>
+        <translation>टैब विड्थ</translation>
+    </message>
+    <message>
+        <source>The width of the tab character, or the number of spaces of an indent</source>
+        <translation>टैब कैरेक्टर की विड्थ, या एक इंडेंट के स्पेस की संख्या</translation>
+    </message>
+    <message>
+        <source>Cursor Width</source>
+        <translation>कर्सर विड्थ</translation>
+    </message>
+    <message>
+        <source>The width of the cursor in pixels</source>
+        <translation>पिक्सेल में कर्सर की चौड़ाई</translation>
+    </message>
+    <message>
+        <source />
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <source>Editor Font</source>
+        <translation>एडिटर फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>The font of the code editor</source>
+        <translation>कोड एडिटर का फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>Use Custom Application Font</source>
+        <translation>कस्टम एप्लीकेशन फ़ॉन्ट का उपयोग करें</translation>
+    </message>
+    <message>
+        <source>Use a custom font for the whole application instead of the default system font.</source>
+        <translation>डिफ़ॉल्ट सिस्टम फ़ॉन्ट के बजाय पूरे एप्लीकेशन के लिए एक कस्टम फ़ॉन्ट का उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>Custom Application Font</source>
+        <translation>कस्टम एप्लीकेशन फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>The custom font for the whole application</source>
+        <translation>पूरे एप्लीकेशन के लिए कस्टम फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>Default Language</source>
+        <translation>डिफ़ॉल्ट लैंग्वेज</translation>
+    </message>
+    <message>
+        <source>The default language used when opening new tabs</source>
+        <translation>नए टैब्स खोलते समय उपयोग की जाने वाली डिफ़ॉल्ट लैंग्वेज</translation>
+    </message>
+    <message>
+        <source>Clang Format Program</source>
+        <translation>क्लैंग फ़ॉर्मेट प्रोग्राम</translation>
+    </message>
+    <message>
+        <source>The path to the Clang Format executable file</source>
+        <translation>क्लैंग फ़ॉर्मेट एक्जीक्यूटेबल फ़ाइल का पाथ</translation>
+    </message>
+    <message>
+        <source>Clang Format Arguments</source>
+        <translation>क्लैंग फ़ॉर्मेट आर्गुमेंट्स</translation>
+    </message>
+    <message>
+        <source>The arguments passed to clang-format. It should NOT contain "-i".</source>
+        <translation>clang-format को पास किए जाने वाले आर्गुमेंट्स। इसमें "-i" शामिल नहीं होना चाहिए।</translation>
+    </message>
+    <message>
+        <source>Clang Format Style</source>
+        <translation>क्लैंग फ़ॉर्मेट स्टाइल</translation>
+    </message>
+    <message>
+        <source>The Clang Format style options, which are usually saved in a .clang-format configuration file.
+You can learn about it at &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt;.</source>
+        <translation>क्लैंग फ़ॉर्मेट स्टाइल ऑप्शंस, जो आमतौर पर एक .clang-format कॉन्फ़िगरेशन फ़ाइल में सेव किए जाते हैं।
+आप इसके बारे में &lt;https://clang.llvm.org/docs/ClangFormatStyleOptions.html&gt; पर जान सकते हैं।</translation>
+    </message>
+    <message>
+        <source>YAPF Program</source>
+        <translation>YAPF प्रोग्राम</translation>
+    </message>
+    <message>
+        <source>The program of YAPF. It could be `yapf` (which doesn't need arguments) or `python` (which needs `-m yapf` as the arguments).</source>
+        <translation>YAPF का प्रोग्राम। यह `yapf` हो सकता है (जिसे आर्गुमेंट्स की आवश्यकता नहीं होती है) या `python` (जिसे आर्गुमेंट्स के रूप में `-m yapf` की आवश्यकता होती है)।</translation>
+    </message>
+    <message>
+        <source>YAPF Arguments</source>
+        <translation>YAPF आर्गुमेंट्स</translation>
+    </message>
+    <message>
+        <source>The arguments passed to the YAPF program. It should NOT contain "-i".</source>
+        <translation>YAPF प्रोग्राम को पास किए जाने वाले आर्गुमेंट्स। इसमें "-i" शामिल नहीं होना चाहिए।</translation>
+    </message>
+    <message>
+        <source>YAPF Style</source>
+        <translation>YAPF स्टाइल</translation>
+    </message>
+    <message>
+        <source>The YAPF style options, which are usually saved in a .style.yapf or setup.conf configuration file.
+You can learn about it by running `yapf --style-help`.</source>
+        <translation>YAPF स्टाइल ऑप्शंस, जो आमतौर पर .style.yapf या setup.conf कॉन्फ़िगरेशन फ़ाइल में सेव होते हैं।
+आप `yapf --style-help` रन करके इसके बारे में जान सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Format code on manual save</source>
+        <translation>मैनुअल सेव करने पर कोड फ़ॉर्मेट करें</translation>
+    </message>
+    <message>
+        <source>Format the code when saving it manually.</source>
+        <translation>मैनुअली सेव करते समय कोड को फ़ॉर्मेट करें।</translation>
+    </message>
+    <message>
+        <source>Format code on auto-save</source>
+        <translation>ऑटो-सेव करने पर कोड फ़ॉर्मेट करें</translation>
+    </message>
+    <message>
+        <source>Format the code when auto-saving it.</source>
+        <translation>ऑटो-सेव करते समय कोड को फ़ॉर्मेट करें।</translation>
+    </message>
+    <message>
+        <source>%1 Template Path</source>
+        <translation>%1 टैम्प्लेट पाथ</translation>
+    </message>
+    <message>
+        <source>The template used when creating a new C++ file</source>
+        <translation>एक नई C++ फ़ाइल बनाते समय उपयोग किया जाने वाला टैम्प्लेट</translation>
+    </message>
+    <message>
+        <source>%1 Template Cursor Position Regex</source>
+        <translation>%1 टैम्प्लेट कर्सर पोजीशन रिगेक्स</translation>
+    </message>
+    <message>
+        <source>The regular expression which matches a part of the code template.
+When opening a template, the position of the cursor is the position of the regex with an offset.
+The cursor will be at the end of the template if there's no match of the regex.</source>
+        <translation>रेगुलर एक्सप्रेशन जो कोड टैम्प्लेट के एक हिस्से से मैच करता है।
+टैम्प्लेट खोलते समय, कर्सर की पोजीशन एक ऑफसेट के साथ रिगेक्स की पोजीशन होती है।
+यदि रिगेक्स का कोई मैच नहीं मिलता है, तो कर्सर टैम्प्लेट के अंत में होगा।</translation>
+    </message>
+    <message>
+        <source>%1 Template Cursor Position Offset Type</source>
+        <translation>%1 टैम्प्लेट कर्सर पोजीशन ऑफसेट टाइप</translation>
+    </message>
+    <message>
+        <source>Whether the offset is relative to the start of the regex or the end of the regex.</source>
+        <translation>क्या ऑफसेट रेगएक्स के स्टार्ट के सापेक्ष है या रेगएक्स के एंड के सापेक्ष है।</translation>
+    </message>
+    <message>
+        <source>%1 Template Cursor Position Offset Characters</source>
+        <translation>%1 टेम्पलेट कर्सर पोजीशन ऑफसेट कैरेक्टर्स</translation>
+    </message>
+    <message>
+        <source>The offset relative to the match of the regex in the number of characters, including white spaces.</source>
+        <translation>कैरेक्टर्स की संख्या में रेगएक्स के मैच के सापेक्ष ऑफसेट, जिसमें व्हाइट स्पेसेस भी शामिल हैं।</translation>
+    </message>
+    <message>
+        <source>%1 Compile Command</source>
+        <translation>%1 कंपाइल कमांड</translation>
+    </message>
+    <message>
+        <source>The command used to compile C++. It should NOT include the path to the source file or "-o &lt;output file&gt;".</source>
+        <translation>C++ को कंपाइल करने के लिए उपयोग किया जाने वाला कमांड। इसमें सोर्स फाइल का पाथ या "-o &lt;आउटपुट फाइल&gt;" शामिल नहीं होना चाहिए।</translation>
+    </message>
+    <message>
+        <source>%1 Executable File Path</source>
+        <translation>%1 एक्ज़ीक्यूटेबल फाइल पाथ</translation>
+    </message>
+    <message>
+        <source>The path of the compiled executable file.
+It's relative to the source file, or the temporary directory if the tab is untitled.
+No ".exe" is needed.
+You can use "${filename}" for the complete file name,
+"${basename}" for the base file name without the suffix,
+"${tmpdir}" or "${tempdir}" for the absolute path of the temporary directory.</source>
+        <translation>कंपाइल्ड एक्ज़ीक्यूटेबल फाइल का पाथ।
+यह सोर्स फाइल के सापेक्ष है, या यदि टैब अनटाइटल्ड है तो टेम्परेरी डायरेक्टरी के सापेक्ष है।
+किसी ".exe" की आवश्यकता नहीं है।
+आप कम्पलीट फाइल नेम के लिए "${filename}" का उपयोग कर सकते हैं,
+बिना सफिक्स के बेस फाइल नेम के लिए "${basename}" का,
+टेम्परेरी डायरेक्टरी के एब्सोल्यूट पाथ के लिए "${tmpdir}" या "${tempdir}" का।</translation>
+    </message>
+    <message>
+        <source>%1 Run Arguments</source>
+        <translation>%1 रन आर्ग्युमेंट्स</translation>
+    </message>
+    <message>
+        <source>The runtime arguments when executing a C++ program</source>
+        <translation>C++ प्रोग्राम को एक्ज़ीक्यूट करते समय रनटाइम आर्ग्युमेंट्स</translation>
+    </message>
+    <message>
+        <source>The template used when creating a new Java file</source>
+        <translation>एक नई Java फाइल बनाते समय उपयोग किया जाने वाला टेम्पलेट</translation>
+    </message>
+    <message>
+        <source>The command used to compile Java.
+It should NOT include the path to the source file or the path of the compiled class file.</source>
+        <translation>Java को कंपाइल करने के लिए उपयोग किया जाने वाला कमांड।
+इसमें सोर्स फाइल का पाथ या कंपाइल्ड क्लास फाइल का पाथ शामिल नहीं होना चाहिए।</translation>
+    </message>
+    <message>
+        <source>The runtime arguments when executing a Java program</source>
+        <translation>Java प्रोग्राम को एक्ज़ीक्यूट करते समय रनटाइम आर्ग्युमेंट्स</translation>
+    </message>
+    <message>
+        <source>%1 Run Command</source>
+        <translation>%1 रन कमांड</translation>
+    </message>
+    <message>
+        <source>The command to start a Java program. It should NOT include "-classpath &lt;path&gt; &lt;class name&gt;".</source>
+        <translation>Java प्रोग्राम को स्टार्ट करने का कमांड। इसमें "-classpath &lt;पाथ&gt; &lt;क्लास नेम&gt;" शामिल नहीं होना चाहिए।</translation>
+    </message>
+    <message>
+        <source>%1 Class Name</source>
+        <translation>%1 क्लास नेम</translation>
+    </message>
+    <message>
+        <source>The name of the main class of your solution.</source>
+        <translation>आपके सॉल्यूशन की मेन क्लास का नाम।</translation>
+    </message>
+    <message>
+        <source>%1 Class Path</source>
+        <translation>%1 क्लास पाथ</translation>
+    </message>
+    <message>
+        <source>The path of the parent directory of the compiled class file.
+It's relative to the source file, or the temporary directory if the tab is untitled.
+You can use "${filename}" for the complete file name,
+"${basename}" for the base file name without the suffix,
+"${tmpdir}" or "${tempdir}" for the absolute path of the temporary directory.</source>
+        <translation>कंपाइल की गई क्लास फाइल की पैरेंट डायरेक्टरी का पाथ।
+यह सोर्स फाइल के रिलेटिव होता है, या यदि टैब अनटाइटल्ड है तो टेम्परेरी डायरेक्टरी के।
+आप पूरी फाइल के नाम के लिए "${filename}" का उपयोग कर सकते हैं,
+बिना सफिक्स के बेस फाइल नाम के लिए "${basename}",
+टेम्परेरी डायरेक्टरी के एब्सोल्यूट पाथ के लिए "${tmpdir}" या "${tempdir}" का उपयोग कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>The template used when creating a new Python file</source>
+        <translation>एक नई Python फाइल बनाते समय उपयोग किया जाने वाला टेंपलेट</translation>
+    </message>
+    <message>
+        <source>The runtime arguments when executing a Python program</source>
+        <translation>Python प्रोग्राम को एग्जीक्यूट करते समय रनटाइम आर्ग्युमेंट्स</translation>
+    </message>
+    <message>
+        <source>The command to start a Python program. It should NOT include the path to the source file.</source>
+        <translation>Python प्रोग्राम शुरू करने की कमांड। इसमें सोर्स फाइल का पाथ शामिल नहीं होना चाहिए।</translation>
+    </message>
+    <message>
+        <source>Editor Theme</source>
+        <translation>एडिटर थीम</translation>
+    </message>
+    <message>
+        <source>The syntax highlight theme of the code editor</source>
+        <translation>कोड एडिटर की सिंटैक्स हाइलाइट थीम</translation>
+    </message>
+    <message>
+        <source>Highlight lines containing diagnostics</source>
+        <translation>डायग्नोस्टिक्स वाली लाइन्स को हाइलाइट करें</translation>
+    </message>
+    <message>
+        <source>Terminal Program</source>
+        <translation>टर्मिनल प्रोग्राम</translation>
+    </message>
+    <message>
+        <source>The terminal emulator to use when running in detached mode.
+This is usually the name or the path of the terminal emulator.
+Some possible values are konsole, gnome-terminal, xfce-terminal, xterm or any other terminal emulator program.</source>
+        <translation>डिटैच्ड मोड में रन करते समय उपयोग किया जाने वाला टर्मिनल एमुलेटर।
+यह आमतौर पर टर्मिनल एमुलेटर का नाम या पाथ होता है।
+कुछ संभावित वैल्यू konsole, gnome-terminal, xfce-terminal, xterm या कोई अन्य टर्मिनल एमुलेटर प्रोग्राम हैं।</translation>
+    </message>
+    <message>
+        <source>Terminal Arguments</source>
+        <translation>टर्मिनल आर्ग्युमेंट्स</translation>
+    </message>
+    <message>
+        <source>Arguments used to execute a given command in the terminal emulator.
+This is "-e" for most terminal emulators, including konsole, xterm, xfce-terminal but can be "--" for gnome-terminal.
+Consult your terminal emulator for the suitable arguments.</source>
+        <translation>टर्मिनल एमुलेटर में दी गई कमांड को एग्जीक्यूट करने के लिए उपयोग किए जाने वाले आर्ग्युमेंट्स।
+यह अधिकांश टर्मिनल एमुलेटर के लिए "-e" होता है, जिसमें konsole, xterm, xfce-terminal शामिल हैं, लेकिन gnome-terminal के लिए "--" हो सकता है।
+उपयुक्त आर्ग्युमेंट्स के लिए अपने टर्मिनल एमुलेटर को कंसल्ट करें।</translation>
+    </message>
+    <message>
+        <source>Auto Complete Parentheses</source>
+        <translation>ऑटो कम्प्लीट पैरेंट्थीसिस</translation>
+    </message>
+    <message>
+        <source>Automatically complete a pair of parentheses when typing the left element of it,
+and move out of it when typing the right element of it.
+This can be overridden for each parenthesis in each language.</source>
+        <translation>पैरेंट्थीसिस के लेफ्ट एलीमेंट को टाइप करते समय उसके जोड़े को ऑटोमेटिकली कम्प्लीट करें,
+और उसके राइट एलीमेंट को टाइप करते समय उससे बाहर निकलें।
+इसे प्रत्येक लैंग्वेज में प्रत्येक पैरेंट्थीसिस के लिए ओवरराइड किया जा सकता है।</translation>
+    </message>
+    <message>
+        <source>Auto Remove Parentheses</source>
+        <translation>ऑटो रिमूव पैरेंट्थीसिस</translation>
+    </message>
+    <message>
+        <source>Automatically delete the whole pair of parentheses when deleting
+the left element of it if the two elements are adjacent.
+This can be overridden for each parenthesis in each language.</source>
+        <translation>जब आप बाईं ओर के एलिमेंट को डिलीट करते हैं, तो पैरेंट्थीसिस के पूरे पेयर को ऑटोमैटिकली डिलीट करें यदि वे दोनों एलिमेंट एडजसेंट हैं।
+इसे प्रत्येक लैंग्वेज में प्रत्येक पैरेंट्थीसिस के लिए ओवरराइड किया जा सकता है।</translation>
+    </message>
+    <message>
+        <source>Jump out of a parenthesis by pressing Tab</source>
+        <translation>टैब प्रेस करके पैरेंट्थीसिस से बाहर जंप करें</translation>
+    </message>
+    <message>
+        <source>When this is enabled, you can use Tab instead of the
+closing parenthesis to jump out of a parenthesis.
+This can be overridden for each parenthesis in each language.</source>
+        <translation>जब यह इनेबल होता है, तो आप पैरेंट्थीसिस से बाहर जंप करने के लिए क्लोजिंग पैरेंट्थीसिस के बजाय टैब का उपयोग कर सकते हैं।
+इसे प्रत्येक लैंग्वेज में प्रत्येक पैरेंट्थीसिस के लिए ओवरराइड किया जा सकता है।</translation>
+    </message>
+    <message>
+        <source>Auto Indent</source>
+        <translation>ऑटो इंडेंट</translation>
+    </message>
+    <message>
+        <source>Add an indent when entering a new line after a "{".</source>
+        <translation>एक "{" के बाद न्यू लाइन एंटर करते समय एक इंडेंट जोड़ें।</translation>
+    </message>
+    <message>
+        <source>Enable Auto Save</source>
+        <translation>ऑटो सेव इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Auto Save Interval (ms)</source>
+        <translation>ऑटो सेव इंटरवल (ms)</translation>
+    </message>
+    <message>
+        <source>The time interval between a modification and an auto-save, or between two auto-saves.</source>
+        <translation>एक मॉडिफिकेशन और एक ऑटो-सेव के बीच, या दो ऑटो-सेव के बीच का टाइम इंटरवल।</translation>
+    </message>
+    <message>
+        <source>Auto Save Interval Type</source>
+        <translation>ऑटो सेव इंटरवल टाइप</translation>
+    </message>
+    <message>
+        <source>After the last modification: the timer will be reset after a modification to the code.
+After the first modification: the timer will start after a modification if at that time the timer is not running.
+Without modification: auto-save happens with a constant interval no matter there are modifications or not.</source>
+        <translation>लास्ट मॉडिफिकेशन के बाद: कोड में मॉडिफिकेशन के बाद टाइमर रीसेट हो जाएगा।
+फर्स्ट मॉडिफिकेशन के बाद: मॉडिफिकेशन के बाद टाइमर स्टार्ट हो जाएगा यदि उस समय टाइमर रन नहीं हो रहा है।
+बिना मॉडिफिकेशन के: ऑटो-सेव एक कॉन्स्टेंट इंटरवल के साथ होता है, भले ही मॉडिफिकेशन हो या न हो।</translation>
+    </message>
+    <message>
+        <source>Wrap Text</source>
+        <translation>रैप टेक्स्ट</translation>
+    </message>
+    <message>
+        <source>Wrap a line into several lines if it doesn't fit into the screen.</source>
+        <translation>यदि कोई लाइन स्क्रीन में फिट नहीं होती है, तो उसे कई लाइनों में रैप करें।</translation>
+    </message>
+    <message>
+        <source>Enable Ctrl+Scroll to change font size</source>
+        <translation>फ़ॉन्ट साइज बदलने के लिए Ctrl+स्क्रॉल इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Change the editor font size by scrolling the mouse wheel while holding the Ctrl key.</source>
+        <translation>Ctrl की को होल्ड करते हुए माउस व्हील को स्क्रॉल करके एडिटर का फ़ॉन्ट साइज बदलें।</translation>
+    </message>
+    <message>
+        <source>Use the beta version</source>
+        <translation>बीटा वर्जन का उपयोग करें</translation>
+    </message>
+    <message>
+        <source>Check for updates marked as pre-releases, which are considered not very stable but have more features.</source>
+        <translation>प्री-रिलीजेस के रूप में मार्क किए गए अपडेट्स के लिए जांच करें, जिन्हें बहुत स्टेबल नहीं माना जाता है लेकिन उनमें अधिक फीचर्स होते हैं।</translation>
+    </message>
+    <message>
+        <source>Replace tabs by spaces</source>
+        <translation>टैब्स को स्पेसेस से रिप्लेस करें</translation>
+    </message>
+    <message>
+        <source>Use spaces instead of a tab character.</source>
+        <translation>टैब कैरेक्टर के बजाय स्पेसेस का उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>Save Testcases on Save</source>
+        <translation>सेव करने पर टेस्टकेसेस सेव करें</translation>
+    </message>
+    <message>
+        <source>Save the test cases on the disk when saving a file, and load the saved test cases when opening a file.</source>
+        <translation>फाइल सेव करते समय टेस्ट केसेस को डिस्क पर सेव करें, और फाइल ओपन करते समय सेव किए गए टेस्ट केसेस को लोड करें।</translation>
+    </message>
+    <message>
+        <source>Check for updates on startup</source>
+        <translation>स्टार्टअप पर अपडेट्स के लिए जांच करें</translation>
+    </message>
+    <message>
+        <source>Check whether there's a new version of CP Editor when starting CP Editor.</source>
+        <translation>CP Editor शुरू करते समय जांचें कि क्या CP Editor का कोई नया वर्जन उपलब्ध है।</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>ओपेसिटी</translation>
+    </message>
+    <message>
+        <source>The opacity of the main window</source>
+        <translation>मेन विंडो की ओपेसिटी</translation>
+    </message>
+    <message>
+        <source>Enable Competitive Companion</source>
+        <translation>कंपीटिटिव कम्पेनियन इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Receive data sent by Competitive Companion and load the example test cases.</source>
+        <translation>कंपीटिटिव कम्पेनियन द्वारा भेजे गए डेटा को रिसीव करें और उदाहरण टेस्ट केसेस को लोड करें।</translation>
+    </message>
+    <message>
+        <source>Connection Port</source>
+        <translation>कनेक्शन पोर्ट</translation>
+    </message>
+    <message>
+        <source>The port used to receive data from Competitive Companion</source>
+        <translation>कंपीटिटिव कम्पेनियन से डेटा रिसीव करने के लिए उपयोग किया जाने वाला पोर्ट</translation>
+    </message>
+    <message>
+        <source>Open New Tabs</source>
+        <translation>न्यू टैब्स ओपन करें</translation>
+    </message>
+    <message>
+        <source>Open a new tab for each problem parsed by Competitive Companion.</source>
+        <translation>Competitive Companion द्वारा पार्स की गई प्रत्येक प्रॉब्लम के लिए एक नया टैब खोलें।</translation>
+    </message>
+    <message>
+        <source>Use the time limit from Competitive Companion</source>
+        <translation>Competitive Companion से टाइम लिमिट का उपयोग करें</translation>
+    </message>
+    <message>
+        <source>Use the time limit parsed by Competitive Companion as the time limit of the corresponding tab.</source>
+        <translation>Competitive Companion द्वारा पार्स की गई टाइम लिमिट को संबंधित टैब की टाइम लिमिट के रूप में उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>Content of the head comments</source>
+        <translation>हेड कमेंट्स का कंटेंट</translation>
+    </message>
+    <message>
+        <source>The comments added at the head of the code when parsing a problem.
+Available place holders are:
+${time}: the time when parsing the problem
+${json.X.Y}: an attribute of the data provided by Competitive Companion, you can read more at https://github.com/jmerle/competitive-companion#explanation</source>
+        <translation>किसी प्रॉब्लम को पार्स करते समय कोड के हेड में जोड़े जाने वाले कमेंट्स।
+उपलब्ध प्लेसहोल्डर हैं:
+${time}: प्रॉब्लम को पार्स करने का समय
+${json.X.Y}: Competitive Companion द्वारा प्रदान किए गए डेटा का एक एट्रीब्यूट, आप https://github.com/jmerle/competitive-companion#explanation पर अधिक पढ़ सकते हैं</translation>
+    </message>
+    <message>
+        <source>Time format for the head comments</source>
+        <translation>हेड कमेंट्स के लिए टाइम फॉर्मेट</translation>
+    </message>
+    <message>
+        <source>The format of the ${time} place holder in the head comments.
+You can read the Qt documentation for available expressions:
+https://doc.qt.io/qt-5/qdate.html#toString
+https://doc.qt.io/qt-5/qtime.html#toString</source>
+        <translation>हेड कमेंट्स में ${time} प्लेसहोल्डर का फॉर्मेट।
+आप उपलब्ध एक्सप्रेशंस के लिए Qt डॉक्यूमेंटेशन पढ़ सकते हैं:
+https://doc.qt.io/qt-5/qdate.html#toString
+https://doc.qt.io/qt-5/qtime.html#toString</translation>
+    </message>
+    <message>
+        <source>Add "Powered By CP Editor" in the head comments</source>
+        <translation>हेड कमेंट्स में "Powered By CP Editor" जोड़ें</translation>
+    </message>
+    <message>
+        <source>Add a line saying "Powered By CP Editor" in the head comments.
+This doesn't cost you anything, but helps more people to know CP Editor.</source>
+        <translation>हेड कमेंट्स में "Powered By CP Editor" वाली एक लाइन जोड़ें।
+इससे आपको कुछ खर्च नहीं करना पड़ेगा, लेकिन अधिक लोगों को CP Editor के बारे में जानने में मदद मिलेगी।</translation>
+    </message>
+    <message>
+        <source>Format Codes</source>
+        <translation>फॉर्मेट कोड्स</translation>
+    </message>
+    <message>
+        <source>Kill All Processes</source>
+        <translation>सभी प्रोसेस किल करें</translation>
+    </message>
+    <message>
+        <source>Compile and Run</source>
+        <translation>कंपाइल और रन करें</translation>
+    </message>
+    <message>
+        <source>Run Only</source>
+        <translation>केवल रन करें</translation>
+    </message>
+    <message>
+        <source>Compile Only</source>
+        <translation>केवल कंपाइल करें</translation>
+    </message>
+    <message>
+        <source>Change View Mode</source>
+        <translation>व्यू मोड बदलें</translation>
+    </message>
+    <message>
+        <source>Use Snippets</source>
+        <translation>स्निपेट्स का उपयोग करें</translation>
+    </message>
+    <message>
+        <source>Restore last session at startup</source>
+        <translation>स्टार्टअप पर पिछला सेशन रिस्टोर करें</translation>
+    </message>
+    <message>
+        <source>Restore the last session when the application starts.
+When this is enabled, you won't be asked whether to save unsaved files when exiting.</source>
+        <translation>एप्लिकेशन शुरू होने पर पिछला सेशन रिस्टोर करें।
+जब यह इनेबल्ड होगा, तो बाहर निकलते समय आपसे अनसेव्ड फाइलों को सेव करने के लिए नहीं पूछा जाएगा।</translation>
+    </message>
+    <message>
+        <source>Auto-save the current session periodically</source>
+        <translation>समय-समय पर करंट सेशन को ऑटो-सेव करें</translation>
+    </message>
+    <message>
+        <source>Auto-save the current session periodically instead of only save when the application exists.
+This is useful if your computer is frozen and you have to cut off the power or
+kill the application with SIGKILL which could not be handled by the application.</source>
+        <translation>केवल एप्लिकेशन के बंद होने पर सेव करने के बजाय समय-समय पर करंट सेशन को ऑटो-सेव करें।
+यह तब उपयोगी होता है जब आपका कंप्यूटर फ्रीज हो जाता है और आपको पावर बंद करनी पड़ती है या
+एप्लिकेशन को SIGKILL के साथ किल करना पड़ता है जिसे एप्लिकेशन द्वारा हैंडल नहीं किया जा सकता।</translation>
+    </message>
+    <message>
+        <source>Auto-save Session Interval</source>
+        <translation>ऑटो-सेव सेशन इंटरवल</translation>
+    </message>
+    <message>
+        <source>The time interval between two auto-saves of the current session.</source>
+        <translation>करंट सेशन के दो ऑटो-सेव के बीच का टाइम इंटरवल।</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>पाथ</translation>
+    </message>
+    <message>
+        <source>The path to the CF Tool executable file</source>
+        <translation>CF टूल एक्सीक्यूटेबल फाइल का पाथ</translation>
+    </message>
+    <message>
+        <source>Show toast messages for submission verdicts</source>
+        <translation>सबमिशन वर्डिक्ट्स के लिए टोस्ट मैसेज दिखाएं</translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known. You can see the message outside of CP Editor.</source>
+        <translation>जब किसी सबमिशन का वर्डिक्ट पता चले तो एक टोस्ट मैसेज दिखाएं। आप इस मैसेज को CP Editor के बाहर भी देख सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Enable CF Tool</source>
+        <translation>CF टूल इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Enable or disable CF Tool Integration.</source>
+        <translation>CF टूल इंटीग्रेशन को इनेबल या डिसेबल करें।</translation>
+    </message>
+    <message>
+        <source>Show Compile And Run Only</source>
+        <translation>केवल कंपाइल और रन दिखाएं</translation>
+    </message>
+    <message>
+        <source>Hide the Compile Only button and the Run Only button under the code editor in the main window.</source>
+        <translation>मेन विंडो में कोड एडिटर के नीचे कंपाइल ओनली बटन और रन ओनली बटन को छिपाएं।</translation>
+    </message>
+    <message>
+        <source>Display EOLN In Diff</source>
+        <translation>डिफ में EOLN डिस्प्ले करें</translation>
+    </message>
+    <message>
+        <source>Use "¶" to represent for the new line character in the HTML Diff Viewer.</source>
+        <translation>HTML डिफ व्यूअर में न्यू लाइन कैरेक्टर को दर्शाने के लिए "¶" का उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>Save Files Faster</source>
+        <translation>फाइलों को तेजी से सेव करें</translation>
+    </message>
+    <message>
+        <source>Always use QFile instead of QSaveFile to save files.
+This will be faster but with a little bit more risk of losing the file (with a very small possibility).</source>
+        <translation>फाइलों को सेव करने के लिए QSaveFile के बजाय हमेशा QFile का उपयोग करें।
+यह अधिक तेज होगा लेकिन फ़ाइल खोने का थोड़ा अधिक जोखिम होगा (बहुत कम संभावना के साथ)।</translation>
+    </message>
+    <message>
+        <source>Default Time Limit (ms)</source>
+        <translation>डिफ़ॉल्ट टाइम लिमिट (ms)</translation>
+    </message>
+    <message>
+        <source>The default time limit when executing the program.
+The program will be killed if it doesn't terminate in the time limit.</source>
+        <translation>प्रोग्राम को एक्जीक्यूट करते समय डिफ़ॉल्ट टाइम लिमिट।
+यदि प्रोग्राम टाइम लिमिट में टर्मिनेट नहीं होता है, तो उसे किल कर दिया जाएगा।</translation>
+    </message>
+    <message>
+        <source>Output Length Limit</source>
+        <translation>आउटपुट लेंथ लिमिट</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in the output of the program.
+The program will be killed if either of its stdout or stderr is too long.</source>
+        <translation>प्रोग्राम के आउटपुट में कैरेक्टर्स की अधिकतम संख्या।
+यदि इसका stdout या stderr बहुत लंबा है, तो प्रोग्राम को किल कर दिया जाएगा।</translation>
+    </message>
+    <message>
+        <source>Output Display Length Limit</source>
+        <translation>आउटपुट डिस्प्ले लेंथ लिमिट</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters to be displayed for the output of the program.
+If the output is too long, it will be elided.</source>
+        <translation>प्रोग्राम के आउटपुट के लिए डिस्प्ले की जाने वाली कैरेक्टर्स की अधिकतम संख्या।
+यदि आउटपुट बहुत लंबा है, तो इसे इलाइड कर दिया जाएगा।</translation>
+    </message>
+    <message>
+        <source>Message Length Limit</source>
+        <translation>मैसेज लेंथ लिमिट</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in each message in the top-right corner of the main window.
+The message will be elided if it's too long.</source>
+        <translation>मेन विंडो के ऊपरी-दाएं कोने में प्रत्येक मैसेज में कैरेक्टर्स की अधिकतम संख्या।
+यदि मैसेज बहुत लंबा है, तो इसे इलाइड कर दिया जाएगा।</translation>
+    </message>
+    <message>
+        <source>HTML Diff Viewer Length Limit</source>
+        <translation>HTML डिफ व्यूअर लेंथ लिमिट</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in the HTML Diff Viewer.
+The Diff Viewer will fall back to plain text if either of the output or the expected output is too long.</source>
+        <translation>HTML डिफ व्यूअर में कैरेक्टर्स की अधिकतम संख्या।
+यदि आउटपुट या एक्सपेक्टेड आउटपुट में से कोई भी बहुत लंबा है, तो डिफ व्यूअर प्लेन टेक्स्ट पर फ़ॉल बैक करेगा।</translation>
+    </message>
+    <message>
+        <source>Open File Length Limit</source>
+        <translation>ओपन फ़ाइल लेंथ लिमिट</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in a source file to open.
+A source file won't be opened if it's too long.</source>
+        <translation>खोलने के लिए किसी सोर्स फाइल में कैरेक्टर्स की अधिकतम संख्या।
+अगर सोर्स फाइल बहुत लंबी है, तो उसे नहीं खोला जाएगा।</translation>
+    </message>
+    <message>
+        <source>Display Test Case Length Limit</source>
+        <translation>टेस्ट केस लेंथ लिमिट डिस्प्ले करें</translation>
+    </message>
+    <message>
+        <source>The maximum number of characters in a test case to be displayed.
+A test case will be elided and read-only if it's too long.</source>
+        <translation>डिस्प्ले किए जाने वाले टेस्ट केस में कैरेक्टर्स की अधिकतम संख्या।
+अगर टेस्ट केस बहुत लंबा है, तो उसे एलाइड और रीड-ओनली कर दिया जाएगा।</translation>
+    </message>
+    <message>
+        <source>Path to LSP executable</source>
+        <translation>एलएसपी एक्ज़ीक्यूटेबल का पाथ</translation>
+    </message>
+    <message>
+        <source>The path to the C++ Language Server executable</source>
+        <translation>C++ लैंग्वेज सर्वर एक्ज़ीक्यूटेबल का पाथ</translation>
+    </message>
+    <message>
+        <source>The path to the Java Language Server executable</source>
+        <translation>जावा लैंग्वेज सर्वर एक्ज़ीक्यूटेबल का पाथ</translation>
+    </message>
+    <message>
+        <source>The path to the Python Language Server executable</source>
+        <translation>पायथन लैंग्वेज सर्वर एक्ज़ीक्यूटेबल का पाथ</translation>
+    </message>
+    <message>
+        <source>Use Linting with Language Server</source>
+        <translation>लैंग्वेज सर्वर के साथ लिंटिंग का यूज़ करें</translation>
+    </message>
+    <message>
+        <source>Show Error, Warning, Information and Hints in Code Editor for C++ Language</source>
+        <translation>C++ लैंग्वेज के लिए कोड एडिटर में एरर, वार्निंग, इन्फॉर्मेशन और हिंट्स शो करें</translation>
+    </message>
+    <message>
+        <source>Show Error, Warning, Information and Hints in Code Editor for Java Language</source>
+        <translation>जावा लैंग्वेज के लिए कोड एडिटर में एरर, वार्निंग, इन्फॉर्मेशन और हिंट्स शो करें</translation>
+    </message>
+    <message>
+        <source>Show Error, Warning, Information and Hints in Code Editor for Python Language</source>
+        <translation>पायथन लैंग्वेज के लिए कोड एडिटर में एरर, वार्निंग, इन्फॉर्मेशन और हिंट्स शो करें</translation>
+    </message>
+    <message>
+        <source>Use auto-complete with Language Server</source>
+        <translation>लैंग्वेज सर्वर के साथ ऑटो-कंप्लीट का यूज़ करें</translation>
+    </message>
+    <message>
+        <source>Use autocomplete results from Language server</source>
+        <translation>लैंग्वेज सर्वर से ऑटोकंप्लीट रिज़ल्ट्स का यूज़ करें</translation>
+    </message>
+    <message>
+        <source>Delay in Linting (ms)</source>
+        <translation>लिंटिंग में डिले (ms)</translation>
+    </message>
+    <message>
+        <source>Delay in linting in milliseconds after last modification to code</source>
+        <translation>कोड में लास्ट मॉडिफिकेशन के बाद मिलीसेकंड्स में लिंटिंग में डिले</translation>
+    </message>
+    <message>
+        <source>Arguments for Language Server</source>
+        <translation>लैंग्वेज सर्वर के लिए आर्गुमेंट्स</translation>
+    </message>
+    <message>
+        <source>Arguments to pass to Language server executable</source>
+        <translation>लैंग्वेज सर्वर एक्ज़ीक्यूटेबल को पास करने के लिए आर्गुमेंट्स</translation>
+    </message>
+    <message>
+        <source>Testcases Matching Rules</source>
+        <translation>टेस्टकेस मैचिंग रूल्स</translation>
+    </message>
+    <message>
+        <source>Pairs of regular expressions used when adding pairs of test cases from files.
+Each pair of regular expressions represents a test case.</source>
+        <translation>फाइल्स से टेस्ट केस के पेयर्स जोड़ते समय उपयोग किए जाने वाले रेगुलर एक्सप्रेशंस के पेयर्स।
+रेगुलर एक्सप्रेशंस का प्रत्येक पेयर एक टेस्ट केस को दर्शाता है।</translation>
+    </message>
+    <message>
+        <source>Input Regex</source>
+        <translation>इनपुट रेगेक्स</translation>
+    </message>
+    <message>
+        <source>The regular expression which matches the whole input file name</source>
+        <translation>वह रेगुलर एक्सप्रेशन जो पूरे इनपुट फाइल नेम से मैच करता है</translation>
+    </message>
+    <message>
+        <source>Answer Replace</source>
+        <translation>आंसर रिप्लेस</translation>
+    </message>
+    <message>
+        <source>The replace expression for the answer file name.
+You can use "\1" for the first captured group.</source>
+        <translation>आंसर फाइल नेम के लिए रिप्लेस एक्सप्रेशन।
+आप पहले कैप्चर किए गए ग्रुप के लिए "\1" का उपयोग कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Input File Save Path</source>
+        <translation>इनपुट फाइल सेव पाथ</translation>
+    </message>
+    <message>
+        <source>The path where the input files are saved.
+This setting is a relative path to the source file.
+You can use "${filename}" for the complete file name,
+"${basename}" for the base file name without the suffix,
+"${0-index}" for the index of the test case started from 0,
+"${1-index}" for the index of the test case started from 1.</source>
+        <translation>वह पाथ जहाँ इनपुट फाइल्स सेव होती हैं।
+यह सेटिंग सोर्स फाइल का एक रिलेटिव पाथ है।
+आप पूरे फाइल नेम के लिए "${filename}",
+बिना सफिक्स के बेस फाइल नेम के लिए "${basename}",
+0 से शुरू होने वाले टेस्ट केस के इंडेक्स के लिए "${0-index}",
+1 से शुरू होने वाले टेस्ट केस के इंडेक्स के लिए "${1-index}" का उपयोग कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Answer File Save Path</source>
+        <translation>आंसर फाइल सेव पाथ</translation>
+    </message>
+    <message>
+        <source>The path where the answer files are saved.
+This setting is a relative path to the source file.
+You can use "${filename}" for the complete file name,
+"${basename}" for the base file name without the suffix,
+"${0-index}" for the index of the test case started from 0,
+"${1-index}" for the index of the test case started from 1.</source>
+        <translation>वह पाथ जहाँ आंसर फाइल्स सेव होती हैं।
+यह सेटिंग सोर्स फाइल का एक रिलेटिव पाथ है।
+आप पूरे फाइल नेम के लिए "${filename}",
+बिना सफिक्स के बेस फाइल नेम के लिए "${basename}",
+0 से शुरू होने वाले टेस्ट केस के इंडेक्स के लिए "${0-index}",
+1 से शुरू होने वाले टेस्ट केस के इंडेक्स के लिए "${1-index}" का उपयोग कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Default File Paths For Problem URLs</source>
+        <translation>प्रॉब्लम यूआरएल्स के लिए डिफ़ॉल्ट फाइल पाथ्स</translation>
+    </message>
+    <message>
+        <source>The default file path used when saving a new file while the problem URL is set</source>
+        <translation>प्रॉब्लम यूआरएल सेट होने के दौरान एक नई फाइल को सेव करते समय उपयोग किया जाने वाला डिफ़ॉल्ट फाइल पाथ</translation>
+    </message>
+    <message>
+        <source>Problem URL</source>
+        <translation>प्रॉब्लम यूआरएल</translation>
+    </message>
+    <message>
+        <source>The regular expression which matches a part of the problem URL</source>
+        <translation>वह रेगुलर एक्सप्रेशन जो प्रॉब्लम URL के एक हिस्से को मैच करता है</translation>
+    </message>
+    <message>
+        <source>File Path</source>
+        <translation>फ़ाइल पाथ</translation>
+    </message>
+    <message>
+        <source>The replace expression for the file path, without file name suffix.
+You can use "\1" for the first captured group.</source>
+        <translation>फ़ाइल पाथ के लिए रिप्लेस एक्सप्रेशन, बिना फ़ाइल नेम सफिक्स के।
+आप पहले कैप्चर्ड ग्रुप के लिए "\1" का उपयोग कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Test Cases Font</source>
+        <translation>टेस्ट केसेस फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>The font of test cases</source>
+        <translation>टेस्ट केसेस का फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>Add extra margin at the bottom of the code editor</source>
+        <translation>कोड एडिटर के बॉटम में एक्स्ट्रा मार्जिन जोड़ें</translation>
+    </message>
+    <message>
+        <source>Add an extra margin with the height of a page at the bottom of the code editor.
+Due to technical reasons, changing the height of the margin affects the undo history.</source>
+        <translation>कोड एडिटर के बॉटम में एक पेज की हाइट जितना एक्स्ट्रा मार्जिन जोड़ें।
+टेक्निकल कारणों से, मार्जिन की हाइट बदलने से अनडू हिस्ट्री प्रभावित होती है।</translation>
+    </message>
+    <message>
+        <source>Message Logger Font</source>
+        <translation>मैसेज लॉगर फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>The font of the message logger</source>
+        <translation>मैसेज लॉगर का फ़ॉन्ट</translation>
+    </message>
+    <message>
+        <source>Save File On Compilation</source>
+        <translation>कम्पाइलेशन पर फ़ाइल सेव करें</translation>
+    </message>
+    <message>
+        <source>Save the source file when compiling it. It won't be saved if the tab is untitled.</source>
+        <translation>सोर्स फ़ाइल को कम्पाइल करते समय इसे सेव करें। यदि टैब अनटाइटल्ड है तो यह सेव नहीं होगी।</translation>
+    </message>
+    <message>
+        <source>Save File On Execution</source>
+        <translation>एग्जीक्यूशन पर फ़ाइल सेव करें</translation>
+    </message>
+    <message>
+        <source>Save the source file when running it. It won't be saved if the tab is untitled.</source>
+        <translation>सोर्स फ़ाइल को रन करते समय इसे सेव करें। यदि टैब अनटाइटल्ड है तो यह सेव नहीं होगी।</translation>
+    </message>
+    <message>
+        <source>Restore the problem URL when opening a file</source>
+        <translation>फ़ाइल खोलते समय प्रॉब्लम URL को रिस्टोर करें</translation>
+    </message>
+    <message>
+        <source>If a problem URL was set for a file, when you open
+that file again, the problem URL will be restored.</source>
+        <translation>यदि किसी फ़ाइल के लिए प्रॉब्लम URL सेट किया गया था, तो जब आप
+उस फ़ाइल को दोबारा खोलते हैं, तो प्रॉब्लम URL रिस्टोर हो जाएगा।</translation>
+    </message>
+    <message>
+        <source>Open the old file when parsing an old problem URL</source>
+        <translation>पुराने प्रॉब्लम URL को पार्स करते समय पुरानी फ़ाइल खोलें</translation>
+    </message>
+    <message>
+        <source>If a problem URL was set for a file, when parsing that problem
+from Competitive Companion again, the old file will be opened.</source>
+        <translation>यदि किसी फ़ाइल के लिए प्रॉब्लम URL सेट किया गया था, तो Competitive Companion से उस प्रॉब्लम को दोबारा पार्स करते समय, पुरानी फ़ाइल खुल जाएगी।</translation>
+    </message>
+    <message>
+        <source>UI Language</source>
+        <translation>UI लैंग्वेज</translation>
+    </message>
+    <message>
+        <source>The language displayed in the UI.</source>
+        <translation>UI में प्रदर्शित भाषा।</translation>
+    </message>
+    <message>
+        <source>Change Locale</source>
+        <translation>लोकैल बदलें</translation>
+    </message>
+    <message>
+        <source>You need to restart the application to completely apply the locale change.</source>
+        <translation>लोकैल बदलाव को पूरी तरह से लागू करने के लिए आपको एप्लिकेशन को रीस्टार्ट करना होगा।</translation>
+    </message>
+    <message>
+        <source>UI Style</source>
+        <translation>UI स्टाइल</translation>
+    </message>
+    <message>
+        <source>The style of the whole application.</source>
+        <translation>पूरे एप्लिकेशन का स्टाइल।</translation>
+    </message>
+    <message>
+        <source>Run your codes on empty test cases</source>
+        <translation>अपने कोड को खाली टेस्ट केस पर रन करें</translation>
+    </message>
+    <message>
+        <source>Run your code on all non-hidden test cases even if the input is empty.</source>
+        <translation>अपने कोड को सभी नॉन-हिडन टेस्ट केस पर रन करें, भले ही इनपुट खाली हो।</translation>
+    </message>
+    <message>
+        <source>Check your answer on test cases with empty output</source>
+        <translation>खाली आउटपुट वाले टेस्ट केस पर अपने आंसर को चेक करें</translation>
+    </message>
+    <message>
+        <source>Check your answer even if your output or the expected output is empty.</source>
+        <translation>अपने आंसर को चेक करें, भले ही आपका आउटपुट या अपेक्षित आउटपुट खाली हो।</translation>
+    </message>
+    <message>
+        <source>Test Case Maximum Height</source>
+        <translation>टेस्ट केस मैक्सिमम हाइट</translation>
+    </message>
+    <message>
+        <source>The maximum height of a test case without a scrollbar in pixels.</source>
+        <translation>बिना स्क्रॉलबार वाले टेस्ट केस की अधिकतम हाइट पिक्सल में।</translation>
+    </message>
+    <message>
+        <source>Enable proxy for checking updates</source>
+        <translation>अपडेट चेक करने के लिए प्रॉक्सी इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Enable proxy to connect to GitHub while checking updates</source>
+        <translation>अपडेट चेक करते समय GitHub से कनेक्ट करने के लिए प्रॉक्सी इनेबल करें</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Enable proxy for checking updates on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>नेटवर्क-प्रॉक्सी</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>टाइप</translation>
+    </message>
+    <message>
+        <source>The type of the proxy. "System" for using the system proxy.</source>
+        <translation>प्रॉक्सी का टाइप। सिस्टम प्रॉक्सी का उपयोग करने के लिए "System" चुनें।</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Type on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>नेटवर्क-प्रॉक्सी</translation>
+    </message>
+    <message>
+        <source>Host Name</source>
+        <translation>होस्ट नेम</translation>
+    </message>
+    <message>
+        <source>The hostname of the proxy, e.g. 127.0.0.1</source>
+        <translation>प्रॉक्सी का होस्टनेम, उदाहरण के लिए 127.0.0.1</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Host Name on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>नेटवर्क-प्रॉक्सी</translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation>पोर्ट</translation>
+    </message>
+    <message>
+        <source>The port of the proxy, e.g. 1080</source>
+        <translation>प्रॉक्सी का पोर्ट, उदाहरण के लिए 1080</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Port on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>नेटवर्क-प्रॉक्सी</translation>
+    </message>
+    <message>
+        <source>User</source>
+        <translation>यूजर</translation>
+    </message>
+    <message>
+        <source>The user of the proxy server. It can be empty if the proxy server doesn't require authentication.</source>
+        <translation>प्रॉक्सी सर्वर का यूजर। यदि प्रॉक्सी सर्वर को ऑथेंटिकेशन की आवश्यकता नहीं है, तो इसे खाली छोड़ा जा सकता है।</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of User on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>नेटवर्क-प्रॉक्सी</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>पासवर्ड</translation>
+    </message>
+    <message>
+        <source>The password of the proxy server. It can be empty if the proxy server doesn't require authentication.</source>
+        <translation>प्रॉक्सी सर्वर का पासवर्ड। यदि प्रॉक्सी सर्वर को ऑथेंटिकेशन की आवश्यकता नहीं है, तो यह खाली हो सकता है।</translation>
+    </message>
+    <message>
+        <source>network-proxy</source>
+        <comment>the anchor of Password on the corresponding page of https://cpeditor.org/docs/preferences</comment>
+        <translation>नेटवर्क-प्रॉक्सी</translation>
+    </message>
+    <message>
+        <source>%1 Compiler Output Codec</source>
+        <translation>%1 कंपाइलर आउटपुट कोडेक</translation>
+    </message>
+    <message>
+        <source>Text codec of the compiler output (errors, warnings, etc.)</source>
+        <translation>कंपाइलर आउटपुट (एरर्स, वार्निंग्स, आदि) का टेक्स्ट कोडेक।</translation>
+    </message>
+    <message>
+        <source>Default Path Names And Paths</source>
+        <translation>डिफ़ॉल्ट पाथ नेम्स और पाथ्स</translation>
+    </message>
+    <message>
+        <source>A list of default paths.
+They can be used in actions' corresponding default paths by using ${&lt;default path name&gt;} as a place holder.
+They can be either manually set or automatically changed after choosing a path for an action.</source>
+        <translation>डिफ़ॉल्ट पाथ्स की एक सूची।
+इन्हें एक्शन्स के संबंधित डिफ़ॉल्ट पाथ्स में प्लेसहोल्डर के रूप में ${&lt;default path name&gt;} का उपयोग करके इस्तेमाल किया जा सकता है।
+इन्हें मैन्युअली सेट किया जा सकता है या किसी एक्शन के लिए पाथ चुनने के बाद ऑटोमैटिकली बदला जा सकता है।</translation>
+    </message>
+    <message>
+        <source>default-paths</source>
+        <comment>the anchor of Default Paths on https://cpeditor.org/docs/preferences/file-path</comment>
+        <translation>डिफ़ॉल्ट-पाथ्स</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <source>The name of a default path</source>
+        <translation>एक डिफ़ॉल्ट पाथ का नाम</translation>
+    </message>
+    <message>
+        <source>The path of a default path</source>
+        <translation>एक डिफ़ॉल्ट पाथ का पाथ</translation>
+    </message>
+    <message>
+        <source>Auto-load external file changes if there's no unsaved modification</source>
+        <translation>यदि कोई अनसेव्ड मॉडिफिकेशन नहीं है, तो एक्सटर्नल फ़ाइल परिवर्तनों को ऑटो-लोड करें</translation>
+    </message>
+    <message>
+        <source>Automatically load file changes that are not made in CP Editor if there's no unsaved modification in CP Editor.</source>
+        <translation>यदि CP Editor में कोई अनसेव्ड मॉडिफिकेशन नहीं है, तो उन फ़ाइल परिवर्तनों को ऑटोमैटिकली लोड करें जो CP Editor में नहीं किए गए हैं।</translation>
+    </message>
+    <message>
+        <source>Ask whether to load external file changes</source>
+        <translation>पूछें कि क्या एक्सटर्नल फ़ाइल परिवर्तनों को लोड करना है</translation>
+    </message>
+    <message>
+        <source>When there are file changes that are not made in CP Editor and is not automatically loaded by
+"%1", ask for whether to load the changes.
+If this is disabled, external file changes will be ignored unless they are loaded by
+"%1".</source>
+        <translation>जब ऐसी फ़ाइल में परिवर्तन हों जो CP Editor में नहीं किए गए हैं और "%1" द्वारा ऑटोमैटिकली लोड नहीं किए गए हैं, तो पूछें कि क्या परिवर्तनों को लोड करना है।
+यदि यह डिसेबल है, तो एक्सटर्नल फ़ाइल परिवर्तनों को इग्नोर कर दिया जाएगा जब तक कि उन्हें "%1" द्वारा लोड न किया जाए।</translation>
+    </message>
+    <message>
+        <source>Show Only Monospaced Font</source>
+        <translation>केवल मोनोस्पेसड फ़ॉन्ट दिखाएं</translation>
+    </message>
+    <message>
+        <source>Show only monospaced fonts when choosing a font</source>
+        <translation>फॉन्ट चुनते समय केवल मोनोस्पेस फॉन्ट्स दिखाएं</translation>
+    </message>
+    <message>
+        <source>Auto Uncheck Accepted Testcases</source>
+        <translation>एक्सेप्टेड टेस्टकेसेस को ऑटो अनचेक करें</translation>
+    </message>
+    <message>
+        <source>Automatically uncheck test cases when they get accepted.</source>
+        <translation>जब टेस्ट केसेस एक्सेप्ट हो जाएं तो उन्हें ऑटोमैटिकली अनचेक करें।</translation>
+    </message>
+    <message>
+        <source>Enable Vim Emulation</source>
+        <translation>विम (Vim) एमुलेशन इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Enable vim emulation in Code Editor</source>
+        <translation>कोड एडिटर में विम (Vim) एमुलेशन इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Vim Configuration</source>
+        <translation>विम (Vim) कॉन्फ़िगरेशन</translation>
+    </message>
+    <message>
+        <source>The contents of Vim RC. It is loaded everytime vim emulation starts. 
+Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
+        <translation>विम (Vim) RC की सामग्री। यह हर बार विम (Vim) एमुलेशन शुरू होने पर लोड होती है। 
+सभी विम (Vim) कमांड्स सपोर्टेड नहीं हैं, कृपया सपोर्टेड कमांड्स की सूची के लिए https://github.com/cpeditor/FakeVim देखें</translation>
+    </message>
+    <message>
+        <source>The path to the WakaTime executable file</source>
+        <translation>वाकाटाइम (WakaTime) एक्जीक्यूटेबल फाइल का पाथ</translation>
+    </message>
+    <message>
+        <source>Api Key</source>
+        <translation>API की</translation>
+    </message>
+    <message>
+        <source>Can be found at https://wakatime.com/settings/account.
+It can be empty if you have the global wakatime config file ~/.wakatime.cfg.</source>
+        <translation>इसे https://wakatime.com/settings/account पर पाया जा सकता है।
+यदि आपके पास ग्लोबल वाकाटाइम (WakaTime) कॉन्फ़िगरेशन फाइल ~/.wakatime.cfg है तो यह खाली हो सकता है।</translation>
+    </message>
+    <message>
+        <source>Enable WakaTime</source>
+        <translation>वाकाटाइम (WakaTime) इनेबल करें</translation>
+    </message>
+    <message>
+        <source>Use WakaTime to track your time usage. The WakaTime CLI needs to be installed.</source>
+        <translation>अपने समय के उपयोग को ट्रैक करने के लिए वाकाटाइम (WakaTime) का उपयोग करें। वाकाटाइम (WakaTime) CLI इंस्टॉल्ड होना चाहिए।</translation>
+    </message>
+    <message>
+        <source>Use Proxy</source>
+        <translation>प्रॉक्सी का उपयोग करें</translation>
+    </message>
+    <message>
+        <source>Use Advanced-&gt;Network Proxy to send data to WakaTime.</source>
+        <translation>वाकाटाइम (WakaTime) को डेटा भेजने के लिए एडवांस-&gt;नेटवर्क प्रॉक्सी का उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>Display Stopwatch</source>
+        <translation>स्टॉपवॉच दिखाएं</translation>
+    </message>
+    <message>
+        <source>Show a stopwatch in the UI. You can use it to track your time spent on solving a problem.</source>
+        <translation>UI में एक स्टॉपवॉच दिखाएं। आप किसी समस्या को हल करने में बिताए गए अपने समय को ट्रैक करने के लिए इसका उपयोग कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Start/Stop stopwatch on tab switch</source>
+        <translation>टैब स्विच करने पर स्टॉपवॉच स्टार्ट/स्टॉप करें</translation>
+    </message>
+    <message>
+        <source>When switching to a different tab, automatically start the stopwatch
+on the current tab and pause the stopwatch on the previous tab.</source>
+        <translation>किसी अलग टैब पर स्विच करते समय, स्वचालित रूप से वर्तमान टैब पर स्टॉपवॉच स्टार्ट करें और पिछले टैब पर स्टॉपवॉच को पॉज़ करें।</translation>
+    </message>
+    <message>
+        <source>Show stopwatch result only when the button is pressed</source>
+        <translation>स्टॉपवॉच का रिज़ल्ट केवल बटन दबाने पर दिखाएं</translation>
+    </message>
+    <message>
+        <source>Hide the time of the stopwatch and only show the time when the "Show" button is pressed.
+This may reduce distractions caused by stopwatch updates.</source>
+        <translation>स्टॉपवॉच का समय छिपाएं और केवल तभी समय दिखाएं जब "Show" बटन दबाया जाए।
+यह स्टॉपवॉच अपडेट के कारण होने वाले डिस्ट्रेक्शन को कम कर सकता है।</translation>
+    </message>
+    <message>
+        <source>Color of error messages</source>
+        <translation>एरर मैसेज का रंग</translation>
+    </message>
+    <message>
+        <source>Color of warning messages</source>
+        <translation>वॉर्निंग मैसेज का रंग</translation>
+    </message>
+    <message>
+        <source>Programming language for the template</source>
+        <translation>टेम्पलेट के लिए प्रोग्रामिंग लैंग्वेज</translation>
+    </message>
+    <message>
+        <source>The programming language used for the generator template.</source>
+        <translation>जनरेटर टेम्पलेट के लिए उपयोग की जाने वाली प्रोग्रामिंग लैंग्वेज।</translation>
+    </message>
+    <message>
+        <source>Path to the template file</source>
+        <translation>टेम्पलेट फ़ाइल का पाथ</translation>
+    </message>
+    <message>
+        <source>The path to the generator template file.</source>
+        <translation>जनरेटर टेम्पलेट फ़ाइल का पाथ।</translation>
+    </message>
+    <message>
+        <source>Template Cursor Position Regex</source>
+        <translation>टेम्पलेट कर्सर पोजीशन Regex</translation>
+    </message>
+    <message>
+        <source>Template Cursor Position Offset Type</source>
+        <translation>टेम्पलेट कर्सर पोजीशन ऑफ़सेट टाइप</translation>
+    </message>
+    <message>
+        <source>Template Cursor Position Offset Characters</source>
+        <translation>टेम्पलेट कर्सर पोजीशन ऑफ़सेट कैरेक्टर</translation>
+    </message>
+    <message>
+        <source>Default path used for %1</source>
+        <translation>%1 के लिए उपयोग किया जाने वाला डिफ़ॉल्ट पाथ</translation>
+    </message>
+    <message>
+        <source>Open File</source>
+        <translation>ओपन फाइल</translation>
+    </message>
+    <message>
+        <source>The default path used when choosing a path for %1.
+You can use ${&lt;default path name&gt;} as a place holder.</source>
+        <translation>%1 के लिए पाथ चुनते समय उपयोग किया जाने वाला डिफॉल्ट पाथ।
+आप प्लेसहोल्डर के रूप में ${&lt;default path name&gt;} का उपयोग कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Default paths changed by %1</source>
+        <translation>%1 द्वारा बदले गए डिफॉल्ट पाथ</translation>
+    </message>
+    <message>
+        <source>The default paths changed after choosing a path for %1.
+It is a list of &lt;default path name&gt;s, separated by commas, and can be empty.</source>
+        <translation>%1 के लिए पाथ चुनने के बाद बदले गए डिफॉल्ट पाथ।
+यह &lt;default path name&gt;s की एक लिस्ट है, जो कॉमा द्वारा अलग की गई है, और खाली हो सकती है।</translation>
+    </message>
+    <message>
+        <source>Save File</source>
+        <translation>सेव फाइल</translation>
+    </message>
+    <message>
+        <source>It can be overridden by %1.</source>
+        <translation>इसे %1 द्वारा ओवरराइड किया जा सकता है।</translation>
+    </message>
+    <message>
+        <source>Open Contest</source>
+        <translation>ओपन कॉन्टेस्ट</translation>
+    </message>
+    <message>
+        <source>Load Single Test Case</source>
+        <translation>लोड सिंगल टेस्ट केस</translation>
+    </message>
+    <message>
+        <source>Add Pairs Of Test Cases</source>
+        <translation>ऐड पेयर्स ऑफ टेस्ट केसेस</translation>
+    </message>
+    <message>
+        <source>Save Test Case To A File</source>
+        <translation>सेव टेस्ट केस टू अ फाइल</translation>
+    </message>
+    <message>
+        <source>Custom Checker</source>
+        <translation>कस्टम चेकर</translation>
+    </message>
+    <message>
+        <source>Export And Import Settings</source>
+        <translation>एक्सपोर्ट एंड इम्पोर्ट सेटिंग्स</translation>
+    </message>
+    <message>
+        <source>Export And Load Session</source>
+        <translation>एक्सपोर्ट एंड लोड सेशन</translation>
+    </message>
+    <message>
+        <source>Extract And Load Snippets</source>
+        <translation>एक्सट्रैक्ट एंड लोड स्निपेट्स</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutItem</name>
+    <message>
+        <source>Clear the shortcut</source>
+        <translation>क्लियर द शॉर्टकट</translation>
+    </message>
+</context>
+<context>
+    <name>StringListsItem</name>
+    <message>
+        <source>Add</source>
+        <translation>ऐड</translation>
+    </message>
+    <message>
+        <source>Insert a row (Ctrl+N)</source>
+        <translation>एक रो इंसर्ट करें (Ctrl+N)</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>रिमूव</translation>
+    </message>
+    <message>
+        <source>Delete the current row (Ctrl+W)</source>
+        <translation>वर्तमान रो को डिलीट करें (Ctrl+W)</translation>
+    </message>
+    <message>
+        <source>Remove Item</source>
+        <translation>रिमूव आइटम</translation>
+    </message>
+    <message>
+        <source>Do you really want to delete the current row?</source>
+        <translation>क्या आप वास्तव में वर्तमान रो को डिलीट करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Move Up</source>
+        <translation>मूव अप</translation>
+    </message>
+    <message>
+        <source>Move the current row up (Ctrl+Shift+Up)</source>
+        <translation>वर्तमान रो को ऊपर ले जाएं (Ctrl+Shift+Up)</translation>
+    </message>
+    <message>
+        <source>Move Down</source>
+        <translation>मूव डाउन</translation>
+    </message>
+    <message>
+        <source>Move the current row down (Ctrl+Shift+Down)</source>
+        <translation>वर्तमान रो को नीचे ले जाएं (Ctrl+Shift+Down)</translation>
+    </message>
+</context>
+<context>
+    <name>SupportEntry</name>
+    <message>
+        <source>Donate</source>
+        <translation>डोनेट</translation>
+    </message>
+</context>
+<context>
+    <name>SupportUsDialog</name>
+    <message>
+        <source>Like CP Editor?</source>
+        <translation>CP Editor पसंद आया?</translation>
+    </message>
+    <message>
+        <source>Thank you for using CP Editor!</source>
+        <translation>CP Editor का उपयोग करने के लिए धन्यवाद!</translation>
+    </message>
+    <message>
+        <source>To support us, you can:</source>
+        <translation>हमारा समर्थन करने के लिए, आप यह कर सकते हैं:</translation>
+    </message>
+    <message>
+        <source>Give us a star on GitHub</source>
+        <translation>हमें GitHub पर स्टार दें</translation>
+    </message>
+    <message>
+        <source>Share CP Editor with your friends</source>
+        <translation>CP Editor को अपने दोस्तों के साथ शेयर करें</translation>
+    </message>
+    <message>
+        <source>I'm using @cpeditor_, an IDE specially designed for competitive programmers, which is awesome!</source>
+        <translation>मैं @cpeditor_ का उपयोग कर रहा हूँ, जो खास तौर पर कॉम्पिटिटिव प्रोग्रामर्स के लिए बनाया गया एक IDE है, और यह बहुत बढ़िया है!</translation>
+    </message>
+    <message>
+        <source>Financially support us</source>
+        <translation>आर्थिक रूप से हमारा समर्थन करें</translation>
+    </message>
+    <message>
+        <source>Provide some suggestions to help us do better</source>
+        <translation>हमें बेहतर बनाने के लिए कुछ सुझाव दें</translation>
+    </message>
+</context>
+<context>
+    <name>Telemetry::UpdateChecker</name>
+    <message>
+        <source>This error is probably caused by the lack of the OpenSSL library. You can visit &lt;a href="https://wiki.openssl.org/index.php/Binaries"&gt;the OpenSSLWiki&lt;/a&gt; to find a binary to install, or install it via your favourite package manager. You have to install a version compatible with this version: [%1]</source>
+        <translation>यह एरर संभवतः OpenSSL लाइब्रेरी की कमी के कारण है। आप एक बाइनरी इंस्टॉल करने के लिए &lt;a href="https://wiki.openssl.org/index.php/Binaries"&gt;OpenSSLWiki&lt;/a&gt; पर जा सकते हैं, या इसे अपने पसंदीदा पैकेज मैनेजर के माध्यम से इंस्टॉल कर सकते हैं। आपको इस वर्ज़न के साथ संगत एक वर्ज़न इंस्टॉल करना होगा: [%1]</translation>
+    </message>
+    <message>
+        <source>No release is found.</source>
+        <translation>कोई रिलीज़ नहीं मिली।</translation>
+    </message>
+    <message>
+        <source>No download URL of the version [%1] is found.</source>
+        <translation>वर्ज़न [%1] का कोई डाउनलोड URL नहीं मिला।</translation>
+    </message>
+</context>
+<context>
+    <name>Util::FileUtil</name>
+    <message>
+        <source>C++ Source Files</source>
+        <translation>C++ सोर्स फाइल्स</translation>
+    </message>
+    <message>
+        <source>Java Source Files</source>
+        <translation>Java सोर्स फाइल्स</translation>
+    </message>
+    <message>
+        <source>Python Source Files</source>
+        <translation>Python सोर्स फाइल्स</translation>
+    </message>
+    <message>
+        <source>Source Files</source>
+        <translation>सोर्स फाइल्स</translation>
+    </message>
+    <message>
+        <source>Failed to open [%1]. Do I have write permission?</source>
+        <translation>[%1] को ओपन करने में विफल। क्या मेरे पास राइट परमिशन है?</translation>
+    </message>
+    <message>
+        <source>Failed to save to [%1]. Do I have write permission?</source>
+        <translation>[%1] में सेव करने में विफल। क्या मेरे पास राइट परमिशन है?</translation>
+    </message>
+    <message>
+        <source>The file [%1] does not exist</source>
+        <translation>फाइल [%1] मौजूद नहीं है</translation>
+    </message>
+    <message>
+        <source>Failed to open [%1]. Do I have read permission?</source>
+        <translation>[%1] को ओपन करने में विफल। क्या मेरे पास रीड परमिशन है?</translation>
+    </message>
+    <message>
+        <source>Open Containing Folder of %1</source>
+        <translation>%1 का कंटेनिंग फोल्डर खोलें</translation>
+    </message>
+    <message>
+        <source>Reveal %1 in Finder</source>
+        <translation>फाइंडर में %1 को रिवील करें</translation>
+    </message>
+    <message>
+        <source>Reveal %1 in Explorer</source>
+        <translation>एक्सप्लोरर में %1 को रिवील करें</translation>
+    </message>
+    <message>
+        <source>Reveal %1 in File Manager</source>
+        <translation>फाइल मैनेजर में %1 को रिवील करें</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::ContestDialog</name>
+    <message>
+        <source>Create a new contest</source>
+        <translation>एक नया कॉन्टेस्ट बनाएँ</translation>
+    </message>
+    <message>
+        <source>Contest Details</source>
+        <translation>कॉन्टेस्ट डिटेल्स</translation>
+    </message>
+    <message>
+        <source>Main Directory</source>
+        <translation>मेन डायरेक्टरी</translation>
+    </message>
+    <message>
+        <source>Subdirectory</source>
+        <translation>सबडायरेक्टरी</translation>
+    </message>
+    <message>
+        <source>Save Path</source>
+        <translation>सेव पाथ</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>लैंग्वेज</translation>
+    </message>
+    <message>
+        <source>Number of Problems</source>
+        <translation>नंबर ऑफ प्रॉब्लम्स</translation>
+    </message>
+    <message>
+        <source>Main Directory doesn't exist</source>
+        <translation>मेन डायरेक्टरी मौजूद नहीं है</translation>
+    </message>
+    <message>
+        <source>The Main Directory [%1] doesn't exist. Do you want to create it and continue?</source>
+        <translation>मेन डायरेक्टरी [%1] मौजूद नहीं है। क्या आप इसे बनाना और जारी रखना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Failed to create directory</source>
+        <translation>डायरेक्टरी बनाने में विफल</translation>
+    </message>
+    <message>
+        <source>Failed to create the directory [%1].</source>
+        <translation>डायरेक्टरी [%1] बनाने में विफल।</translation>
+    </message>
+    <message>
+        <source>Choose Main Directory</source>
+        <translation>मेन डायरेक्टरी चुनें</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::DiffViewer</name>
+    <message>
+        <source>Diff Viewer</source>
+        <translation>डिफ़ व्यूअर</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>आउटपुट</translation>
+    </message>
+    <message>
+        <source>Expected</source>
+        <translation>एक्सपेक्टेड</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::Stopwatch</name>
+    <message>
+        <source>Stopwatch</source>
+        <translation>स्टॉपवॉच</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation>शो</translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation>स्टार्ट</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>रीसेट</translation>
+    </message>
+    <message>
+        <source>Pause</source>
+        <translation>पॉज</translation>
+    </message>
+    <message>
+        <source>Resume</source>
+        <translation>रिज्यूम</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::StressTesting</name>
+    <message>
+        <source>Stress Testing</source>
+        <translation>स्ट्रेस टेस्टिंग</translation>
+    </message>
+    <message>
+        <source>User Program: %1</source>
+        <translation>यूजर प्रोग्राम: %1</translation>
+    </message>
+    <message>
+        <source>Generator Path:</source>
+        <translation>जनरेटर पाथ:</translation>
+    </message>
+    <message>
+        <source>Use Generator Arguments:</source>
+        <translation>यूज़ जनरेटर आर्गुमेंट्स:</translation>
+    </message>
+    <message>
+        <source>Example: "10 [5..100] abacaba"</source>
+        <translation>उदाहरण: "10 [5..100] abacaba"</translation>
+    </message>
+    <message>
+        <source>Standard Program Path:</source>
+        <translation>स्टैंडर्ड प्रोग्राम पाथ:</translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation>स्टार्ट</translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation>स्टॉप</translation>
+    </message>
+    <message>
+        <source>Invalid arguments pattern</source>
+        <translation>इनवैलिड आर्गुमेंट्स पैटर्न</translation>
+    </message>
+    <message>
+        <source>Please select a generator and a standard program</source>
+        <translation>कृपया एक जनरेटर और एक स्टैंडर्ड प्रोग्राम चुनें</translation>
+    </message>
+    <message>
+        <source>Read Generator</source>
+        <translation>रीड जनरेटर</translation>
+    </message>
+    <message>
+        <source>Read Standard Program</source>
+        <translation>रीड स्टैंडर्ड प्रोग्राम</translation>
+    </message>
+    <message>
+        <source>Failed to open generator</source>
+        <translation>जनरेटर खोलने में विफल</translation>
+    </message>
+    <message>
+        <source>Failed to open standard program</source>
+        <translation>स्टैंडर्ड प्रोग्राम खोलने में विफल</translation>
+    </message>
+    <message>
+        <source>Failed to create temporary directory</source>
+        <translation>टेम्परेरी डायरेक्टरी बनाने में विफल</translation>
+    </message>
+    <message>
+        <source>Read testlib.h</source>
+        <translation>रीड testlib.h</translation>
+    </message>
+    <message>
+        <source>Save testlib.h</source>
+        <translation>सेव testlib.h</translation>
+    </message>
+    <message>
+        <source>Generator</source>
+        <translation>जनरेटर</translation>
+    </message>
+    <message>
+        <source>User program</source>
+        <translation>यूज़र प्रोग्राम</translation>
+    </message>
+    <message>
+        <source>Standard program</source>
+        <translation>स्टैंडर्ड प्रोग्राम</translation>
+    </message>
+    <message>
+        <source>Compiler</source>
+        <translation>कंपाइलर</translation>
+    </message>
+    <message>
+        <source>%1 compilation has started</source>
+        <translation>%1 कंपाइलेशन शुरू हो गया है</translation>
+    </message>
+    <message>
+        <source>%1 compilation has finished</source>
+        <translation>%1 कंपाइलेशन समाप्त हो गया है</translation>
+    </message>
+    <message>
+        <source>%1 compilation error: %2</source>
+        <translation>%1 कंपाइलेशन एरर: %2</translation>
+    </message>
+    <message>
+        <source>%1 compilation failed: %2</source>
+        <translation>%1 कंपाइलेशन फेल हो गया: %2</translation>
+    </message>
+    <message>
+        <source>%1 compilation killed</source>
+        <translation>%1 कंपाइलेशन किल्ड</translation>
+    </message>
+    <message>
+        <source>Elapsed: %1:%2  |  Completed: %3</source>
+        <translation>इलैप्सड: %1:%2  |  कंप्लीटेड: %3</translation>
+    </message>
+    <message>
+        <source>All tests finished</source>
+        <translation>सभी टेस्ट्स फिनिश हो गए हैं</translation>
+    </message>
+    <message>
+        <source>Running with arguments "%1"</source>
+        <translation>आर्गुमेंट्स "%1" के साथ रन हो रहा है</translation>
+    </message>
+    <message>
+        <source>Time Limit Exceeded</source>
+        <translation>टाइम लिमिट एक्सीडेड</translation>
+    </message>
+    <message>
+        <source>Execution has finished with non-zero exitcode %1 in %2ms</source>
+        <translation>एग्जीक्यूशन नॉन-ज़ीरो एग्जिटकोड %1 के साथ %2ms में फिनिश हो गया है</translation>
+    </message>
+    <message>
+        <source>The program was killed</source>
+        <translation>प्रोग्राम को किल कर दिया गया था</translation>
+    </message>
+    <message>
+        <source>Output limit exceeded</source>
+        <translation>आउटपुट लिमिट एक्सीडेड</translation>
+    </message>
+    <message>
+        <source>Counterexample Found</source>
+        <translation>काउंटरएग्जांपल फाउंड</translation>
+    </message>
+    <message>
+        <source>Add to testcases</source>
+        <translation>टेस्टकेसेस में ऐड करें</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation>इग्नोर</translation>
+    </message>
+    <message>
+        <source>Stop stress testing</source>
+        <translation>स्ट्रेस टेस्टिंग रोकें</translation>
+    </message>
+    <message>
+        <source>Counterexample added to testcases</source>
+        <translation>काउंटर-एग्जांपल टेस्टकेस में जोड़ा गया</translation>
+    </message>
+    <message>
+        <source>Select generator from opened files...</source>
+        <translation>ओपन फाइलों में से जनरेटर चुनें...</translation>
+    </message>
+    <message>
+        <source>Select standard program from opened files...</source>
+        <translation>ओपन फाइलों में से स्टैंडर्ड प्रोग्राम चुनें...</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::TestCase</name>
+    <message>
+        <source>Input</source>
+        <translation>इनपुट</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>आउटपुट</translation>
+    </message>
+    <message>
+        <source>Expected</source>
+        <translation>एक्सपेक्टेड</translation>
+    </message>
+    <message>
+        <source>Run</source>
+        <translation>रन</translation>
+    </message>
+    <message>
+        <source>Del</source>
+        <translation>डेल</translation>
+    </message>
+    <message>
+        <source>Test on a single testcase</source>
+        <translation>एक सिंगल टेस्टकेस पर टेस्ट करें</translation>
+    </message>
+    <message>
+        <source>Open the Diff Viewer</source>
+        <translation>डिफ़ व्यूअर खोलें</translation>
+    </message>
+    <message>
+        <source>Input #%1</source>
+        <translation>इनपुट #%1</translation>
+    </message>
+    <message>
+        <source>Output #%1</source>
+        <translation>आउटपुट #%1</translation>
+    </message>
+    <message>
+        <source>Expected #%1</source>
+        <translation>एक्सपेक्टेड #%1</translation>
+    </message>
+    <message>
+        <source>Delete Testcase</source>
+        <translation>डिलीट टेस्ट केस</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete test case #%1?</source>
+        <translation>क्या आप वाकई टेस्ट केस #%1 को डिलीट करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Diff Viewer[%1]</source>
+        <translation>डिफ़ व्यूअर[%1]</translation>
+    </message>
+    <message>
+        <source>The output/expected contains more than %1 characters, HTML diff viewer is disabled. You can change the length limit at %2.</source>
+        <translation>आउटपुट/एक्सपेक्टेड में %1 से अधिक कैरेक्टर हैं, HTML डिफ़ व्यूअर डिसेबल है। आप %2 पर लेंथ लिमिट बदल सकते हैं।</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::TestCaseEdit</name>
+    <message>
+        <source>Input</source>
+        <translation>इनपुट</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>आउटपुट</translation>
+    </message>
+    <message>
+        <source>Expected</source>
+        <translation>एक्सपेक्टेड</translation>
+    </message>
+    <message>
+        <source>Only the first %1 characters are shown. Now the test case editor is read-only. You can set the length limit at %2.</source>
+        <translation>केवल पहले %1 कैरेक्टर दिखाए गए हैं। अब टेस्ट केस एडिटर रीड-ओनली है। आप %2 पर लेंथ लिमिट सेट कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Save to file</source>
+        <translation>सेव टू फ़ाइल</translation>
+    </message>
+    <message>
+        <source>Save test case to file</source>
+        <translation>टेस्ट केस को फ़ाइल में सेव करें</translation>
+    </message>
+    <message>
+        <source>Load From File</source>
+        <translation>लोड फ़्रॉम फ़ाइल</translation>
+    </message>
+    <message>
+        <source>Edit in Bigger Window</source>
+        <translation>एडिट इन बिगर विंडो</translation>
+    </message>
+    <message>
+        <source>Edit Testcase</source>
+        <translation>एडिट टेस्ट केस</translation>
+    </message>
+    <message>
+        <source>Copy Output to Expected</source>
+        <translation>कॉपी आउटपुट टू एक्सपेक्टेड</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::TestCases</name>
+    <message>
+        <source>Test Cases</source>
+        <translation>टेस्ट केसेस</translation>
+    </message>
+    <message>
+        <source>Checker:</source>
+        <translation>चेकर:</translation>
+    </message>
+    <message>
+        <source>Add Test</source>
+        <translation>ऐड टेस्ट</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation>मोर</translation>
+    </message>
+    <message>
+        <source>Add Checker</source>
+        <translation>ऐड चेकर</translation>
+    </message>
+    <message>
+        <source>Unaccepted / Accepted / Total</source>
+        <translation>अनएक्सेप्टेड / एक्सेप्टेड / टोटल</translation>
+    </message>
+    <message>
+        <source>Add a custom testlib checker</source>
+        <translation>एक कस्टम टेस्टलिब चेकर ऐड करें</translation>
+    </message>
+    <message>
+        <source>Add Pairs of Testcases From Files</source>
+        <translation>फाइलों से टेस्टकेसेस के पेयर्स ऐड करें</translation>
+    </message>
+    <message>
+        <source>Choose Testcase Files</source>
+        <translation>टेस्टकेस फाइलें चुनें</translation>
+    </message>
+    <message>
+        <source>Testcases</source>
+        <translation>टेस्टकेसेस</translation>
+    </message>
+    <message>
+        <source>Load Testcases</source>
+        <translation>लोड टेस्टकेसेस</translation>
+    </message>
+    <message>
+        <source>A pair of testcases [%1] and [%2] is loaded</source>
+        <translation>टेस्टकेसेस का एक पेयर [%1] और [%2] लोड हो गया है</translation>
+    </message>
+    <message>
+        <source>An input [%1] is loaded</source>
+        <translation>एक इनपुट [%1] लोड हो गया है</translation>
+    </message>
+    <message>
+        <source>The following files are not loaded because they are not matched:%1. You can set the matching rules at %2.</source>
+        <translation>निम्नलिखित फाइलें लोड नहीं की गई हैं क्योंकि वे मैच नहीं हुईं:%1। आप %2 पर मैचिंग रूल्स सेट कर सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Check All</source>
+        <extracomment>Here "Check" means to check the checkbox</extracomment>
+        <translation>चेक ऑल</translation>
+    </message>
+    <message>
+        <source>Uncheck All</source>
+        <translation>अनचेक ऑल</translation>
+    </message>
+    <message>
+        <source>Uncheck Accepted</source>
+        <translation>एक्सेप्टेड अनचेक करें</translation>
+    </message>
+    <message>
+        <source>Invert</source>
+        <extracomment>This action checks the checkboxes which were not checked, and unchecks the ones which were checked</extracomment>
+        <translation>इनवर्ट</translation>
+    </message>
+    <message>
+        <source>Delete All</source>
+        <translation>डिलीट ऑल</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete all test cases?</source>
+        <translation>क्या आप वाकई सभी टेस्ट केसेस डिलीट करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Delete Empty</source>
+        <translation>डिलीट एम्पटी</translation>
+    </message>
+    <message>
+        <source>Delete Checked</source>
+        <extracomment>Here "checked" means the checkbox is checked</extracomment>
+        <translation>डिलीट चेक्ड</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete all checked test cases?</source>
+        <translation>क्या आप वाकई सभी चेक्ड टेस्ट केसेस डिलीट करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Copy Test Cases</source>
+        <translation>कॉपी टेस्ट केसेस</translation>
+    </message>
+    <message>
+        <source>Paste Test Cases</source>
+        <translation>पेस्ट टेस्ट केसेस</translation>
+    </message>
+    <message>
+        <source>Copy Output to Expected</source>
+        <translation>कॉपी आउटपुट टू एक्सपेक्टेड</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to copy all checked output to their corresponding expected?</source>
+        <extracomment>Here "checked" means the checkbox is checked</extracomment>
+        <translation>क्या आप वाकई सभी चेक्ड आउटपुट को उनके संबंधित एक्सपेक्टेड में कॉपी करना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Ignore trailing spaces</source>
+        <translation>ट्रेलिंग स्पेस इग्नोर करें</translation>
+    </message>
+    <message>
+        <source>Strictly the same</source>
+        <translation>स्ट्रिक्टली द सेम</translation>
+    </message>
+    <message>
+        <source>ncmp - Compare int64s</source>
+        <translation>ncmp - कंपेयर int64s</translation>
+    </message>
+    <message>
+        <source>rcmp4 - Compare doubles, max error 1e-4</source>
+        <translation>rcmp4 - कंपेयर doubles, मैक्स एरर 1e-4</translation>
+    </message>
+    <message>
+        <source>rcmp6 - Compare doubles, max error 1e-6</source>
+        <translation>rcmp6 - डबल्स को कंपेयर करें, अधिकतम एरर 1e-6</translation>
+    </message>
+    <message>
+        <source>rcmp9 - Compare doubles, max error 1e-9</source>
+        <translation>rcmp9 - डबल्स को कंपेयर करें, अधिकतम एरर 1e-9</translation>
+    </message>
+    <message>
+        <source>wcmp - Compare tokens</source>
+        <translation>wcmp - टोकन्स को कंपेयर करें</translation>
+    </message>
+    <message>
+        <source>nyesno - Compare YES/NOs, case insensitive</source>
+        <translation>nyesno - YES/NOs को कंपेयर करें, केस इनसेंसिटिव</translation>
+    </message>
+    <message>
+        <source>Add Test Case</source>
+        <translation>टेस्ट केस ऐड करें</translation>
+    </message>
+    <message>
+        <source>There are already %1 test cases, you can't add more.</source>
+        <translation>पहले से ही %1 टेस्ट केस मौजूद हैं, आप और ऐड नहीं कर सकते।</translation>
+    </message>
+    <message>
+        <source>Input #%1</source>
+        <translation>इनपुट #%1</translation>
+    </message>
+    <message>
+        <source>Expected #%1</source>
+        <translation>एक्सपेक्टेड #%1</translation>
+    </message>
+    <message>
+        <source>Save Input #%1</source>
+        <translation>इनपुट #%1 सेव करें</translation>
+    </message>
+    <message>
+        <source>Save Expected #%1</source>
+        <translation>एक्सपेक्टेड #%1 सेव करें</translation>
+    </message>
+    <message>
+        <source>Load %1</source>
+        <translation>लोड %1</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::UpdatePresenter</name>
+    <message>
+        <source>Download</source>
+        <translation>डाउनलोड</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>क्लोज</translation>
+    </message>
+    <message>
+        <source>New update available</source>
+        <translation>नया अपडेट उपलब्ध है</translation>
+    </message>
+    <message>
+        <source>A new %1 update &lt;a href="%2"&gt;%3&lt;/a&gt; is available. See below for the changelog.&lt;br /&gt;We highly recommend you keep the editor up to date so that you won't miss the awesome new features and bug fixes.</source>
+        <translation>एक नया %1 अपडेट &lt;a href="%2"&gt;%3&lt;/a&gt; उपलब्ध है। चेंजलॉग के लिए नीचे देखें।&lt;br /&gt;हम पुरजोर सलाह देते हैं कि आप एडिटर को अपडेट रखें ताकि आप शानदार नए फीचर्स और बग फिक्स का लाभ उठा सकें।</translation>
+    </message>
+    <message>
+        <source>beta</source>
+        <translation>बीटा</translation>
+    </message>
+    <message>
+        <source>stable</source>
+        <translation>स्टेबल</translation>
+    </message>
+</context>
+<context>
+    <name>Widgets::UpdateProgressDialog</name>
+    <message>
+        <source>Cancel</source>
+        <translation>कैंसिल</translation>
+    </message>
+    <message>
+        <source>Close this dialog and abort the update check</source>
+        <translation>इस डायलॉग को क्लोज करें और अपडेट चेक को एबॉल्ट करें</translation>
+    </message>
+    <message>
+        <source>Update Checker</source>
+        <translation>अपडेट चेकर</translation>
+    </message>
+    <message>
+        <source>Fetching the list of releases...</source>
+        <translation>रिलीज़ की लिस्ट फेच की जा रही है...</translation>
+    </message>
+    <message>
+        <source>Error: %1&lt;br /&gt;&lt;br /&gt;Updater failed to check for update. Please manually check for update at&lt;br /&gt;&lt;a href="https://cpeditor.org/download"&gt;https://cpeditor.org/download&lt;/a&gt; or &lt;a href="https://github.com/cpeditor/cpeditor/releases"&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt;.</source>
+        <translation>एरर: %1&lt;br /&gt;&lt;br /&gt;अपडेटर अपडेट चेक करने में फेल हो गया। कृपया &lt;br /&gt;&lt;a href="https://cpeditor.org/download"&gt;https://cpeditor.org/download&lt;/a&gt; या &lt;a href="https://github.com/cpeditor/cpeditor/releases"&gt;https://github.com/cpeditor/cpeditor/releases&lt;/a&gt; पर मैन्युअल रूप से अपडेट चेक करें।</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>क्लोज</translation>
+    </message>
+    <message>
+        <source>Hooray!! You are already using the latest release of CP Editor.</source>
+        <translation>हुर्रे!! आप पहले से ही CP Editor का लेटेस्ट रिलीज़ इस्तेमाल कर रहे हैं।</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Description

This PR introduces the complete Hindi (`hi_IN`) translation for CP Editor and resolves a minor UI settings bug. 

**Key Changes:**
* **i18n:** Translated missing/unfinished strings in `hi_IN.ts` to natural Hindi, keeping technical terms (like Build, Run, Indent) accurately transliterated to avoid confusion.
* **Configuration:** Registered the `hi_IN` locale across the build system and core files (`CMakeLists.txt`, `src/Core/Translator.cpp`, `src/Settings/settings.json`, and `tools/updateTranslation.sh`).
* **Changelog:** Added the relevant entry in `CHANGELOG.md` under the `[Unreleased]` section.

**Screnshot**
<img width="1920" height="1080" alt="cpeditor_4Rz5yOjbiX" src="https://github.com/user-attachments/assets/fc9a5b39-1479-4a18-8fad-98839a69235e" />

## Type of change
- [x] Translation / New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have read the contributing guidelines.
- [x] My code follows the code style of this project (ran `clang-format`).
- [x] I have updated the `CHANGELOG.md` accordingly.
- [x] I have tested these changes locally and verified that the UI renders the translated text correctly without any layout breaks.

cc @coder3101 (Thanks for assigning this issue to me!)