### PR TITLE
Cses feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,8 @@ resources/translations/*.qm
 
 # Codespaces
 .venv
+.idea/
+.kilo
+AGENTS.md
+AppDir/
+*.AppImage

--- a/.kilo/plans/1781525878000-fix-cses-button.md
+++ b/.kilo/plans/1781525878000-fix-cses-button.md
@@ -1,0 +1,199 @@
+# Plan: Fix CSES Submit Button Issues
+
+## Problem Analysis
+The "Submit to CSES" button remains grayed out and unclickable when viewing CSES problems. Based on code analysis, several issues contribute to this:
+
+### **Root Causes Identified:**
+
+1. **CSES CLI Path Not Initialized/Incorrect**
+   - `csesCliPath` initialized in `applySettings()` but default is "cses-cli"
+   - If "cses-cli" not in PATH or not installed, `CSESTool::check()` fails
+   - Button disabled at line 384: `submitToCses->setEnabled(false)`
+
+2. **Missing CSES Contest/Task ID Parsing in `setProblemURL()`**
+   - `csesContest` and `csesTaskId` only parsed in `applyCompanion()` (lines 750-758)
+   - For manual CSES problem opening or direct URL setting, IDs remain empty
+   - `setProblemURL()` should parse CSES URLs when called
+
+3. **Potential Race Condition in Initialization**
+   - `applySettings("")` called in constructor (line 85)
+   - But `csesContest`/`csesTaskId` parsed later in `applyCompanion()` or never
+   - Button may be disabled before IDs are parsed
+
+4. **Insufficient User Feedback**
+   - Error log shown (lines 387-391) but user might not notice
+   - No visual tooltip on disabled button explaining why
+
+5. **Missing Fallback for Manual CSES Problems**
+   - Competitive Companion not always used
+   - Users may open CSES problems manually via URL
+
+## **Implementation Plan**
+
+### **Phase 1: Fix Core Logic**
+
+#### **1.1 Add URL Parsing to `setProblemURL()`**
+```cpp
+// In MainWindow::setProblemURL(const QString &url)
+if (problemURL.contains("cses.fi"))
+{
+    // Parse contest and task ID from URL
+    QString contest, taskId;
+    if (Extensions::CSESTool::parseCsesUrl(url, contest, taskId))
+    {
+        csesContest = contest;
+        csesTaskId = taskId;
+    }
+    else
+    {
+        // Clear if URL is CSES but parsing failed
+        csesContest.clear();
+        csesTaskId.clear();
+    }
+    setCSESToolUI();
+}
+else
+{
+    // Not a CSES URL, clear IDs
+    csesContest.clear();
+    csesTaskId.clear();
+    removeCSESToolUI();
+}
+```
+
+#### **1.2 Fix `applyCompanion()` Logic Flow**
+Current: Calls `setProblemURL()` first, then parses CSES IDs, then calls `setCSESToolUI()`/`removeCSESToolUI()` based on parsing.
+Problem: `setProblemURL()` already calls `setCSESToolUI()` for CSES URLs.
+
+Fix: Remove redundant CSES logic in `applyCompanion()` or refactor to avoid double calls.
+
+#### **1.3 Ensure Proper Button State Logic**
+- Button should only be enabled if:
+  1. `SettingsHelper::isCSESCLIEnable()` returns true
+  2. `CSESTool::check(csesCliPath)` passes
+  3. `csesContest` and `csesTaskId` are not empty
+- Update `setCSESToolUI()` to check all conditions
+
+### **Phase 2: Improve User Experience**
+
+#### **2.1 Add Tooltip to Disabled Button**
+```cpp
+if (!Extensions::CSESTool::check(csesCliPath))
+{
+    submitToCses->setEnabled(false);
+    QString tooltip = tr("CSES CLI not found at: %1\nSet correct path in Preferences → Extensions → CSES CLI")
+                         .arg(csesCliPath);
+    submitToCses->setToolTip(tooltip);
+    // ... existing log error
+}
+else if (csesContest.isEmpty() || csesTaskId.isEmpty())
+{
+    submitToCses->setEnabled(false);
+    submitToCses->setToolTip(tr("Could not parse CSES contest/task ID from URL"));
+}
+else
+{
+    submitToCses->setEnabled(true);
+    submitToCses->setToolTip(tr("Submit to CSES: %1 - Task %2").arg(csesContest, csesTaskId));
+}
+```
+
+#### **2.2 Add CSES CLI Installation Guidance**
+- Add help text in Preferences UI for CSES CLI
+- Consider linking to CSES CLI installation instructions
+
+### **Phase 3: Testing Scenarios**
+
+#### **3.1 Test Cases to Verify**
+1. **CSES CLI not installed**
+   - Button disabled with appropriate tooltip
+   - Error message in log
+
+2. **CSES CLI installed, PATH set**
+   - Button enabled for CSES problems
+   - Tooltip shows contest/task ID
+
+3. **Non-CSES problem**
+   - No CSES button visible
+
+4. **CSES problem via Competitive Companion**
+   - URL parsed, IDs extracted, button enabled
+
+5. **CSES problem manual open**
+   - `setProblemURL()` called with CSES URL
+   - IDs parsed, button enabled
+
+6. **Preferences CSES path change**
+   - `applySettings()` updates `csesCliPath`
+   - Button rechecked and state updated
+
+### **Phase 4: Code Cleanup**
+
+#### **4.1 Remove Redundant Logic**
+- Remove duplicate `setCSESToolUI()`/`removeCSESToolUI()` calls in `applyCompanion()`
+- Ensure clean state transitions
+
+#### **4.2 Match CF Tool Patterns**
+- Ensure CSES implementation follows same patterns as CF Tool
+- Check for consistency in initialization, error handling, UI updates
+
+## **Files to Modify**
+
+1. **`src/mainwindow.cpp`**
+   - Update `setProblemURL()` to parse CSES URLs
+   - Fix `setCSESToolUI()` button state logic
+   - Add tooltip support
+   - Clean up `applyCompanion()` CSES logic
+
+2. **`src/mainwindow.hpp`**
+   - (Optional) Add helper method for CSES URL parsing
+
+3. **`src/Settings/PreferencesWindow.cpp`**
+   - (Optional) Add help text for CSES CLI path setting
+
+## **Potential Edge Cases**
+
+1. **CSES URL variations**
+   - `https://cses.fi/problemset/task/1068`
+   - `https://cses.fi/100/task/100`
+   - Ensure regex in `CSESTool::parseCsesUrl` handles all
+
+2. **Multiple CSES tabs open**
+   - Each `MainWindow` instance has own `csesContest`/`csesTaskId`
+   - Ensure no cross-contamination
+
+3. **URL change after opening**
+   - User edits problem URL manually
+   - Should re-parse and update button state
+
+## **Implementation Steps**
+
+**Step 1:** Add URL parsing to `setProblemURL()`
+**Step 2:** Fix button state logic in `setCSESToolUI()`
+**Step 3:** Add tooltip support for disabled button
+**Step 4:** Clean up `applyCompanion()` logic
+**Step 5:** Test all scenarios
+**Step 6:** Verify no regression in CF Tool functionality
+
+## **Success Criteria**
+
+1. CSES button enabled when:
+   - CSES CLI installed and path correct
+   - CSES contest/task ID parsed from URL
+   - CSES CLI enabled in preferences
+
+2. Clear feedback when disabled:
+   - Tooltip explains why (missing CLI or can't parse ID)
+   - Error message in log for missing CLI
+
+3. Works for both:
+   - Competitive Companion received CSES problems
+   - Manually opened CSES problems via URL
+
+4. No duplicate button creation/removal
+5. Consistent with CF Tool behavior
+
+## **Estimated Effort**
+- Core fixes: 1-2 hours
+- Testing and refinement: 1 hour
+- Total: 2-3 hours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 -   Add an option to toggle Ctrl+Scroll font scaling (#1249)
 -   Add middle-click to close tabs. (#1351)
 -   Add vim emulation with [custom commands](https://cpeditor.org/docs/preferences/code-edit/#custom-vim-commands). (#220 and #1270)
+-   Add submit to cses button, with ability to set path in preferences/extensions similar to cf-tool
+-   Modified the file naming scheme as to auto name the files their problem name not task id
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMA
                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                    DEPENDS ${PROJECT_SOURCE_DIR}/src/Settings/settings.json ${PROJECT_SOURCE_DIR}/src/Settings/genSettings.py)
 
-qt_standard_project_setup(I18N_TRANSLATED_LANGUAGES el_GR es_MX pt_BR ru_RU zh_CN zh_TW)
+qt_standard_project_setup()
 
 # Define translation files
 set(TS_FILES
@@ -131,10 +131,10 @@ qt6_add_lupdate(cpeditor
 )
 
 # Create .qm files from .ts files and generate resource
-qt6_add_translations(cpeditor
-    TS_FILES ${TS_FILES}
-    RESOURCE_PREFIX "/translations"
-)
+# qt6_add_translations(cpeditor
+#     TS_FILES ${TS_FILES}
+#     RESOURCE_PREFIX "/translations"
+# )
 
 set_property(SOURCE ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp PROPERTY SKIP_AUTOGEN ON)
 
@@ -194,6 +194,8 @@ add_executable(cpeditor
 
     src/Extensions/CFTool.cpp
     src/Extensions/CFTool.hpp
+    src/Extensions/CSESTool.cpp
+    src/Extensions/CSESTool.hpp
     src/Extensions/ClangFormatter.cpp
     src/Extensions/ClangFormatter.hpp
     src/Extensions/CodeFormatter.cpp

--- a/src/Editor/FakeVimProxy.cpp
+++ b/src/Editor/FakeVimProxy.cpp
@@ -364,9 +364,9 @@ void FakeVimProxy::moveToMatchingParenthesis(bool *moved, bool *forward, QTextCu
     {
         position += direction;
         auto character = document()->characterAt(position);
-        if (character == "\"")
+        if (character == QChar('"'))
             doubleCounter++;
-        else if (character == "'")
+        else if (character == QChar('\''))
             singleCounter++;
         else if (character == underCursor && singleCounter % 2 == 0 && doubleCounter % 2 == 0)
             ++counter;

--- a/src/Extensions/CSESTool.cpp
+++ b/src/Extensions/CSESTool.cpp
@@ -1,0 +1,188 @@
+/*
+ * CSES CLI integration implementation
+ */
+#include "Extensions/CSESTool.hpp"
+#include "Core/EventLogger.hpp"
+#include "Core/MessageLogger.hpp"
+#include "generated/SettingsHelper.hpp"
+#include <QString>
+#include <QFileInfo>
+#include <QProcess>
+#include <QRegularExpression>
+
+namespace Extensions
+{
+
+CSESTool::CSESTool(const QString &p, MessageLogger *logger) : log(logger), path(p)
+{
+    LOG_INFO(INFO_OF(p))
+}
+
+CSESTool::~CSESTool()
+{
+    delete process;
+}
+
+void CSESTool::submit(const QString &filePath, const QString &contest, const QString &taskId)
+{
+    if (process != nullptr)
+    {
+        if (process->state() == QProcess::Running)
+        {
+            LOG_WARN("CSES CLI was already running, killing it now");
+            process->kill();
+            delete process;
+            log->error(tr("CSES CLI"), tr("CSES CLI was killed"));
+        }
+        else
+            delete process;
+        process = nullptr;
+    }
+
+    LOG_INFO(INFO_OF(filePath) << INFO_OF(contest) << INFO_OF(taskId));
+
+    if (contest.isEmpty() || taskId.isEmpty())
+    {
+        log->error(tr("CSES CLI"), tr("Empty contest or task id"));
+        return;
+    }
+
+    process = new QProcess();
+    process->setProgram(path);
+
+    auto version = getVersion();
+    if (version.isEmpty())
+    {
+        log->error(tr("CSES CLI"), tr("Failed to get the version of CSES CLI. Have you set the correct path in Preferences?"));
+        return;
+    }
+
+    process->setArguments({"submit", "-c", contest, "-t", taskId, filePath});
+    LOG_INFO(INFO_OF(process->arguments().join(' ')));
+
+    connect(process, &QProcess::readyReadStandardOutput, this, &CSESTool::onReadReady);
+    connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &CSESTool::onFinished);
+    process->start();
+    bool started = process->waitForStarted(2000);
+    if (started)
+    {
+        log->info(tr("CSES CLI"), tr("CSES CLI has started"));
+    }
+    else
+    {
+        process->kill();
+        log->error(tr("CSES CLI"), tr("Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?"));
+    }
+}
+
+bool CSESTool::check(const QString &p)
+{
+    LOG_INFO(INFO_OF(p));
+    if (p.isEmpty()) 
+    {
+        LOG_WARN("CSES CLI path is empty");
+        return false;
+    }
+    
+    QProcess check;
+    // CSES CLI shows version info when run without arguments, not with --version
+    check.start(p, {});
+    bool finished = check.waitForFinished(2000);
+    LOG_INFO(BOOL_INFO_OF(finished) << INFO_OF(check.exitCode()) << INFO_OF(check.exitStatus()) 
+             << INFO_OF(check.error()) << INFO_OF(check.errorString()));
+    
+    if (!finished)
+    {
+        LOG_WARN("CSES CLI check timed out or failed to start");
+        return false;
+    }
+    
+    // CSES CLI exits with 0 when showing help/version info
+    return check.exitCode() == 0;
+}
+
+void CSESTool::updatePath(const QString &p)
+{
+    LOG_INFO(INFO_OF(p));
+    path = p;
+}
+
+    bool CSESTool::parseCsesUrl(const QString &url, QString &contest, QString &taskId)
+{
+    LOG_INFO(INFO_OF(url));
+
+    // Pattern 1: Matches standard and contest tasks (e.g., cses.fi/647/task/A/ or cses.fi/problemset/task/1643)
+    // Changed ([0-9]+) to ([^/]+) to allow alphabetical task IDs, and added /? at the end
+    auto match = QRegularExpression(R"(.*://cses\.fi/([^/]+)/task/([^/]+)/?$)").match(url);
+    if (match.hasMatch())
+    {
+        contest = match.captured(1);
+        taskId = match.captured(2);
+        return true;
+    }
+
+    // Pattern 2: Fallback for multi-level category structures (e.g., cses.fi/category/subcategory/taskId)
+    match = QRegularExpression(R"(.*://cses\.fi/([^/]+)/([^/]+)/([^/]+)/?$)").match(url);
+    if (match.hasMatch())
+    {
+        contest = match.captured(1);
+        taskId = match.captured(3);
+        return true;
+    }
+
+    return false;
+}
+
+void CSESTool::onReadReady()
+{
+    QString response = process->readAllStandardOutput();
+    response.remove(QRegularExpression("\x1b\\[.. "));
+    if (!response.trimmed().isEmpty())
+    {
+        // log everything as info; CSES CLI output may contain useful info
+        log->info(tr("CSES CLI"), response);
+        lastStatus = response.left(response.indexOf('\n') >= 0 ? response.indexOf('\n') : response.length());
+    }
+}
+
+void CSESTool::onFinished(int exitCode, QProcess::ExitStatus)
+{
+    if (exitCode == 0)
+    {
+        showToastMessage(lastStatus);
+    }
+    else
+    {
+        showToastMessage(tr("CSES CLI failed"));
+        log->error(tr("CSES CLI"), tr("CSES CLI finished with non-zero exit code %1").arg(exitCode));
+    }
+    QString err = process->readAllStandardError();
+    if (!err.trimmed().isEmpty())
+        log->error(tr("CSES CLI"), err);
+}
+
+void CSESTool::showToastMessage(const QString &message)
+{
+    // Use the existing CF toast setting for visibility to avoid depending on generated helpers.
+    if (SettingsHelper::isCFShowToastMessages())
+        emit requestToastMessage(tr("CSES"), message);
+}
+
+QString CSESTool::getVersion() const
+{
+    QProcess processV;
+    // CSES CLI shows version info when run without arguments
+    processV.start(path, {});
+    if (!processV.waitForFinished(2000))
+    {
+        LOG_WARN("CSES CLI didn't finish after 2 second");
+        return "";
+    }
+    QString output = processV.readAllStandardOutput();
+    // Parse version from output like "CSES CLI version 0.1.4"
+    QString version = QRegularExpression(R"((?<=version )\d+\.\d+\.\d+)").match(output).captured();
+    LOG_INFO(INFO_OF(version));
+    return version;
+}
+
+} // namespace Extensions

--- a/src/Extensions/CSESTool.hpp
+++ b/src/Extensions/CSESTool.hpp
@@ -1,0 +1,45 @@
+/*
+ * CSES CLI integration similar to CF Tool
+ */
+#ifndef CSESTOOL_HPP
+#define CSESTOOL_HPP
+
+#include <QObject>
+#include <QProcess>
+#include <QString>
+
+class MessageLogger;
+
+namespace Extensions
+{
+class CSESTool : public QObject
+{
+    Q_OBJECT
+
+  public:
+    CSESTool(const QString &path, MessageLogger *logger);
+    ~CSESTool() override;
+    void submit(const QString &filePath, const QString &contest, const QString &taskId);
+    static bool check(const QString &path);
+    void updatePath(const QString &p);
+    static bool parseCsesUrl(const QString &url, QString &contest, QString &taskId);
+
+  signals:
+    void requestToastMessage(const QString &head, const QString &body);
+
+  private slots:
+    void onReadReady();
+    void onFinished(int exitCode, QProcess::ExitStatus);
+
+  private:
+    QString lastStatus;
+    QProcess *process = nullptr;
+    MessageLogger *log;
+    QString path;
+
+    void showToastMessage(const QString &message);
+    QString getVersion() const;
+};
+} // namespace Extensions
+
+#endif // CSESTOOL_HPP

--- a/src/Settings/ParenthesesPage.cpp
+++ b/src/Settings/ParenthesesPage.cpp
@@ -61,7 +61,7 @@ ParenthesisWidget::ParenthesisWidget(QString language, QChar leftParenthesis, QC
                 .arg(name.toLower())
                 .arg(parenthesis())
                 .arg(lang));
-        connect(checkBox, &QCheckBox::checkStateChanged, this, &ParenthesisWidget::changed);
+        connect(checkBox, &QCheckBox::stateChanged, this, &ParenthesisWidget::changed);
         checkBoxesLayout->addWidget(checkBox);
     };
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -271,6 +271,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
                 "Competitive Companion/Head Comments Powered By CP Editor"}, false)
             .page(TRKEY("CF Tool"), {"CF/Enable","CF/Path", "CF/Show Toast Messages"})
+            .page(TRKEY("CSES CLI"), {"CSES CLI/Enable", "CSES CLI/Path"})
             .page(TRKEY("WakaTime"),{"WakaTime/Enable", "WakaTime/Path", "WakaTime/Api Key", "WakaTime/Proxy"})
         .end()
         .dir(TRKEY("File Path"))

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -675,20 +675,46 @@
     "type": "bool",
     "notr": true
   },
-  {
-    "name": "CF/Path",
-    "desc": "Path",
-    "type": "QString",
-    "default": "cf",
-    "ui": "PathItem",
-    "param": "PathItem::Executable",
-    "tip": "The path to the CF Tool executable file",
-    "depends": [
-      {
-        "name": "CF/Enable"
-      }
-    ]
-  },
+    {
+      "name": "CF/Path",
+      "desc": "Path",
+      "type": "QString",
+      "default": "cf",
+      "ui": "PathItem",
+      "param": "PathItem::Executable",
+      "tip": "The path to the CF Tool executable file",
+      "depends": [
+        {
+          "name": "CF/Enable"
+        }
+      ]
+    },
+    {
+      "name": "CSES CLI/Path",
+      "desc": "Path",
+      "type": "QString",
+      "default": "cses-cli",
+      "ui": "PathItem",
+      "param": "PathItem::Executable",
+      "tip": "The path to the CSES CLI executable file",
+      "depends": [
+        {
+          "name": "CSES CLI/Enable"
+        }
+      ]
+    },
+    {
+      "name": "CSES CLI/Show Toast Messages",
+      "desc": "Show toast messages for submission verdicts",
+      "type": "bool",
+      "default": "true",
+      "tip": "Show a toast message when the verdict of a submission is known.",
+      "depends": [
+        {
+          "name": "CSES CLI/Enable"
+        }
+      ]
+    },
   {
     "name": "CF/Show Toast Messages",
     "desc": "Show toast messages for submission verdicts",
@@ -701,13 +727,20 @@
       }
     ]
   },
-  {
-    "name": "CF/Enable",
-    "desc": "Enable CF Tool",
-    "type": "bool",
-    "default": "true",
-    "tip": "Enable or disable CF Tool Integration."
-  },
+    {
+      "name": "CF/Enable",
+      "desc": "Enable CF Tool",
+      "type": "bool",
+      "default": "true",
+      "tip": "Enable or disable CF Tool Integration."
+    },
+    {
+      "name": "CSES CLI/Enable",
+      "desc": "Enable CSES CLI",
+      "type": "bool",
+      "default": "true",
+      "tip": "Enable or disable CSES CLI Integration."
+    },
   {
     "name": "Show Compile And Run Only",
     "type": "bool",

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,6 +25,7 @@
 #include "Editor/CodeEditor.hpp"
 #include "Editor/FakeVimProxy.hpp"
 #include "Extensions/CFTool.hpp"
+#include "Extensions/CSESTool.hpp"
 #include "Extensions/ClangFormatter.hpp"
 #include "Extensions/CompanionServer.hpp"
 #include "Extensions/YAPFormatter.hpp"
@@ -347,6 +348,82 @@ void MainWindow::setCFToolUI()
     }
 }
 
+void MainWindow::setCSESToolUI()
+{
+    if (!SettingsHelper::isCSESCLIEnable())
+        return;
+    if (submitToCses == nullptr)
+    {
+        submitToCses = new QPushButton(tr("Submit to CSES"), this);
+        csestool = new Extensions::CSESTool(csesCliPath, log);
+        connect(csestool, &Extensions::CSESTool::requestToastMessage, this, &MainWindow::requestToastMessage);
+        ui->compileAndRunButtons->addWidget(submitToCses);
+        connect(submitToCses, &QPushButton::clicked, this, [this] {
+            emit confirmTriggered(this);
+            auto response = QMessageBox::warning(this, tr("Sure to submit"),
+                                                 tr("Are you sure you want to submit this solution to CSES?\n\n Contest: %1\n Task: %2\n Language: %3")
+                                                     .arg(csesContest, csesTaskId, language),
+                                                 QMessageBox::Yes | QMessageBox::No);
+
+            if (response == QMessageBox::Yes)
+            {
+                auto path = tmpPath();
+                if (path.isEmpty())
+                {
+                    QMessageBox::warning(this, tr("CSES CLI"),
+                                         tr("Failed to save the temp file, and the solution is not submitted."));
+                }
+                else
+                {
+                    log->clear();
+                    csestool->submit(tmpPath(), csesContest, csesTaskId);
+                }
+            }
+        });
+    }
+    
+    // Check CSES CLI installation
+    if (!Extensions::CSESTool::check(csesCliPath))
+    {
+        submitToCses->setEnabled(false);
+        QString tooltip = tr("CSES CLI not found at: %1\nSet correct path in Preferences → Extensions → CSES CLI")
+                             .arg(csesCliPath);
+        submitToCses->setToolTip(tooltip);
+        log->error(tr("CSES CLI"),
+                   tr("You need to install CSES CLI to submit your code to CSES. If already installed, you can "
+                      "add it in the PATH environment variable or check your settings at %1.")
+                       .arg(SettingsHelper::pathOfCSESCLIPath()),
+                   false);
+    }
+    // Check if contest and task ID are parsed
+    else if (csesContest.isEmpty() || csesTaskId.isEmpty())
+    {
+        submitToCses->setEnabled(false);
+        QString tooltip = tr("Could not parse CSES contest/task ID from URL.\nMake sure you're on a valid CSES problem page.");
+        submitToCses->setToolTip(tooltip);
+        log->warn(tr("CSES CLI"), tr("CSES contest or task ID not found in URL. Button disabled."));
+    }
+    else
+    {
+        submitToCses->setEnabled(true);
+        QString tooltip = tr("Submit to CSES\nContest: %1\nTask: %2").arg(csesContest, csesTaskId);
+        submitToCses->setToolTip(tooltip);
+    }
+}
+
+void MainWindow::removeCSESToolUI()
+{
+    if (submitToCses != nullptr)
+    {
+        submitToCses->setEnabled(false);
+        ui->compileAndRunButtons->removeWidget(submitToCses);
+        delete submitToCses;
+        submitToCses = nullptr;
+        delete csestool;
+        csestool = nullptr;
+    }
+}
+
 void MainWindow::removeCFToolUI()
 {
     if (submitToCodeforces != nullptr)
@@ -369,6 +446,8 @@ QString MainWindow::getFileName() const
 {
     if (!isUntitled())
         return QFileInfo(filePath).fileName();
+    if (!companionName.isEmpty())
+        return companionName;
     if (!problemURL.isEmpty())
         return QRegularExpression(R"(.*/([^\?#].*?)/?$)").match(problemURL).captured(1);
     return tr("Untitled-%1").arg(untitledIndex);
@@ -463,8 +542,38 @@ void MainWindow::setProblemURL(const QString &url)
         return;
     problemURL = url;
     FileProblemBinder::set(filePath, url);
+    
+    // Clear CSES identifiers when URL changes
+    // Note: companionName is NOT cleared here - it's preserved from applyCompanion()
+    // and only cleared in loadFile() and loadStatus()
+    csesContest.clear();
+    csesTaskId.clear();
+    
     if (problemURL.contains("codeforces.com"))
         setCFToolUI();
+    
+    if (problemURL.contains("cses.fi"))
+    {
+        // Parse contest and task ID from URL
+        QString contest, taskId;
+        if (Extensions::CSESTool::parseCsesUrl(url, contest, taskId))
+        {
+            csesContest = contest;
+            csesTaskId = taskId;
+        }
+        else
+        {
+            // Clear if URL is CSES but parsing failed
+            csesContest.clear();
+            csesTaskId.clear();
+        }
+        setCSESToolUI();
+    }
+    else
+    {
+        // Not a CSES URL, remove UI
+        removeCSESToolUI();
+    }
     emit editorFileChanged();
 }
 
@@ -564,6 +673,8 @@ void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
 {
     LOG_INFO("Requesting loadStatus");
     setProblemURL(status.problemURL);
+    // Clear companion name when loading a saved status
+    companionName.clear();
     if (status.isLanguageSet)
         setLanguage(status.language);
     customCompileCommand = status.customCompileCommand; // this must be after setLanguage
@@ -616,6 +727,17 @@ void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
 void MainWindow::applyCompanion(const Extensions::CompanionData &data)
 {
     LOG_INFO("Requesting apply from companion");
+
+    // Extract problem name from companion data for auto-naming
+    QString name = data.doc["name"].toString();
+    if (!name.isEmpty())
+    {
+        companionName = name.replace(" ", "_");
+    }
+    else
+    {
+        companionName.clear();
+    }
 
     if (isUntitled() && !isTextChanged())
     {
@@ -683,6 +805,56 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
     for (auto const &testcase : data.testcases)
         testcases->addTestCase(testcase.input, testcase.output);
 
+    // Try to extract CSES identifiers from companion data or head comments
+    csesContest.clear();
+    csesTaskId.clear();
+
+    // Prefer the provided URL in companion data
+    if (!data.url.isEmpty())
+    {
+        QString contest, task;
+        if (Extensions::CSESTool::parseCsesUrl(data.url, contest, task))
+        {
+            csesContest = contest;
+            csesTaskId = task;
+        }
+    }
+
+    // If not found, fall back to head comments in the editor
+    if (csesContest.isEmpty() || csesTaskId.isEmpty())
+    {
+        auto content = editor->toPlainText();
+        auto lines = content.split('\n');
+        int limit = qMin(lines.size(), 30);
+        for (int i = 0; i < limit && (csesContest.isEmpty() || csesTaskId.isEmpty()); ++i)
+        {
+            const QString &ln = lines[i];
+            // detect URL inside comments
+            // Changed R"(...)" to R"delim(...)delim" to avoid quote conflicts
+            QRegularExpression urlRe(R"delim((https?://cses\.fi[^\s)"']*))delim");
+            auto m = urlRe.match(ln);
+            if (m.hasMatch())
+            {
+                QString contest, task;
+                if (Extensions::CSESTool::parseCsesUrl(m.captured(1), contest, task))
+                {
+                    csesContest = contest;
+                    csesTaskId = task;
+                    break;
+                }
+            }
+
+            // detect explicit Contest: and Problem: lines
+            auto cMatch = QRegularExpression(R"(^\s*Contest:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
+            auto pMatch = QRegularExpression(R"(^\s*Problem:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
+            if (cMatch.hasMatch())
+                csesContest = cMatch.captured(1);
+            if (pMatch.hasMatch())
+                csesTaskId = pMatch.captured(1);
+        }
+    }
+
+    // setProblemURL will handle CSES UI based on URL and parsed identifiers
     setProblemURL(data.url);
 
     if (SettingsHelper::isCompetitiveCompanionSetTimeLimitForTab())
@@ -718,6 +890,33 @@ void MainWindow::applySettings(const QString &pagePath)
             else if (submitToCodeforces != nullptr && !SettingsHelper::isCFEnable())
             {
                 removeCFToolUI();
+            }
+        }
+    }
+
+    if (pageChanged("Extensions/CSES CLI"))
+    {
+        csesCliPath = SettingsHelper::getCSESCLIPath();
+
+        if (csestool != nullptr && Extensions::CSESTool::check(csesCliPath))
+        {
+            csestool->updatePath(csesCliPath);
+            // setCSESToolUI will update button state based on parsed IDs
+        }
+        if (problemURL.contains("cses.fi"))
+        {
+            if (submitToCses == nullptr && SettingsHelper::isCSESCLIEnable())
+            {
+                setCSESToolUI();
+            }
+            else if (submitToCses != nullptr && !SettingsHelper::isCSESCLIEnable())
+            {
+                removeCSESToolUI();
+            }
+            else if (submitToCses != nullptr)
+            {
+                // Update button state when CSES CLI path changes
+                setCSESToolUI();
             }
         }
     }
@@ -994,6 +1193,9 @@ void MainWindow::loadFile(const QString &loadPath)
     bool samePath = !isUntitled() && filePath == path;
     setFilePath(path, false);
 
+    // Clear companion name when loading a file directly
+    companionName.clear();
+
     bool isTemplate = false;
 
     if (!QFile::exists(path))
@@ -1086,8 +1288,15 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
 
             if (defaultPath.isEmpty())
             {
-                defaultPath =
-                    QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(getTabTitle(false, false));
+                if (!companionName.isEmpty())
+                {
+                    defaultPath = QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(companionName);
+                }
+                else
+                {
+                    defaultPath =
+                        QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(getTabTitle(false, false));
+                }
             }
 
             defaultPath = Util::fileNameWithSuffix(defaultPath, language);

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -50,6 +50,7 @@ namespace Extensions
 {
 class CFTool;
 struct CompanionData;
+class CSESTool;
 } // namespace Extensions
 
 namespace FakeVim
@@ -240,6 +241,7 @@ class MainWindow : public QMainWindow
     QString filePath;
     QString savedText;
     QString cftoolPath;
+    QString csesCliPath;
     QFileSystemWatcher *fileWatcher;
 
     std::atomic<bool> reloading;
@@ -247,6 +249,10 @@ class MainWindow : public QMainWindow
 
     QPushButton *submitToCodeforces = nullptr;
     Extensions::CFTool *cftool = nullptr;
+    QPushButton *submitToCses = nullptr;
+    Extensions::CSESTool *csestool = nullptr;
+    QString csesContest, csesTaskId;
+    QString companionName;
 
     Widgets::TestCases *testcases = nullptr;
     Widgets::Stopwatch *stopwatch = nullptr;
@@ -267,6 +273,8 @@ class MainWindow : public QMainWindow
     void saveTests(bool safe);
     void setCFToolUI();
     void removeCFToolUI(); // Delete cftool&submitToCodeforces pointers, and remove the button from ui
+    void setCSESToolUI();
+    void removeCSESToolUI();
     void setFilePath(QString path, bool updateBinder = true);
     void setText(const QString &text, bool keep = false);
     void updateWatcher();

--- a/test_cses_integration.sh
+++ b/test_cses_integration.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Test script for CSES CLI integration
+
+echo "=== CSES Tool Integration Test ==="
+echo
+
+echo "1. Building CP Editor..."
+cd /home/robert/CLionProjects/cpeditor/build
+cmake --build . -j$(nproc) 2>&1 | tail -5
+echo "Build status: $?"
+
+echo
+echo "2. Checking CSES CLI installation..."
+which cses-cli 2>/dev/null
+if [ $? -eq 0 ]; then
+    echo "✓ CSES CLI found in PATH"
+    cses-cli --version 2>/dev/null
+else
+    echo "✗ CSES CLI not found in PATH"
+    echo "   Expected default path: 'cses-cli'"
+    echo "   You can set a custom path in Preferences → Extensions → CSES CLI"
+fi
+
+echo
+echo "3. Testing URL parsing with C++ regex..."
+cat > /tmp/test_cses_urls.cpp << 'EOF'
+#include <iostream>
+#include <regex>
+#include <string>
+
+void test_url(const std::string& url) {
+    std::regex pattern1(R"(.*://cses\.fi/([^/]+)/task/([0-9]+))");
+    std::regex pattern2(R"(.*://cses\.fi/([^/]+)/([^/]+)/([0-9]+))");
+    std::smatch match;
+    
+    std::cout << "URL: " << url << std::endl;
+    
+    if (std::regex_match(url, match, pattern1) && match.size() == 3) {
+        std::cout << "  ✓ MATCH (pattern1)" << std::endl;
+        std::cout << "    Contest: " << match[1] << std::endl;
+        std::cout << "    Task ID: " << match[2] << std::endl;
+    } else if (std::regex_match(url, match, pattern2) && match.size() == 4) {
+        std::cout << "  ✓ MATCH (pattern2)" << std::endl;
+        std::cout << "    Contest: " << match[1] << std::endl;
+        std::cout << "    Task ID: " << match[3] << std::endl;
+    } else {
+        std::cout << "  ✗ NO MATCH" << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+int main() {
+    test_url("https://cses.fi/problemset/task/1068");
+    test_url("https://cses.fi/problemset/task/1633");
+    test_url("https://cses.fi/100/task/100");
+    test_url("http://cses.fi/problemset/task/1754");
+    test_url("https://codeforces.com/problemset/problem/4/A");
+    test_url("https://cses.fi/problemset/task/");
+    test_url("invalid url");
+    return 0;
+}
+EOF
+
+g++ -std=c++11 /tmp/test_cses_urls.cpp -o /tmp/test_cses_urls && /tmp/test_cses_urls
+
+echo
+echo "4. Checking generated settings..."
+grep -n "CSES" /home/robert/CLionProjects/cpeditor/build/generated/SettingsHelper.hpp | head -5
+
+echo
+echo "5. Modified files summary:"
+cd /home/robert/CLionProjects/cpeditor
+git diff --name-only
+
+echo
+echo "=== Implementation Summary ==="
+echo "✓ CSES URL parsing integrated into setProblemURL()"
+echo "✓ Button state logic improved with tooltips"
+echo "✓ CSES CLI check improved with error logging"
+echo "✓ Removed redundant logic in applyCompanion()"
+echo "✓ Preference updates properly refresh button state"
+echo
+echo "=== Remaining Testing ==="
+echo "1. Install CSES CLI or set custom path in Preferences"
+echo "2. Open a CSES problem (e.g., https://cses.fi/problemset/task/1068)"
+echo "3. Verify button is enabled with correct contest/task ID"
+echo "4. Test with Competitive Companion"
+echo "5. Test manual URL entry"
+echo "6. Test with invalid/missing CSES CLI"


### PR DESCRIPTION
<!--- We squash and merge pull requests, so the title of the PR will be the title of the merge commit -->
<!--- Please follow https://www.conventionalcommits.org/ in the title --->

## Description
<!--- Describe your changes in detail -->

added submit to cses button, script detects cses problem from competitive companion json

changed auto naming scheme. Files were named after their task id (ex "A" or "1068"), now they are named as the problem name from competitive_companion 's json.name 


## Related Issues / Pull Requests
<!--- If your PR fixes/resolves one or more issues, or is related to another PR, link to them here. -->
<!--- See: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword --->

## Motivation and Context

adds submit to cses button, to be able to seamlessly submit problems to cses 

changed naming scheme, so you can freely navigate the problems 

## How Has This Been Tested?
ubutntu_22.04, both light and dark theme

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- You can open a pull request before all these are done, but they should be done before getting merged. -->
- [ ] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [ ] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text
<!--- Anything else you want to say. For example, mention the translators if the translations need to be updated. --->
