### PR TITLE
Cses feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ resources/translations/*.qm
 
 # Codespaces
 .venv
+.idea/
+.kilo/
+AGENTS.md
+AppDir/
+*.AppImage
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 -   Add an option to toggle Ctrl+Scroll font scaling (#1249)
 -   Add middle-click to close tabs. (#1351)
 -   Add vim emulation with [custom commands](https://cpeditor.org/docs/preferences/code-edit/#custom-vim-commands). (#220 and #1270)
+-   Add submit to cses button, with ability to set path in preferences/extensions similar to cf-tool
+-   Modified the file naming scheme as to auto name the files their problem name not task id
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMA
                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                    DEPENDS ${PROJECT_SOURCE_DIR}/src/Settings/settings.json ${PROJECT_SOURCE_DIR}/src/Settings/genSettings.py)
 
-qt_standard_project_setup(I18N_TRANSLATED_LANGUAGES el_GR es_MX pt_BR ru_RU zh_CN zh_TW ar_EG hi_IN)
+qt_standard_project_setup()
 
 # Define translation files
 set(TS_FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,10 +132,10 @@ qt6_add_lupdate(cpeditor
 )
 
 # Create .qm files from .ts files and generate resource
-qt6_add_translations(cpeditor
-    TS_FILES ${TS_FILES}
-    RESOURCE_PREFIX "/translations"
-)
+# qt6_add_translations(cpeditor
+#     TS_FILES ${TS_FILES}
+#     RESOURCE_PREFIX "/translations"
+# )
 
 set_property(SOURCE ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp PROPERTY SKIP_AUTOGEN ON)
 
@@ -195,6 +195,8 @@ add_executable(cpeditor
 
     src/Extensions/CFTool.cpp
     src/Extensions/CFTool.hpp
+    src/Extensions/CSESTool.cpp
+    src/Extensions/CSESTool.hpp
     src/Extensions/ClangFormatter.cpp
     src/Extensions/ClangFormatter.hpp
     src/Extensions/CodeFormatter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,14 +119,6 @@ set(TS_FILES
     translations/zh_TW.ts
 )
 
-# Create lupdate target to update .ts files
-qt6_add_lupdate(cpeditor
-    TS_FILES ${TS_FILES}
-    SOURCES src ui
-    NO_GLOBAL_TARGET
-)
-
-
 set_property(SOURCE ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp PROPERTY SKIP_AUTOGEN ON)
 
 if(USE_CLANG_TIDY)
@@ -308,6 +300,12 @@ if(APPLE)
     RESOURCE "dist/mac/cpeditor.icns"
   )
 endif()
+
+# Create .qm files from .ts files and generate resource
+qt6_add_translations(cpeditor
+    TS_FILES ${TS_FILES}
+    RESOURCE_PREFIX "/translations"
+)
 
 if(UNIX AND NOT APPLE)
   include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ if(WIN32)
   set(GUI_TYPE WIN32)
 endif()
 
-set(QT_DEFAULT_QT_MAJOR_VERSION 6 CACHE STRING "Default Qt major version")
 find_package(Qt6 COMPONENTS Widgets REQUIRED)
 find_package(Qt6 COMPONENTS Network REQUIRED)
 find_package(Qt6 COMPONENTS Core5Compat REQUIRED)
@@ -53,15 +52,11 @@ else()
   message(STATUS "Will build the setup version")
 endif()
 
-# https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949
-option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." On)
-if(${FORCE_COLORED_OUTPUT})
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-fdiagnostics-color=always)
   elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     add_compile_options(-fcolor-diagnostics)
   endif()
-endif()
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git)
@@ -131,11 +126,6 @@ qt6_add_lupdate(cpeditor
     NO_GLOBAL_TARGET
 )
 
-# Create .qm files from .ts files and generate resource
-# qt6_add_translations(cpeditor
-#     TS_FILES ${TS_FILES}
-#     RESOURCE_PREFIX "/translations"
-# )
 
 set_property(SOURCE ${CMAKE_BINARY_DIR}/generated/SettingsHelper.hpp ${CMAKE_BINARY_DIR}/generated/SettingsInfo.cpp PROPERTY SKIP_AUTOGEN ON)
 
@@ -301,16 +291,10 @@ add_executable(cpeditor
 include_directories("generated/")
 include_directories("src/")
 
-target_link_libraries(cpeditor PRIVATE LSPClient)
-target_link_libraries(cpeditor PRIVATE Qt6::Network)
-target_link_libraries(cpeditor PRIVATE Qt6::Widgets)
-target_link_libraries(cpeditor PRIVATE Qt6::Core5Compat)
-target_link_libraries(cpeditor PRIVATE QtFindReplaceDialog)
-target_link_libraries(cpeditor PRIVATE SingleApplication)
-target_link_libraries(cpeditor PRIVATE fakevim)
-target_link_libraries(cpeditor PRIVATE QHttp)
-target_link_libraries(cpeditor PRIVATE diff_match_patch)
-target_link_libraries(cpeditor PRIVATE KF6::SyntaxHighlighting)
+target_link_libraries(cpeditor PRIVATE
+    LSPClient Qt6::Network Qt6::Widgets Qt6::Core5Compat
+    QtFindReplaceDialog SingleApplication fakevim QHttp diff_match_patch
+    KF6::SyntaxHighlighting)
 
 if(MSVC)
   target_compile_options(cpeditor PUBLIC "/utf-8")

--- a/src/Core/Compiler.cpp
+++ b/src/Core/Compiler.cpp
@@ -116,8 +116,7 @@ QString Compiler::outputPath(const QString &tmpFilePath, const QString &sourceFi
                                               .toString()
                                               .replace("${filename}", fileInfo.fileName())
                                               .replace("${basename}", fileInfo.completeBaseName())
-                                              .replace("${tmpdir}", QFileInfo(tmpFilePath).absolutePath())
-                                              .replace("${tempdir}", QFileInfo(tmpFilePath).absolutePath()));
+                                              .replace("${tmpdir}", QFileInfo(tmpFilePath).absolutePath()));
 
     if (lang == "C++")
         res += Util::exeSuffix; // Note: Util::exeSuffix is empty on UNIX

--- a/src/Editor/FakeVimProxy.cpp
+++ b/src/Editor/FakeVimProxy.cpp
@@ -364,9 +364,9 @@ void FakeVimProxy::moveToMatchingParenthesis(bool *moved, bool *forward, QTextCu
     {
         position += direction;
         auto character = document()->characterAt(position);
-        if (character == "\"")
+        if (character == QChar('"'))
             doubleCounter++;
-        else if (character == "'")
+        else if (character == QChar('\''))
             singleCounter++;
         else if (character == underCursor && singleCounter % 2 == 0 && doubleCounter % 2 == 0)
             ++counter;

--- a/src/Extensions/CSESTool.cpp
+++ b/src/Extensions/CSESTool.cpp
@@ -1,0 +1,188 @@
+/*
+ * CSES CLI integration implementation
+ */
+#include "Extensions/CSESTool.hpp"
+#include "Core/EventLogger.hpp"
+#include "Core/MessageLogger.hpp"
+#include "generated/SettingsHelper.hpp"
+#include <QString>
+#include <QFileInfo>
+#include <QProcess>
+#include <QRegularExpression>
+
+namespace Extensions
+{
+
+CSESTool::CSESTool(const QString &p, MessageLogger *logger) : log(logger), path(p)
+{
+    LOG_INFO(INFO_OF(p))
+}
+
+CSESTool::~CSESTool()
+{
+    delete process;
+}
+
+void CSESTool::submit(const QString &filePath, const QString &contest, const QString &taskId)
+{
+    if (process != nullptr)
+    {
+        if (process->state() == QProcess::Running)
+        {
+            LOG_WARN("CSES CLI was already running, killing it now");
+            process->kill();
+            delete process;
+            log->error(tr("CSES CLI"), tr("CSES CLI was killed"));
+        }
+        else
+            delete process;
+        process = nullptr;
+    }
+
+    LOG_INFO(INFO_OF(filePath) << INFO_OF(contest) << INFO_OF(taskId));
+
+    if (contest.isEmpty() || taskId.isEmpty())
+    {
+        log->error(tr("CSES CLI"), tr("Empty contest or task id"));
+        return;
+    }
+
+    process = new QProcess();
+    process->setProgram(path);
+
+    auto version = getVersion();
+    if (version.isEmpty())
+    {
+        log->error(tr("CSES CLI"), tr("Failed to get the version of CSES CLI. Have you set the correct path in Preferences?"));
+        return;
+    }
+
+    process->setArguments({"submit", "-c", contest, "-t", taskId, filePath});
+    LOG_INFO(INFO_OF(process->arguments().join(' ')));
+
+    connect(process, &QProcess::readyReadStandardOutput, this, &CSESTool::onReadReady);
+    connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &CSESTool::onFinished);
+    process->start();
+    bool started = process->waitForStarted(2000);
+    if (started)
+    {
+        log->info(tr("CSES CLI"), tr("CSES CLI has started"));
+    }
+    else
+    {
+        process->kill();
+        log->error(tr("CSES CLI"), tr("Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?"));
+    }
+}
+
+bool CSESTool::check(const QString &p)
+{
+    LOG_INFO(INFO_OF(p));
+    if (p.isEmpty()) 
+    {
+        LOG_WARN("CSES CLI path is empty");
+        return false;
+    }
+    
+    QProcess check;
+    // CSES CLI shows version info when run without arguments, not with --version
+    check.start(p, {});
+    bool finished = check.waitForFinished(2000);
+    LOG_INFO(BOOL_INFO_OF(finished) << INFO_OF(check.exitCode()) << INFO_OF(check.exitStatus()) 
+             << INFO_OF(check.error()) << INFO_OF(check.errorString()));
+    
+    if (!finished)
+    {
+        LOG_WARN("CSES CLI check timed out or failed to start");
+        return false;
+    }
+    
+    // CSES CLI exits with 0 when showing help/version info
+    return check.exitCode() == 0;
+}
+
+void CSESTool::updatePath(const QString &p)
+{
+    LOG_INFO(INFO_OF(p));
+    path = p;
+}
+
+    bool CSESTool::parseCsesUrl(const QString &url, QString &contest, QString &taskId)
+{
+    LOG_INFO(INFO_OF(url));
+
+    // Pattern 1: Matches standard and contest tasks (e.g., cses.fi/647/task/A/ or cses.fi/problemset/task/1643)
+    // Changed ([0-9]+) to ([^/]+) to allow alphabetical task IDs, and added /? at the end
+    auto match = QRegularExpression(R"(.*://cses\.fi/([^/]+)/task/([^/]+)/?$)").match(url);
+    if (match.hasMatch())
+    {
+        contest = match.captured(1);
+        taskId = match.captured(2);
+        return true;
+    }
+
+    // Pattern 2: Fallback for multi-level category structures (e.g., cses.fi/category/subcategory/taskId)
+    match = QRegularExpression(R"(.*://cses\.fi/([^/]+)/([^/]+)/([^/]+)/?$)").match(url);
+    if (match.hasMatch())
+    {
+        contest = match.captured(1);
+        taskId = match.captured(3);
+        return true;
+    }
+
+    return false;
+}
+
+void CSESTool::onReadReady()
+{
+    QString response = process->readAllStandardOutput();
+    response.remove(QRegularExpression("\x1b\\[.. "));
+    if (!response.trimmed().isEmpty())
+    {
+        // log everything as info; CSES CLI output may contain useful info
+        log->info(tr("CSES CLI"), response);
+        lastStatus = response.left(response.indexOf('\n') >= 0 ? response.indexOf('\n') : response.length());
+    }
+}
+
+void CSESTool::onFinished(int exitCode, QProcess::ExitStatus)
+{
+    if (exitCode == 0)
+    {
+        showToastMessage(lastStatus);
+    }
+    else
+    {
+        showToastMessage(tr("CSES CLI failed"));
+        log->error(tr("CSES CLI"), tr("CSES CLI finished with non-zero exit code %1").arg(exitCode));
+    }
+    QString err = process->readAllStandardError();
+    if (!err.trimmed().isEmpty())
+        log->error(tr("CSES CLI"), err);
+}
+
+void CSESTool::showToastMessage(const QString &message)
+{
+    // Use the existing CF toast setting for visibility to avoid depending on generated helpers.
+    if (SettingsHelper::isCFShowToastMessages())
+        emit requestToastMessage(tr("CSES"), message);
+}
+
+QString CSESTool::getVersion() const
+{
+    QProcess processV;
+    // CSES CLI shows version info when run without arguments
+    processV.start(path, {});
+    if (!processV.waitForFinished(2000))
+    {
+        LOG_WARN("CSES CLI didn't finish after 2 second");
+        return "";
+    }
+    QString output = processV.readAllStandardOutput();
+    // Parse version from output like "CSES CLI version 0.1.4"
+    QString version = QRegularExpression(R"((?<=version )\d+\.\d+\.\d+)").match(output).captured();
+    LOG_INFO(INFO_OF(version));
+    return version;
+}
+
+} // namespace Extensions

--- a/src/Extensions/CSESTool.cpp
+++ b/src/Extensions/CSESTool.cpp
@@ -32,7 +32,8 @@ void CSESTool::submit(const QString &filePath, const QString &contest, const QSt
             LOG_WARN("CSES CLI was already running, killing it now");
             process->kill();
             delete process;
-            log->error(tr("CSES CLI"), tr("CSES CLI was killed"));
+            if (log)
+                log->error(tr("CSES CLI"), tr("CSES CLI was killed"));
         }
         else
             delete process;
@@ -43,7 +44,8 @@ void CSESTool::submit(const QString &filePath, const QString &contest, const QSt
 
     if (contest.isEmpty() || taskId.isEmpty())
     {
-        log->error(tr("CSES CLI"), tr("Empty contest or task id"));
+        if (log)
+            log->error(tr("CSES CLI"), tr("Empty contest or task id"));
         return;
     }
 
@@ -53,7 +55,8 @@ void CSESTool::submit(const QString &filePath, const QString &contest, const QSt
     auto version = getVersion();
     if (version.isEmpty())
     {
-        log->error(tr("CSES CLI"), tr("Failed to get the version of CSES CLI. Have you set the correct path in Preferences?"));
+        if (log)
+            log->error(tr("CSES CLI"), tr("Failed to get the version of CSES CLI. Have you set the correct path in Preferences?"));
         return;
     }
 
@@ -66,12 +69,14 @@ void CSESTool::submit(const QString &filePath, const QString &contest, const QSt
     bool started = process->waitForStarted(2000);
     if (started)
     {
-        log->info(tr("CSES CLI"), tr("CSES CLI has started"));
+        if (log)
+            log->info(tr("CSES CLI"), tr("CSES CLI has started"));
     }
     else
     {
         process->kill();
-        log->error(tr("CSES CLI"), tr("Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?"));
+        if (log)
+            log->error(tr("CSES CLI"), tr("Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?"));
     }
 }
 
@@ -140,7 +145,8 @@ void CSESTool::onReadReady()
     if (!response.trimmed().isEmpty())
     {
         // log everything as info; CSES CLI output may contain useful info
-        log->info(tr("CSES CLI"), response);
+        if (log)
+            log->info(tr("CSES CLI"), response);
         lastStatus = response.left(response.indexOf('\n') >= 0 ? response.indexOf('\n') : response.length());
     }
 }
@@ -154,17 +160,19 @@ void CSESTool::onFinished(int exitCode, QProcess::ExitStatus)
     else
     {
         showToastMessage(tr("CSES CLI failed"));
-        log->error(tr("CSES CLI"), tr("CSES CLI finished with non-zero exit code %1").arg(exitCode));
+        if (log)
+            log->error(tr("CSES CLI"), tr("CSES CLI finished with non-zero exit code %1").arg(exitCode));
     }
     QString err = process->readAllStandardError();
     if (!err.trimmed().isEmpty())
-        log->error(tr("CSES CLI"), err);
+        if (log)
+            log->error(tr("CSES CLI"), err);
 }
 
 void CSESTool::showToastMessage(const QString &message)
 {
     // Use the existing CF toast setting for visibility to avoid depending on generated helpers.
-    if (SettingsHelper::isCFShowToastMessages())
+    if (SettingsHelper::isCSESCLIShowToastMessages())
         emit requestToastMessage(tr("CSES"), message);
 }
 

--- a/src/Extensions/CSESTool.cpp
+++ b/src/Extensions/CSESTool.cpp
@@ -5,20 +5,18 @@
 #include "Core/EventLogger.hpp"
 #include "Core/MessageLogger.hpp"
 #include "generated/SettingsHelper.hpp"
-#include <QString>
 #include <QFileInfo>
 #include <QProcess>
 #include <QRegularExpression>
+#include <QString>
 
 namespace Extensions
 {
 
-CSESTool::CSESTool(const QString &p, MessageLogger *logger) : log(logger), path(p)
-{
-    LOG_INFO(INFO_OF(p))
-}
+CSESTool::CSESTool(const QString &p, MessageLogger *logger)
+    : log(logger), path(p){LOG_INFO(INFO_OF(p))}
 
-CSESTool::~CSESTool()
+      CSESTool::~CSESTool()
 {
     delete process;
 }
@@ -56,7 +54,8 @@ void CSESTool::submit(const QString &filePath, const QString &contest, const QSt
     if (version.isEmpty())
     {
         if (log)
-            log->error(tr("CSES CLI"), tr("Failed to get the version of CSES CLI. Have you set the correct path in Preferences?"));
+            log->error(tr("CSES CLI"),
+                       tr("Failed to get the version of CSES CLI. Have you set the correct path in Preferences?"));
         return;
     }
 
@@ -76,32 +75,33 @@ void CSESTool::submit(const QString &filePath, const QString &contest, const QSt
     {
         process->kill();
         if (log)
-            log->error(tr("CSES CLI"), tr("Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?"));
+            log->error(tr("CSES CLI"),
+                       tr("Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?"));
     }
 }
 
 bool CSESTool::check(const QString &p)
 {
     LOG_INFO(INFO_OF(p));
-    if (p.isEmpty()) 
+    if (p.isEmpty())
     {
         LOG_WARN("CSES CLI path is empty");
         return false;
     }
-    
+
     QProcess check;
     // CSES CLI shows version info when run without arguments, not with --version
     check.start(p, {});
     bool finished = check.waitForFinished(2000);
-    LOG_INFO(BOOL_INFO_OF(finished) << INFO_OF(check.exitCode()) << INFO_OF(check.exitStatus()) 
-             << INFO_OF(check.error()) << INFO_OF(check.errorString()));
-    
+    LOG_INFO(BOOL_INFO_OF(finished) << INFO_OF(check.exitCode()) << INFO_OF(check.exitStatus())
+                                    << INFO_OF(check.error()) << INFO_OF(check.errorString()));
+
     if (!finished)
     {
         LOG_WARN("CSES CLI check timed out or failed to start");
         return false;
     }
-    
+
     // CSES CLI exits with 0 when showing help/version info
     return check.exitCode() == 0;
 }
@@ -112,7 +112,7 @@ void CSESTool::updatePath(const QString &p)
     path = p;
 }
 
-    bool CSESTool::parseCsesUrl(const QString &url, QString &contest, QString &taskId)
+bool CSESTool::parseCsesUrl(const QString &url, QString &contest, QString &taskId)
 {
     LOG_INFO(INFO_OF(url));
 
@@ -151,7 +151,7 @@ void CSESTool::onReadReady()
     }
 }
 
-void CSESTool::onFinished(int exitCode, QProcess::ExitStatus)
+void CSESTool::onFinished(int exitCode, QProcess::ExitStatus /*exitStatus*/)
 {
     if (exitCode == 0)
     {

--- a/src/Extensions/CSESTool.hpp
+++ b/src/Extensions/CSESTool.hpp
@@ -1,0 +1,45 @@
+/*
+ * CSES CLI integration similar to CF Tool
+ */
+#ifndef CSESTOOL_HPP
+#define CSESTOOL_HPP
+
+#include <QObject>
+#include <QProcess>
+#include <QString>
+
+class MessageLogger;
+
+namespace Extensions
+{
+class CSESTool : public QObject
+{
+    Q_OBJECT
+
+  public:
+    CSESTool(const QString &path, MessageLogger *logger);
+    ~CSESTool() override;
+    void submit(const QString &filePath, const QString &contest, const QString &taskId);
+    static bool check(const QString &path);
+    void updatePath(const QString &p);
+    static bool parseCsesUrl(const QString &url, QString &contest, QString &taskId);
+
+  signals:
+    void requestToastMessage(const QString &head, const QString &body);
+
+  private slots:
+    void onReadReady();
+    void onFinished(int exitCode, QProcess::ExitStatus);
+
+  private:
+    QString lastStatus;
+    QProcess *process = nullptr;
+    MessageLogger *log;
+    QString path;
+
+    void showToastMessage(const QString &message);
+    QString getVersion() const;
+};
+} // namespace Extensions
+
+#endif // CSESTOOL_HPP

--- a/src/Extensions/CompanionServer.cpp
+++ b/src/Extensions/CompanionServer.cpp
@@ -26,18 +26,6 @@
 #include <QJsonArray>
 #include <QJsonObject>
 
-#define USER_INFO(x)                                                                                                   \
-    if (log)                                                                                                           \
-        log->info("Companion", x);
-
-#define USER_WARN(x)                                                                                                   \
-    if (log)                                                                                                           \
-        log->warn("Companion", x);
-
-#define USER_ERR(x)                                                                                                    \
-    if (log)                                                                                                           \
-        log->error("Companion", x);
-
 namespace Extensions
 {
 CompanionServer::CompanionServer(int port, QObject *parent) : QObject(parent)
@@ -72,11 +60,13 @@ bool CompanionServer::startListeningOn(int port)
 
             if (methodType != "POST")
             {
-                USER_WARN(tr("A %1 request is received and ignored").arg(methodType));
+                if (log)
+                    log->warn("Companion", tr("A %1 request is received and ignored").arg(methodType));
             }
             else if (!isJson)
             {
-                USER_ERR(tr("The request received is not JSON"));
+                if (log)
+                    log->error("Companion", tr("The request received is not JSON"));
             }
             else
             {
@@ -102,7 +92,8 @@ void CompanionServer::updatePort(int port)
     {
         delete server;
         server = nullptr;
-        USER_INFO(tr("Server is closed"));
+        if (log)
+            log->info("Companion", tr("Server is closed"));
         lastListeningPort = -1;
         return;
     }
@@ -113,11 +104,13 @@ void CompanionServer::updatePort(int port)
         if (started)
         {
             lastListeningPort = port;
-            USER_INFO(tr("Port is set to %1").arg(port));
+            if (log)
+                log->info("Companion", tr("Port is set to %1").arg(port));
         }
         else
         {
-            USER_ERR(tr("Failed to listen to port %1. Is there another process listening?").arg(port));
+            if (log)
+            log->error("Companion", tr("Failed to listen to port %1. Is there another process listening?").arg(port));
         }
     }
 }
@@ -146,14 +139,16 @@ void CompanionServer::parseAndEmit(QByteArray &data)
     }
     else
     {
-        USER_ERR(tr("JSON parser reported errors:\n%1").arg(error.errorString()));
+        if (log)
+            log->error("Companion", tr("JSON parser reported errors:\n%1").arg(error.errorString()));
         LOG_WARN("JSON parser reported error " << error.errorString());
     }
 }
 
 CompanionServer::~CompanionServer()
 {
-    USER_INFO(tr("Stopped Server"));
+    if (log)
+        log->info("Companion", tr("Stopped Server"));
     delete server;
 }
 

--- a/src/Extensions/CompanionServer.cpp
+++ b/src/Extensions/CompanionServer.cpp
@@ -110,7 +110,8 @@ void CompanionServer::updatePort(int port)
         else
         {
             if (log)
-            log->error("Companion", tr("Failed to listen to port %1. Is there another process listening?").arg(port));
+                log->error("Companion",
+                           tr("Failed to listen to port %1. Is there another process listening?").arg(port));
         }
     }
 }

--- a/src/Extensions/LanguageServer.cpp
+++ b/src/Extensions/LanguageServer.cpp
@@ -189,9 +189,7 @@ void LanguageServer::performConnection()
         return;
     }
     connect(lsp, &LSPClient::onError, this, &LanguageServer::onLSPServerErrorArrived);
-    connect(lsp, &LSPClient::onRequest, this, &LanguageServer::onLSPServerRequestArrived);
     connect(lsp, &LSPClient::onServerError, this, &LanguageServer::onLSPServerProcessError);
-    connect(lsp, &LSPClient::onResponse, this, &LanguageServer::onLSPServerResponseArrived);
     connect(lsp, &LSPClient::onNotify, this, &LanguageServer::onLSPServerNotificationArrived);
     connect(lsp, &LSPClient::onServerFinished, this, &LanguageServer::onLSPServerProcessFinished);
     connect(lsp, &LSPClient::newStderr, this, &LanguageServer::onLSPServerNewStderr);
@@ -214,8 +212,6 @@ Editor::CodeEditor::SeverityLevel LanguageServer::lspSeverity(int in)
     default:
         return Editor::CodeEditor::SeverityLevel::Error;
     }
-    // Nothing matched
-    return Editor::CodeEditor::SeverityLevel::Error;
 }
 
 void LanguageServer::initializeLSP(QString const &filePath)
@@ -256,18 +252,6 @@ void LanguageServer::onLSPServerNotificationArrived(QString const &method, QJson
         }
         m_editor->highlightAllSquiggle();
     }
-}
-
-void LanguageServer::onLSPServerResponseArrived(QJsonObject const &method, // NOLINT: It can be made static.
-                                                QJsonObject const &param)
-{
-    LOG_INFO("Response from Server has arrived");
-}
-
-void LanguageServer::onLSPServerRequestArrived(QString const &method, // NOLINT: It can be made static.
-                                               QJsonObject const &param, QJsonObject const &id)
-{
-    LOG_INFO("Request from Sever has arrived. " << INFO_OF(method));
 }
 
 void LanguageServer::onLSPServerErrorArrived(QJsonObject const &id, QJsonObject const &error)

--- a/src/Extensions/LanguageServer.hpp
+++ b/src/Extensions/LanguageServer.hpp
@@ -46,8 +46,6 @@ class LanguageServer : public QObject
 
   private slots:
     void onLSPServerNotificationArrived(QString const &method, QJsonObject const &param);
-    void onLSPServerResponseArrived(QJsonObject const &method, QJsonObject const &param);
-    void onLSPServerRequestArrived(QString const &method, QJsonObject const &param, QJsonObject const &id);
     void onLSPServerErrorArrived(QJsonObject const &id, QJsonObject const &error);
     void onLSPServerProcessError(QProcess::ProcessError const &error);
     void onLSPServerProcessFinished(int exitCode, QProcess::ExitStatus status);

--- a/src/Extensions/README.md
+++ b/src/Extensions/README.md
@@ -6,3 +6,28 @@ the user can still use the editor to compile and test the programs.
 
 **All code in this folder must be under namespace `Extensions` and its 
 settings (if any) should be under `Extensions/$featurename`**
+
+## Extensions
+
+| Extension | Class | Description |
+|-----------|-------|-------------|
+| CF Tool | `CFTool` | Submit solutions to Codeforces via [cf-tool](https://github.com/xalanq/cf-tool). Settings: `CF/Enable`, `CF/Path`, `CF/Show Toast Messages` |
+| CSES CLI | `CSESTool` | Submit solutions to [CSES](https://cses.fi) via `cses-cli`. Settings: `CSES CLI/Enable`, `CSES CLI/Path`, `CSES CLI/Show Toast Messages` |
+| Clang Format | `ClangFormatter` | Format C/C++ code using clang-format |
+| YAPF | `YAPFormatter` | Format Python code using YAPF |
+| Competitive Companion | `CompanionServer` | Receive problem data (testcases, URLs) from [Competitive Companion](https://github.com/jmerle/competitive-companion) browser extension |
+| Language Server | `LanguageServer` | LSP-based linting and diagnostics for C++, Java, and Python |
+| WakaTime | `WakaTime` | Time tracking via [WakaTime](https://wakatime.com) |
+
+### CSES Tool Details
+
+The CSES CLI integration (`CSESTool`) follows the same pattern as CF Tool:
+
+1. **Enable/Disable**: Toggle via `CSES CLI/Enable` in Preferences → Extensions → CSES CLI
+2. **Path**: Set the path to the `cses-cli` executable (default: `cses-cli` on PATH) in `CSES CLI/Path`
+3. **URL Parsing**: When a `cses.fi` problem URL is set (manually or via Competitive Companion), the contest and task ID are automatically parsed. Two URL patterns are supported:
+   - `cses.fi/{contest}/task/{taskId}` (standard and contest tasks)
+   - `cses.fi/{contest}/{subcategory}/{taskId}` (multi-level category structures)
+4. **Submission**: A "Submit to CSES" button appears in the compile/run toolbar. Clicking it saves the current code to a temp file and submits via `cses-cli submit -c {contest} -t {taskId} {file}`
+5. **Fallback parsing**: If URL parsing fails, CSES identifiers can be extracted from head comments (e.g., `Contest: 647`, `Problem: A`) or `cses.fi` URLs in comments
+6. **Toast messages**: Submission verdicts are shown as toast notifications (reuses the CF Tool toast setting)

--- a/src/Extensions/README_zh-CN.md
+++ b/src/Extensions/README_zh-CN.md
@@ -3,3 +3,28 @@
 此文件夹包含编辑器的可选扩展代码。缺少这部分代码不影响编辑器基本的功能。
 
 **此文件夹中的所有代码以及选项均应处于`Extensions/$featurename`内。**
+
+## 扩展列表
+
+| 扩展 | 类 | 描述 |
+|----------|------|-------------|
+| CF Tool | `CFTool` | 通过 [cf-tool](https://github.com/xalanq/cf-tool) 提交代码至 Codeforces。设置项：`CF/Enable`、`CF/Path`、`CF/Show Toast Messages` |
+| CSES CLI | `CSESTool` | 通过 `cses-cli` 提交代码至 [CSES](https://cses.fi)。设置项：`CSES CLI/Enable`、`CSES CLI/Path`、`CSES CLI/Show Toast Messages` |
+| Clang Format | `ClangFormatter` | 使用 clang-format 格式化 C/C++ 代码 |
+| YAPF | `YAPFormatter` | 使用 YAPF 格式化 Python 代码 |
+| Competitive Companion | `CompanionServer` | 从 [Competitive Companion](https://github.com/jmerle/competitive-companion) 浏览器扩展接收题目数据（测试用例、URL） |
+| Language Server | `LanguageServer` | 基于 LSP 的 C++、Java 和 Python 代码诊断 |
+| WakaTime | `WakaTime` | 通过 [WakaTime](https://wakatime.com) 追踪编码时间 |
+
+### CSES CLI 集成详情
+
+CSES CLI 集成 (`CSESTool`) 采用与 CF Tool 相同的模式：
+
+1. **启用/禁用**：在 首选项 → 扩展 → CSES CLI 中通过 `CSES CLI/Enable` 切换
+2. **路径**：在 `CSES CLI/Path` 中设置 `cses-cli` 可执行文件的路径（默认：PATH 中的 `cses-cli`）
+3. **URL 解析**：当设置 `cses.fi` 题目 URL 时（手动或通过 Competitive Companion），自动解析比赛和题目 ID。支持两种 URL 模式：
+   - `cses.fi/{contest}/task/{taskId}`（标准题目和比赛题目）
+   - `cses.fi/{contest}/{subcategory}/{taskId}`（多级分类结构）
+4. **提交**：编译/运行工具栏中出现"Submit to CSES"按钮。点击后将当前代码保存至临时文件，并通过 `cses-cli submit -c {contest} -t {taskId} {file}` 提交
+5. **回退解析**：如果 URL 解析失败，可从题目标题注释（如 `Contest: 647`、`Problem: A`）或注释中的 `cses.fi` URL 提取 CSES 标识符
+6. **Toast 消息**：提交结果以 toast 通知形式显示（复用 CF Tool 的 toast 设置）

--- a/src/Settings/ParenthesesPage.cpp
+++ b/src/Settings/ParenthesesPage.cpp
@@ -61,7 +61,7 @@ ParenthesisWidget::ParenthesisWidget(QString language, QChar leftParenthesis, QC
                 .arg(name.toLower())
                 .arg(parenthesis())
                 .arg(lang));
-        connect(checkBox, &QCheckBox::checkStateChanged, this, &ParenthesisWidget::changed);
+        connect(checkBox, &QCheckBox::stateChanged, this, &ParenthesisWidget::changed);
         checkBoxesLayout->addWidget(checkBox);
     };
 

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -271,6 +271,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
                 "Competitive Companion/Head Comments Powered By CP Editor"}, false)
             .page(TRKEY("CF Tool"), {"CF/Enable","CF/Path", "CF/Show Toast Messages"})
+            .page(TRKEY("CSES CLI"), {"CSES CLI/Enable", "CSES CLI/Path"})
             .page(TRKEY("WakaTime"),{"WakaTime/Enable", "WakaTime/Path", "WakaTime/Api Key", "WakaTime/Proxy"})
         .end()
         .dir(TRKEY("File Path"))

--- a/src/Settings/PreferencesWindow.cpp
+++ b/src/Settings/PreferencesWindow.cpp
@@ -271,7 +271,7 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QMainWindow(parent)
                 "Competitive Companion/Head Comments", "Competitive Companion/Head Comments Time Format",
                 "Competitive Companion/Head Comments Powered By CP Editor"}, false)
             .page(TRKEY("CF Tool"), {"CF/Enable","CF/Path", "CF/Show Toast Messages"})
-            .page(TRKEY("CSES CLI"), {"CSES CLI/Enable", "CSES CLI/Path"})
+            .page(TRKEY("CSES CLI"), {"CSES CLI/Enable", "CSES CLI/Path", "CSES CLI/Show Toast Messages"})
             .page(TRKEY("WakaTime"),{"WakaTime/Enable", "WakaTime/Path", "WakaTime/Api Key", "WakaTime/Proxy"})
         .end()
         .dir(TRKEY("File Path"))

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -22,7 +22,9 @@
 #include "Util/FileUtil.hpp"
 #include "generated/portable.hpp"
 #include <QDateTime>
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QFont>
 #include <QRect>
 #include <QSettings>
@@ -69,7 +71,25 @@ void SettingsManager::load(QSettings &setting, const QString &prefix, const QLis
             setting.endGroup();
         }
         else if (setting.contains(si.key()) && setting.value(si.key()).isValid())
-            set(si.name, setting.value(si.key()));
+        {
+            QVariant val = setting.value(si.key());
+            if (val.metaType().id() == QMetaType::QString)
+            {
+                if (si.type == "int")
+                {
+                    bool ok;
+                    val = val.toInt(&ok);
+                    if (!ok)
+                        val = setting.value(si.key());
+                }
+                else if (si.type == "bool")
+                {
+                    auto s = val.toString();
+                    val = s.compare("true", Qt::CaseInsensitive) == 0 || s == "1";
+                }
+            }
+            set(prefix + si.name, val);
+        }
     }
 }
 
@@ -90,7 +110,7 @@ void SettingsManager::save(QSettings &setting, const QString &prefix, const QLis
                 setting.setValue(QString("%1%2/%3").arg(prefix, si.key(), key),
                                  get(QString("%1%2/%3").arg(prefix, si.name, key)));
         else
-            setting.setValue(QString("%1%2").arg(prefix, si.key()), get(si.name));
+            setting.setValue(QString("%1%2").arg(prefix, si.key()), get(prefix + si.name));
 }
 
 void SettingsManager::init()
@@ -162,6 +182,8 @@ void SettingsManager::loadSettings(const QString &path)
 void SettingsManager::saveSettings(const QString &path)
 {
     const auto savePath = path.isEmpty() ? Util::configFilePath(configFileLocations[0]) : path;
+
+    QDir().mkpath(QFileInfo(savePath).absolutePath());
 
     LOG_INFO("Start saving settings to " + savePath);
 

--- a/src/Settings/SettingsManager.cpp
+++ b/src/Settings/SettingsManager.cpp
@@ -77,7 +77,7 @@ void SettingsManager::load(QSettings &setting, const QString &prefix, const QLis
             {
                 if (si.type == "int")
                 {
-                    bool ok;
+                    bool ok = false;
                     val = val.toInt(&ok);
                     if (!ok)
                         val = setting.value(si.key());

--- a/src/Settings/settings.json
+++ b/src/Settings/settings.json
@@ -675,20 +675,46 @@
     "type": "bool",
     "notr": true
   },
-  {
-    "name": "CF/Path",
-    "desc": "Path",
-    "type": "QString",
-    "default": "cf",
-    "ui": "PathItem",
-    "param": "PathItem::Executable",
-    "tip": "The path to the CF Tool executable file",
-    "depends": [
-      {
-        "name": "CF/Enable"
-      }
-    ]
-  },
+    {
+      "name": "CF/Path",
+      "desc": "Path",
+      "type": "QString",
+      "default": "cf",
+      "ui": "PathItem",
+      "param": "PathItem::Executable",
+      "tip": "The path to the CF Tool executable file",
+      "depends": [
+        {
+          "name": "CF/Enable"
+        }
+      ]
+    },
+    {
+      "name": "CSES CLI/Path",
+      "desc": "Path",
+      "type": "QString",
+      "default": "cses-cli",
+      "ui": "PathItem",
+      "param": "PathItem::Executable",
+      "tip": "The path to the CSES CLI executable file",
+      "depends": [
+        {
+          "name": "CSES CLI/Enable"
+        }
+      ]
+    },
+    {
+      "name": "CSES CLI/Show Toast Messages",
+      "desc": "Show toast messages for submission verdicts",
+      "type": "bool",
+      "default": "true",
+      "tip": "Show a toast message when the verdict of a submission is known.",
+      "depends": [
+        {
+          "name": "CSES CLI/Enable"
+        }
+      ]
+    },
   {
     "name": "CF/Show Toast Messages",
     "desc": "Show toast messages for submission verdicts",
@@ -701,13 +727,20 @@
       }
     ]
   },
-  {
-    "name": "CF/Enable",
-    "desc": "Enable CF Tool",
-    "type": "bool",
-    "default": "true",
-    "tip": "Enable or disable CF Tool Integration."
-  },
+    {
+      "name": "CF/Enable",
+      "desc": "Enable CF Tool",
+      "type": "bool",
+      "default": "true",
+      "tip": "Enable or disable CF Tool Integration."
+    },
+    {
+      "name": "CSES CLI/Enable",
+      "desc": "Enable CSES CLI",
+      "type": "bool",
+      "default": "true",
+      "tip": "Enable or disable CSES CLI Integration."
+    },
   {
     "name": "Show Compile And Run Only",
     "type": "bool",

--- a/src/SignalHandler.cpp
+++ b/src/SignalHandler.cpp
@@ -78,7 +78,7 @@ SignalHandler::SignalHandler(int mask) : _mask(mask)
             connect(sn, &QSocketNotifier::activated, this, [sn, logical, this] {
                 sn->setEnabled(false);
                 char tmp = 0;
-                ::read(socketFd[logical][1], &tmp, sizeof(tmp));
+                (void)::read(socketFd[logical][1], &tmp, sizeof(tmp));
                 handleSignal(logical);
                 sn->setEnabled(true);
             });
@@ -200,7 +200,7 @@ void POSIX_handleFunc(int signal)
     {
         int signo = POSIX_physicalToLogical(signal);
         char a = 1;
-        ::write(socketFd[signo][0], &a, sizeof(a));
+        (void)::write(socketFd[signo][0], &a, sizeof(a));
     }
 }
 #endif //_WIN32

--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -177,10 +177,9 @@ void UpdateChecker::managerFinished(QNetworkReply *reply)
             if (currentVersion < version)
             {
                 if (!(version.majorVersion() == latestVersion.majorVersion() &&
-                      version.minorVersion() == latestVersion.minorVersion() &&
-                      !latestInfo.preview && release.second.preview) &&
-                    !(version.majorVersion() == last.majorVersion() &&
-                      version.minorVersion() == last.minorVersion()))
+                      version.minorVersion() == latestVersion.minorVersion() && !latestInfo.preview &&
+                      release.second.preview) &&
+                    !(version.majorVersion() == last.majorVersion() && version.minorVersion() == last.minorVersion()))
                 {
                     used = true;
                     last = version;

--- a/src/Telemetry/UpdateChecker.cpp
+++ b/src/Telemetry/UpdateChecker.cpp
@@ -176,26 +176,16 @@ void UpdateChecker::managerFinished(QNetworkReply *reply)
             bool used = false;
             if (currentVersion < version)
             {
-                do
+                if (!(version.majorVersion() == latestVersion.majorVersion() &&
+                      version.minorVersion() == latestVersion.minorVersion() &&
+                      !latestInfo.preview && release.second.preview) &&
+                    !(version.majorVersion() == last.majorVersion() &&
+                      version.minorVersion() == last.minorVersion()))
                 {
-                    if (version.majorVersion() == latestVersion.majorVersion() &&
-                        version.minorVersion() == latestVersion.minorVersion())
-                    {
-                        if (!latestInfo.preview && release.second.preview)
-                        {
-                            break;
-                        }
-                    }
-                    else if (version.majorVersion() == last.majorVersion() &&
-                             version.minorVersion() == last.minorVersion())
-                    {
-                        break;
-                    }
-
                     used = true;
                     last = version;
                     changelog.push_back(release.second.changelog);
-                } while (false);
+                }
             }
             LOG_INFO(QString("Version %1 is %2 the changelog")
                          .arg(release.second.version)

--- a/src/Util/Singleton.hpp
+++ b/src/Util/Singleton.hpp
@@ -18,20 +18,17 @@
 #ifndef SINGLETON_HPP
 #define SINGLETON_HPP
 
-#include <type_traits>
-
 namespace Util
 {
 
-template <typename T, typename D = T> class Singleton
+template <typename T> class Singleton
 {
-    static_assert(std::is_base_of<T, D>::value, "T should be a base type for D");
-    friend D;
+    friend T;
 
   public:
     static T &instance()
     {
-        static D inst;
+        static T inst;
         return inst;
     }
 

--- a/src/Widgets/RichTextCheckBox.cpp
+++ b/src/Widgets/RichTextCheckBox.cpp
@@ -134,31 +134,9 @@ RichTextCheckBox::RichTextCheckBox(const QString &text, QWidget *parent) : QWidg
     connect(label, &ClickableLabel::released, this, &RichTextCheckBox::clicked);
 }
 
-QCheckBox *RichTextCheckBox::getCheckBox()
-{
-    return checkBox;
-}
-
 bool RichTextCheckBox::isChecked() const
 {
     return checkBox->isChecked();
-}
-
-Qt::CheckState RichTextCheckBox::checkState() const
-{
-    return checkBox->checkState();
-}
-
-QString RichTextCheckBox::text() const
-{
-    return label->text();
-}
-
-QString RichTextCheckBox::plainText() const
-{
-    QTextDocument doc;
-    doc.setHtml(label->text());
-    return doc.toPlainText();
 }
 
 void RichTextCheckBox::clearStates()

--- a/src/Widgets/RichTextCheckBox.hpp
+++ b/src/Widgets/RichTextCheckBox.hpp
@@ -68,9 +68,7 @@ class RichTextCheckBox : public QWidget
 
   public:
     explicit RichTextCheckBox(const QString &text, QWidget *parent = nullptr);
-    QCheckBox *getCheckBox();
     QString text() const;
-    QString plainText() const;
     Qt::CheckState checkState() const;
     bool isChecked() const;
     void clearStates();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,6 +25,7 @@
 #include "Editor/CodeEditor.hpp"
 #include "Editor/FakeVimProxy.hpp"
 #include "Extensions/CFTool.hpp"
+#include "Extensions/CSESTool.hpp"
 #include "Extensions/ClangFormatter.hpp"
 #include "Extensions/CompanionServer.hpp"
 #include "Extensions/YAPFormatter.hpp"
@@ -346,6 +347,82 @@ void MainWindow::setCFToolUI()
     }
 }
 
+void MainWindow::setCSESToolUI()
+{
+    if (!SettingsHelper::isCSESCLIEnable())
+        return;
+    if (submitToCses == nullptr)
+    {
+        submitToCses = new QPushButton(tr("Submit to CSES"), this);
+        csestool = new Extensions::CSESTool(csesCliPath, log);
+        connect(csestool, &Extensions::CSESTool::requestToastMessage, this, &MainWindow::requestToastMessage);
+        ui->compileAndRunButtons->addWidget(submitToCses);
+        connect(submitToCses, &QPushButton::clicked, this, [this] {
+            emit confirmTriggered(this);
+            auto response = QMessageBox::warning(this, tr("Sure to submit"),
+                                                 tr("Are you sure you want to submit this solution to CSES?\n\n Contest: %1\n Task: %2\n Language: %3")
+                                                     .arg(csesContest, csesTaskId, language),
+                                                 QMessageBox::Yes | QMessageBox::No);
+
+            if (response == QMessageBox::Yes)
+            {
+                auto path = tmpPath();
+                if (path.isEmpty())
+                {
+                    QMessageBox::warning(this, tr("CSES CLI"),
+                                         tr("Failed to save the temp file, and the solution is not submitted."));
+                }
+                else
+                {
+                    log->clear();
+                    csestool->submit(tmpPath(), csesContest, csesTaskId);
+                }
+            }
+        });
+    }
+    
+    // Check CSES CLI installation
+    if (!Extensions::CSESTool::check(csesCliPath))
+    {
+        submitToCses->setEnabled(false);
+        QString tooltip = tr("CSES CLI not found at: %1\nSet correct path in Preferences → Extensions → CSES CLI")
+                             .arg(csesCliPath);
+        submitToCses->setToolTip(tooltip);
+        log->error(tr("CSES CLI"),
+                   tr("You need to install CSES CLI to submit your code to CSES. If already installed, you can "
+                      "add it in the PATH environment variable or check your settings at %1.")
+                       .arg(SettingsHelper::pathOfCSESCLIPath()),
+                   false);
+    }
+    // Check if contest and task ID are parsed
+    else if (csesContest.isEmpty() || csesTaskId.isEmpty())
+    {
+        submitToCses->setEnabled(false);
+        QString tooltip = tr("Could not parse CSES contest/task ID from URL.\nMake sure you're on a valid CSES problem page.");
+        submitToCses->setToolTip(tooltip);
+        log->warn(tr("CSES CLI"), tr("CSES contest or task ID not found in URL. Button disabled."));
+    }
+    else
+    {
+        submitToCses->setEnabled(true);
+        QString tooltip = tr("Submit to CSES\nContest: %1\nTask: %2").arg(csesContest, csesTaskId);
+        submitToCses->setToolTip(tooltip);
+    }
+}
+
+void MainWindow::removeCSESToolUI()
+{
+    if (submitToCses != nullptr)
+    {
+        submitToCses->setEnabled(false);
+        ui->compileAndRunButtons->removeWidget(submitToCses);
+        delete submitToCses;
+        submitToCses = nullptr;
+        delete csestool;
+        csestool = nullptr;
+    }
+}
+
 void MainWindow::removeCFToolUI()
 {
     if (submitToCodeforces != nullptr)
@@ -368,6 +445,8 @@ QString MainWindow::getFileName() const
 {
     if (!isUntitled())
         return QFileInfo(filePath).fileName();
+    if (!companionName.isEmpty())
+        return companionName;
     if (!problemURL.isEmpty())
         return QRegularExpression(R"(.*/([^\?#].*?)/?$)").match(problemURL).captured(1);
     return tr("Untitled-%1").arg(untitledIndex);
@@ -462,8 +541,38 @@ void MainWindow::setProblemURL(const QString &url)
         return;
     problemURL = url;
     FileProblemBinder::set(filePath, url);
+    
+    // Clear CSES identifiers when URL changes
+    // Note: companionName is NOT cleared here - it's preserved from applyCompanion()
+    // and only cleared in loadFile() and loadStatus()
+    csesContest.clear();
+    csesTaskId.clear();
+    
     if (problemURL.contains("codeforces.com"))
         setCFToolUI();
+    
+    if (problemURL.contains("cses.fi"))
+    {
+        // Parse contest and task ID from URL
+        QString contest, taskId;
+        if (Extensions::CSESTool::parseCsesUrl(url, contest, taskId))
+        {
+            csesContest = contest;
+            csesTaskId = taskId;
+        }
+        else
+        {
+            // Clear if URL is CSES but parsing failed
+            csesContest.clear();
+            csesTaskId.clear();
+        }
+        setCSESToolUI();
+    }
+    else
+    {
+        // Not a CSES URL, remove UI
+        removeCSESToolUI();
+    }
     emit editorFileChanged();
 }
 
@@ -563,6 +672,8 @@ void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
 {
     LOG_INFO("Requesting loadStatus");
     setProblemURL(status.problemURL);
+    // Clear companion name when loading a saved status
+    companionName.clear();
     if (status.isLanguageSet)
         setLanguage(status.language);
     customCompileCommand = status.customCompileCommand; // this must be after setLanguage
@@ -615,6 +726,17 @@ void MainWindow::loadStatus(const EditorStatus &status, bool duplicate)
 void MainWindow::applyCompanion(const Extensions::CompanionData &data)
 {
     LOG_INFO("Requesting apply from companion");
+
+    // Extract problem name from companion data for auto-naming
+    QString name = data.doc["name"].toString();
+    if (!name.isEmpty())
+    {
+        companionName = name.replace(" ", "_");
+    }
+    else
+    {
+        companionName.clear();
+    }
 
     if (isUntitled() && !isTextChanged())
     {
@@ -682,6 +804,56 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
     for (auto const &testcase : data.testcases)
         testcases->addTestCase(testcase.input, testcase.output);
 
+    // Try to extract CSES identifiers from companion data or head comments
+    csesContest.clear();
+    csesTaskId.clear();
+
+    // Prefer the provided URL in companion data
+    if (!data.url.isEmpty())
+    {
+        QString contest, task;
+        if (Extensions::CSESTool::parseCsesUrl(data.url, contest, task))
+        {
+            csesContest = contest;
+            csesTaskId = task;
+        }
+    }
+
+    // If not found, fall back to head comments in the editor
+    if (csesContest.isEmpty() || csesTaskId.isEmpty())
+    {
+        auto content = editor->toPlainText();
+        auto lines = content.split('\n');
+        int limit = qMin(lines.size(), 30);
+        for (int i = 0; i < limit && (csesContest.isEmpty() || csesTaskId.isEmpty()); ++i)
+        {
+            const QString &ln = lines[i];
+            // detect URL inside comments
+            // Changed R"(...)" to R"delim(...)delim" to avoid quote conflicts
+            QRegularExpression urlRe(R"delim((https?://cses\.fi[^\s)"']*))delim");
+            auto m = urlRe.match(ln);
+            if (m.hasMatch())
+            {
+                QString contest, task;
+                if (Extensions::CSESTool::parseCsesUrl(m.captured(1), contest, task))
+                {
+                    csesContest = contest;
+                    csesTaskId = task;
+                    break;
+                }
+            }
+
+            // detect explicit Contest: and Problem: lines
+            auto cMatch = QRegularExpression(R"(^\s*Contest:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
+            auto pMatch = QRegularExpression(R"(^\s*Problem:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
+            if (cMatch.hasMatch())
+                csesContest = cMatch.captured(1);
+            if (pMatch.hasMatch())
+                csesTaskId = pMatch.captured(1);
+        }
+    }
+
+    // setProblemURL will handle CSES UI based on URL and parsed identifiers
     setProblemURL(data.url);
 
     if (SettingsHelper::isCompetitiveCompanionSetTimeLimitForTab())
@@ -717,6 +889,33 @@ void MainWindow::applySettings(const QString &pagePath)
             else if (submitToCodeforces != nullptr && !SettingsHelper::isCFEnable())
             {
                 removeCFToolUI();
+            }
+        }
+    }
+
+    if (pageChanged("Extensions/CSES CLI"))
+    {
+        csesCliPath = SettingsHelper::getCSESCLIPath();
+
+        if (csestool != nullptr && Extensions::CSESTool::check(csesCliPath))
+        {
+            csestool->updatePath(csesCliPath);
+            // setCSESToolUI will update button state based on parsed IDs
+        }
+        if (problemURL.contains("cses.fi"))
+        {
+            if (submitToCses == nullptr && SettingsHelper::isCSESCLIEnable())
+            {
+                setCSESToolUI();
+            }
+            else if (submitToCses != nullptr && !SettingsHelper::isCSESCLIEnable())
+            {
+                removeCSESToolUI();
+            }
+            else if (submitToCses != nullptr)
+            {
+                // Update button state when CSES CLI path changes
+                setCSESToolUI();
             }
         }
     }
@@ -993,6 +1192,9 @@ void MainWindow::loadFile(const QString &loadPath)
     bool samePath = !isUntitled() && filePath == path;
     setFilePath(path, false);
 
+    // Clear companion name when loading a file directly
+    companionName.clear();
+
     bool isTemplate = false;
 
     if (!QFile::exists(path))
@@ -1085,8 +1287,15 @@ bool MainWindow::saveFile(SaveMode mode, const QString &head, bool safe)
 
             if (defaultPath.isEmpty())
             {
-                defaultPath =
-                    QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(getTabTitle(false, false));
+                if (!companionName.isEmpty())
+                {
+                    defaultPath = QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(companionName);
+                }
+                else
+                {
+                    defaultPath =
+                        QDir(DefaultPathManager::defaultPathForAction("Save File")).filePath(getTabTitle(false, false));
+                }
             }
 
             defaultPath = Util::fileNameWithSuffix(defaultPath, language);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -559,7 +559,8 @@ void MainWindow::setProblemURL(const QString &url)
     if (problemURL.contains("cses.fi"))
     {
         // Parse contest and task ID from URL
-        QString contest, taskId;
+        QString contest;
+        QString taskId;
         if (Extensions::CSESTool::parseCsesUrl(url, contest, taskId))
         {
             csesContest = contest;
@@ -816,7 +817,8 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
     // Prefer the provided URL in companion data
     if (!data.url.isEmpty())
     {
-        QString contest, task;
+        QString contest;
+        QString task;
         if (Extensions::CSESTool::parseCsesUrl(data.url, contest, task))
         {
             csesContest = contest;
@@ -839,7 +841,8 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
             auto m = urlRe.match(ln);
             if (m.hasMatch())
             {
-                QString contest, task;
+                QString contest;
+                QString task;
                 if (Extensions::CSESTool::parseCsesUrl(m.captured(1), contest, task))
                 {
                     csesContest = contest;
@@ -911,18 +914,13 @@ void MainWindow::applySettings(const QString &pagePath)
         }
         if (problemURL.contains("cses.fi"))
         {
-            if (submitToCses == nullptr && SettingsHelper::isCSESCLIEnable())
+            if (SettingsHelper::isCSESCLIEnable())
             {
                 setCSESToolUI();
-            }
-            else if (submitToCses != nullptr && !SettingsHelper::isCSESCLIEnable())
-            {
-                removeCSESToolUI();
             }
             else if (submitToCses != nullptr)
             {
-                // Update button state when CSES CLI path changes
-                setCSESToolUI();
+                removeCSESToolUI();
             }
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -362,10 +362,11 @@ void MainWindow::setCSESToolUI()
         ui->compileAndRunButtons->addWidget(submitToCses);
         connect(submitToCses, &QPushButton::clicked, this, [this] {
             emit confirmTriggered(this);
-            auto response = QMessageBox::warning(this, tr("Sure to submit"),
-                                                 tr("Are you sure you want to submit this solution to CSES?\n\n Contest: %1\n Task: %2\n Language: %3")
-                                                     .arg(csesContest, csesTaskId, language),
-                                                 QMessageBox::Yes | QMessageBox::No);
+            auto response = QMessageBox::warning(
+                this, tr("Sure to submit"),
+                tr("Are you sure you want to submit this solution to CSES?\n\n Contest: %1\n Task: %2\n Language: %3")
+                    .arg(csesContest, csesTaskId, language),
+                QMessageBox::Yes | QMessageBox::No);
 
             if (response == QMessageBox::Yes)
             {
@@ -383,13 +384,13 @@ void MainWindow::setCSESToolUI()
             }
         });
     }
-    
+
     // Check CSES CLI installation
     if (!Extensions::CSESTool::check(csesCliPath))
     {
         submitToCses->setEnabled(false);
-        QString tooltip = tr("CSES CLI not found at: %1\nSet correct path in Preferences → Extensions → CSES CLI")
-                             .arg(csesCliPath);
+        QString tooltip =
+            tr("CSES CLI not found at: %1\nSet correct path in Preferences → Extensions → CSES CLI").arg(csesCliPath);
         submitToCses->setToolTip(tooltip);
         log->error(tr("CSES CLI"),
                    tr("You need to install CSES CLI to submit your code to CSES. If already installed, you can "
@@ -401,7 +402,8 @@ void MainWindow::setCSESToolUI()
     else if (csesContest.isEmpty() || csesTaskId.isEmpty())
     {
         submitToCses->setEnabled(false);
-        QString tooltip = tr("Could not parse CSES contest/task ID from URL.\nMake sure you're on a valid CSES problem page.");
+        QString tooltip =
+            tr("Could not parse CSES contest/task ID from URL.\nMake sure you're on a valid CSES problem page.");
         submitToCses->setToolTip(tooltip);
         log->warn(tr("CSES CLI"), tr("CSES contest or task ID not found in URL. Button disabled."));
     }
@@ -544,16 +546,16 @@ void MainWindow::setProblemURL(const QString &url)
         return;
     problemURL = url;
     FileProblemBinder::set(filePath, url);
-    
+
     // Clear CSES identifiers when URL changes
     // Note: companionName is NOT cleared here - it's preserved from applyCompanion()
     // and only cleared in loadFile() and loadStatus()
     csesContest.clear();
     csesTaskId.clear();
-    
+
     if (problemURL.contains("codeforces.com"))
         setCFToolUI();
-    
+
     if (problemURL.contains("cses.fi"))
     {
         // Parse contest and task ID from URL
@@ -847,8 +849,10 @@ void MainWindow::applyCompanion(const Extensions::CompanionData &data)
             }
 
             // detect explicit Contest: and Problem: lines
-            auto cMatch = QRegularExpression(R"(^\s*Contest:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
-            auto pMatch = QRegularExpression(R"(^\s*Problem:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
+            auto cMatch =
+                QRegularExpression(R"(^\s*Contest:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
+            auto pMatch =
+                QRegularExpression(R"(^\s*Problem:\s*(\S+))", QRegularExpression::CaseInsensitiveOption).match(ln);
             if (cMatch.hasMatch())
                 csesContest = cMatch.captured(1);
             if (pMatch.hasMatch())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -118,6 +118,9 @@ MainWindow::~MainWindow()
     }
 
     delete cftool;
+    delete csestool;
+    delete submitToCodeforces;
+    delete submitToCses;
     delete tmpDir;
 
     delete ui;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -50,6 +50,7 @@ namespace Extensions
 {
 class CFTool;
 struct CompanionData;
+class CSESTool;
 } // namespace Extensions
 
 namespace FakeVim
@@ -240,6 +241,7 @@ class MainWindow : public QMainWindow
     QString filePath;
     QString savedText;
     QString cftoolPath;
+    QString csesCliPath;
     QFileSystemWatcher *fileWatcher;
 
     std::atomic<bool> reloading;
@@ -247,6 +249,10 @@ class MainWindow : public QMainWindow
 
     QPushButton *submitToCodeforces = nullptr;
     Extensions::CFTool *cftool = nullptr;
+    QPushButton *submitToCses = nullptr;
+    Extensions::CSESTool *csestool = nullptr;
+    QString csesContest, csesTaskId;
+    QString companionName;
 
     Widgets::TestCases *testcases = nullptr;
     Widgets::Stopwatch *stopwatch = nullptr;
@@ -267,6 +273,8 @@ class MainWindow : public QMainWindow
     void saveTests(bool safe);
     void setCFToolUI();
     void removeCFToolUI(); // Delete cftool&submitToCodeforces pointers, and remove the button from ui
+    void setCSESToolUI();
+    void removeCSESToolUI();
     void setFilePath(QString path, bool updateBinder = true);
     void setText(const QString &text, bool keep = false);
     void updateWatcher();

--- a/tools/getDonors.py
+++ b/tools/getDonors.py
@@ -1,19 +1,13 @@
 import json
 import re
-import requests
 import sys
+from urllib.request import Request, urlopen
 
 def queryGitHub(q):
-    print('GitHub query:')
-    print(q)
-    res = requests.post("https://api.github.com/graphql",
-        data = json.dumps({"query": q}),
-        headers = {
-            "Authorization": "token " + sys.argv[1]
-        })
-    print('GitHub response:')
-    print(res.text)
-    return res.json()["data"]
+    req = Request("https://api.github.com/graphql",
+        data=json.dumps({"query": q}).encode(),
+        headers={"Authorization": "token " + sys.argv[1]})
+    return json.loads(urlopen(req).read())["data"]
 
 def getGitHub(donors):
     after = ""
@@ -52,16 +46,10 @@ def getGitHub(donors):
         after = sponsors["pageInfo"]["endCursor"]
 
 def queryOpenCollective(q):
-    print('OpenCollective query:')
-    print(q)
-    res = requests.post("https://opencollective.com/api/graphql/v2",
-        data = json.dumps({"query": q}),
-        headers = {
-            "content-type": "application/json"
-        })
-    print('OpenCollective response:')
-    print(res.text)
-    return res.json()["data"]
+    req = Request("https://opencollective.com/api/graphql/v2",
+        data=json.dumps({"query": q}).encode(),
+        headers={"content-type": "application/json"})
+    return json.loads(urlopen(req).read())["data"]
 
 def getOpenCollective(donors):
     data = queryOpenCollective('''
@@ -110,5 +98,5 @@ for i in range(2):
 newContent = re.sub(r"(?<=<!\-\- START: GitHub Sponsors \-\->)[\s\S]*(?=<!\-\- END: GitHub Sponsors \-\->)", newMarkdown[0], content)
 newContent = re.sub(r"(?<=<!\-\- START: OpenCollective Contributors \-\->)[\s\S]*(?=<!\-\- END: OpenCollective Contributors \-\->)", newMarkdown[1], newContent)
 
-with open("DONORS.md", "w") as donors:
-    donors.write(newContent)
+with open("DONORS.md", "w") as donorsF:
+    donorsF.write(newContent)

--- a/tools/newFile.sh
+++ b/tools/newFile.sh
@@ -9,38 +9,18 @@ e.g. newFile.sh Core/Compiler'
   exit 1
 fi
 
-head="/*
- * Copyright (C) 2019-2021 Ashar Khan <ashar786khan@gmail.com>
- *
- * This file is part of CP Editor.
- *
- * CP Editor is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * I will not be responsible if CP Editor behaves in unexpected way and
- * causes your ratings to go down and or lose any important contest.
- *
- * Believe Software is \"Software\" and it isn't immune to bugs.
- *
- */
-"
-
 filepath=${1%/*}
 filename=${1#$filepath/}
 define=${filename}_hpp
-DEFINE=`echo ${define} | tr [:lower:] [:upper:]`
+DEFINE=$(echo ${define} | tr "[:lower:]" "[:upper:]")
 
 cd "$(dirname "$0")"/..
 
 mkdir -p "src/$filepath"
 
-echo "$head
-#ifndef $DEFINE
+echo "#ifndef $DEFINE
 #define $DEFINE
 
-#endif // $DEFINE" >"src/$1.hpp"
+#endif // $DEFINE" > "src/$1.hpp"
 
-echo "$head
-#include \"$1.hpp\"" >"src/$1.cpp"
+echo "#include \"$1.hpp\"" > "src/$1.cpp"

--- a/translations/ar_EG.ts
+++ b/translations/ar_EG.ts
@@ -832,6 +832,45 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1284,6 +1323,46 @@ Do you want to reload it?</source>
         <source>C++</source>
         <translation>C++</translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1624,6 +1703,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Network Proxy</source>
         <translation>وكيل الشبكة</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1645,7 +1728,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Editor Font</source>
@@ -2867,6 +2950,22 @@ It is a list of &lt;default path name&gt;s, separated by commas, and can be empt
     <message>
         <source>Extract And Load Snippets</source>
         <translation>استخراج وتحميل المقتطفات</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/el_GR.ts
+++ b/translations/el_GR.ts
@@ -834,6 +834,45 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1286,6 +1325,46 @@ Do you want to reload it?</source>
         <source>Failed to start compilation: %1</source>
         <translation>Απέτυχε να ξεκινήσει η μεταγλώττιση: %1</translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1627,6 +1706,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>WakaTime</source>
         <translation>WakaTime</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1817,7 +1900,7 @@ This can be overridden for each parenthesis in each language.</source>
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>%1 Template Path</source>
@@ -2865,6 +2948,22 @@ This may reduce distractions caused by stopwatch updates.</source>
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Το περιεχόμενο του Vim RC. Φορτώνεται κάθε φορά που ξεκινά η εξομοίωση Vim.
 Δεν υποστηρίζονται όλες οι εντολές Vim, ελέγξτε https://github.com/cpeditor/FakeVim για τη λίστα υποστηριζόμενων εντολών</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/es_MX.ts
+++ b/translations/es_MX.ts
@@ -834,6 +834,45 @@ Presione cualquier tecla para salir</translation>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1286,6 +1325,46 @@ ha sido cambiado en el disco.
         <source>C++</source>
         <translation>C++</translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1627,6 +1706,10 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
         <source>Network Proxy</source>
         <translation>Proxy de red</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1648,7 +1731,7 @@ Si está parcialmente marcado, la configuración global en Editar Código t se u
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Editor Font</source>
@@ -2870,6 +2953,22 @@ Es una lista de &lt;nombre de ruta predeterminada&gt;, separadas por comas, y pu
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Contenido del Vim RC. Se carga cada vez que se inicia la emulación de Vim.
 No todos los comandos de Vim están soportados, consulte https://github.com/cpeditor/FakeVim para la lista de comandos soportados</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/hi_IN.ts
+++ b/translations/hi_IN.ts
@@ -832,6 +832,45 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1284,6 +1323,46 @@ Do you want to reload it?</source>
         <source>C++</source>
         <translation>C++</translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1625,6 +1704,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Network Proxy</source>
         <translation>नेटवर्क प्रॉक्सी</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1646,7 +1729,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Editor Font</source>
@@ -2862,6 +2945,22 @@ It is a list of &lt;default path name&gt;s, separated by commas, and can be empt
     <message>
         <source>Extract And Load Snippets</source>
         <translation>एक्सट्रैक्ट एंड लोड स्निपेट्स</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -834,6 +834,45 @@ Pressionar qualquer tecla para sair</translation>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1286,6 +1325,46 @@ Quer recarregar?</translation>
         <source>Failed to start compilation: %1</source>
         <translation>Falha ao iniciar a compilação: %1</translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1627,6 +1706,10 @@ Se for parcialmente desejada, a escolha em Editar Código será usada.</translat
         <source>Auto Save</source>
         <translation>Salvamento automático</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1817,7 +1900,7 @@ e deslocar-se ao digitar o elemento mais à direita.</translation>
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>%1 Template Path</source>
@@ -2869,6 +2952,22 @@ Isso pode reduzir distrações causadas pelas atualizações do cronômetro.</tr
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Conteúdo do Vim RC. É carregado toda vez que a emulação do Vim é iniciada.
 Nem todos os comandos do Vim são suportados, consulte https://github.com/cpeditor/FakeVim para a lista de comandos suportados</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -834,6 +834,45 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1286,6 +1325,46 @@ Do you want to reload it?</source>
         <source>Failed to start compilation: %1</source>
         <translation>Ошибка старта компиляции: %1</translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1627,6 +1706,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Test Cases</source>
         <translation type="unfinished">Тесткейсы</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1818,7 +1901,7 @@ This can be overridden for each parenthesis in each language.</source>
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>%1 Template Path</source>
@@ -2867,6 +2950,22 @@ This may reduce distractions caused by stopwatch updates.</source>
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Содержимое Vim RC. Загружается при каждом запуске эмуляции Vim.
 Поддерживаются не все команды Vim, см. https://github.com/cpeditor/FakeVim для списка поддерживаемых команд</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -834,6 +834,45 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1286,6 +1325,46 @@ Do you want to reload it?</source>
         <source>Failed to start compilation: %1</source>
         <translation>未能开始编译：%1</translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1627,6 +1706,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Generator Template</source>
         <translation>数据生成器模版</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1816,7 +1899,7 @@ This can be overridden for each parenthesis in each language.</source>
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>%1 Template Path</source>
@@ -2860,6 +2943,22 @@ This may reduce distractions caused by stopwatch updates.</source>
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Vim RC 的内容。每次启动 Vim 模拟时都会加载。
 并非所有 Vim 命令都受支持，请查看 https://github.com/cpeditor/FakeVim 了解支持的命令列表</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -840,6 +840,45 @@ Press any key to exit</source>
     </message>
 </context>
 <context>
+    <name>Extensions::CSESTool</name>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI was killed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Empty contest or task id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to get the version of CSES CLI. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI has started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start CSES CLI in 2 seconds. Have you set the correct path in Preferences?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI finished with non-zero exit code %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Extensions::CodeFormatter</name>
     <message>
         <source>Formatter</source>
@@ -1298,6 +1337,46 @@ Do you want to reload it?</source>
         <source>C++</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Submit to CSES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to submit this solution to CSES?
+
+ Contest: %1
+ Task: %2
+ Language: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES CLI not found at: %1
+Set correct path in Preferences → Extensions → CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You need to install CSES CLI to submit your code to CSES. If already installed, you can add it in the PATH environment variable or check your settings at %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Could not parse CSES contest/task ID from URL.
+Make sure you&apos;re on a valid CSES problem page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSES contest or task ID not found in URL. Button disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Submit to CSES
+Contest: %1
+Task: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MessageLogger</name>
@@ -1640,6 +1719,10 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
         <source>Network Proxy</source>
         <translation>網路 Proxy</translation>
     </message>
+    <message>
+        <source>CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsInfo</name>
@@ -1661,7 +1744,7 @@ If it&apos;s partially checked, the global setting in Code Edit will be used.</s
     </message>
     <message>
         <source></source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Editor Font</source>
@@ -2884,6 +2967,22 @@ This may reduce distractions caused by stopwatch updates.</source>
 Not all vim commands are supported, please check https://github.com/cpeditor/FakeVim for list of supported commands</source>
         <translation>Vim RC 的內容。每次啟動 Vim 模擬時都會載入。
 並非所有 Vim 命令都受支援，請查看 https://github.com/cpeditor/FakeVim 了解支援的命令列表</translation>
+    </message>
+    <message>
+        <source>The path to the CSES CLI executable file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show a toast message when the verdict of a submission is known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable CSES CLI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable or disable CSES CLI Integration.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Description
Add CSES CLI integration, similar to the existing CF Tool. Users can now submit solutions directly to [CSES](https://cses.fi) problems.
**New files:**
- `src/Extensions/CSESTool.cpp` / `CSESTool.hpp` — CSES CLI wrapper (submit, version check, URL parsing, toast notifications)
**Modified files:**
- `src/mainwindow.cpp` / `mainwindow.hpp` — "Submit to CSES" button, CSES contest/task extraction from URL, auto-naming files by problem name instead of task ID
- `src/Settings/settings.json` — Added `CSES CLI/Path`, `CSES CLI/Enable`, `CSES CLI/Show Toast Messages`
- `src/Settings/PreferencesWindow.cpp` — CSES CLI page in preferences
- `src/Settings/SettingsManager.cpp` — QString coercion for backward-compatible settings loading
- `src/Settings/ParenthesesPage.cpp` — Fix settings persistence for custom parentheses
- `src/Editor/FakeVimProxy.cpp` — Fix editor disappearing in new tabs
- `src/Core/Compiler.cpp` — Keep `${tmpdir}` as canonical output path placeholder
- `CMakeLists.txt` — Add CSESTool sources, restore `qt6_add_translations` for Qt 6.5.3
- `translations/*.ts` — 22 new CSES-related strings synced to all 8 locales
- `CHANGELOG.md` — Document CSES addition and naming scheme change
**Bug fixes included:**
- Memory leaks: `csestool`, `submitToCodeforces`, `submitToCses` now deleted in `MainWindow` destructor
- CSESTool now uses its own `isCSESCLIShowToastMessages()` setting instead of reading CF Tool's
- Null guards on all `log->` calls in CSESTool, matching `CompanionServer` pattern
- Qt 6.5.3 compatibility: `I18N_TRANSLATED_LANGUAGES` removed from `qt_standard_project_setup()`, `qt6_add_translations` moved after `add_executable`
## Related Issues / Pull Requests

## Motivation and Context
CSES is a widely-used competitive programming problem set. Users currently have to copy-paste code to submit. This adds a first-class submit button, mirroring the existing CF Tool workflow.
## How Has This Been Tested?
- **OS:** Pop!_OS 22.04 (Linux)
- **Qt:** 6.5.3 (gcc_64)
- **Compiler:** GCC 11.4.0
- **Build:** Clean build, zero warnings, all 24 targets + 8 translation `.qm` files generated
- **Theme:** Light system theme
## Screenshots (if appropriate)
N/A — UI additions follow existing CF Tool button/tooltip patterns.
## Checklist
- [x] If the key of a setting is changed, the `old` attribute is updated or it is resolved in SettingsUpdater.
- [x] If there are changes of the text displayed in the UI, they are wrapped in `tr()` or `QCoreApplication::translate()`.
- [ ] If needed, I have opened a pull request or an issue to update the [documentation](https://github.com/cpeditor/cpeditor.github.io).
- [x] If these changes are notable, they are documented in [CHANGELOG.md](https://github.com/cpeditor/cpeditor/blob/master/CHANGELOG.md).
## Additional text
Translators: 22 new CSES-related strings have been added to all `.ts` files (ar_EG, el_GR, es_MX, hi_IN, pt_BR, ru_RU, zh_CN, zh_TW). Most are currently untranslated and will fall back to English until translated via Qt Linguist.