### PR TITLE
fix: editor disappearing in new tabs

### DIFF
--- a/src/Editor/CodeEditor.cpp
+++ b/src/Editor/CodeEditor.cpp
@@ -58,6 +58,7 @@
 #include <QTextBlock>
 #include <QTextCharFormat>
 #include <QTextStream>
+#include <QTimer>
 #include <QToolTip>
 
 namespace Editor
@@ -76,6 +77,12 @@ CodeEditor::CodeEditor(QWidget *widget) : QPlainTextEdit(widget)
 
     setCenterOnScroll(true);
     setMouseTracking(true);
+
+    QTimer::singleShot(0, [this] {
+        updateSidebarGeometry();
+        sideBar->update();
+        viewport()->update();
+    });
 }
 
 void CodeEditor::applySettings(const QString &lang)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -88,7 +88,6 @@ MainWindow::MainWindow(int index, AppWindow *parent)
             &MainWindow::onCompilationErrorOccurred);
     connect(stressTesting, &Widgets::StressTesting::compilationKilled, this, &MainWindow::onCompilationKilled);
     connect(stressTesting, &Widgets::StressTesting::compilationFailed, this, &MainWindow::onCompilationFailed);
-    QTimer::singleShot(0, [this] { editor->resize(0, 0); }); // refresh editor geometry
 }
 
 MainWindow::MainWindow(const QString &fileOpen, int index, AppWindow *parent) : MainWindow(index, parent)


### PR DESCRIPTION
## Description

Remove the queued resize of the editor to `0x0` and refresh the
sidebar geometry directly instead.

The previous implementation used `editor->resize(0, 0)` to trigger a
resize event and update the line-number sidebar. This could leave the
editor at zero size when no subsequent layout pass restored its
geometry.

## Related Issues / Pull Requests

Related to #1312.

## Motivation and Context

When FakeVim is enabled, opening multiple tabs with the editor font
size set to 12 can cause the editor in the second new tab to disappear.

Steps to reproduce:

1. Enable FakeVim.
2. Set the editor font size to 12.
3. Open two new tabs consecutively.
4. Observe that the editor in the second new tab is not visible.

The sidebar refresh should not depend on temporarily resizing the
entire editor to zero. Updating the sidebar geometry directly preserves
the intended behavior without relying on another layout pass to restore
the editor size.

## How Has This Been Tested?

Verified that the issue can be reproduced before the change using the
steps above.

Verified after the change that:

* The editor remains visible after opening multiple new tabs.
* The issue no longer occurs with FakeVim enabled and the editor font
  size set to 12.
* The line-number sidebar geometry is updated correctly.

Test environment:

* OS: Linux
* Desktop environment: KDE Plasma 6.7.2
* Qt version: 6.11.1
* System theme: light

## Screenshots (if appropriate)

Not applicable.

## Checklist

* [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
* [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
* [x] If needed, I have opened a pull request or an issue to update the [[documentation](https://github.com/cpeditor/cpeditor.github.io)](https://github.com/cpeditor/cpeditor.github.io).
* [ ] If these changes are notable, they are documented in [[CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md)](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).

## Additional text

No user-facing text, setting keys, or documentation were changed.